### PR TITLE
Fix sqlite callback signature

### DIFF
--- a/sources/cqlrt_common.c
+++ b/sources/cqlrt_common.c
@@ -4295,7 +4295,7 @@ cleanup:
 }
 
 // this is not normally called but we need something here for linkage
-static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
+static void _stub_udf_callback(sqlite3_context *_Nullable context, int argc, sqlite3_value *_Nullable *_Nullable argv)
 {
 }
 


### PR DESCRIPTION
I was getting those errors:

```sh
cc -I./ -Iout -g -Werror -c cqlrt.c -o out/cqlrt.o
In file included from cqlrt.c:400:
./cqlrt_common.c:4298:47: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                              ^
./cqlrt_common.c:4298:47: note: insert '_Nullable' if the pointer may be null
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                              ^
                                                _Nullable
./cqlrt_common.c:4298:47: note: insert '_Nonnull' if the pointer should never be null
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                              ^
                                                _Nonnull
./cqlrt_common.c:4298:81: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                                                                ^
./cqlrt_common.c:4298:81: note: insert '_Nullable' if the pointer may be null
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                                                                ^
                                                                                 _Nullable
./cqlrt_common.c:4298:81: note: insert '_Nonnull' if the pointer should never be null
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                                                                ^
                                                                                 _Nonnull
./cqlrt_common.c:4298:82: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                                                                 ^
./cqlrt_common.c:4298:82: note: insert '_Nullable' if the pointer may be null
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                                                                 ^
                                                                                   _Nullable
./cqlrt_common.c:4298:82: note: insert '_Nonnull' if the pointer should never be null
static void _stub_udf_callback(sqlite3_context* context, int argc, sqlite3_value** argv)
                                                                                 ^
                                                                                   _Nonnull
3 errors generated.
make: *** [out/cqlrt.o] Error 1
```
