### PR TITLE
repl — Enable SQLite tracing

### DIFF
--- a/sources/repl/go.sh
+++ b/sources/repl/go.sh
@@ -23,4 +23,4 @@ echo "${CQL} ready"
 cc -E -x c go.sql >go.sql.pre
 $CQL --in go.sql.pre --cg go.h go.c
 cc -g -I.. -I. -o go go.c ../cqlrt.c main.c -lsqlite3
-./go
+./go $@

--- a/sources/repl/main.c
+++ b/sources/repl/main.c
@@ -17,12 +17,22 @@
 #define E(x) _E(x, x)
 #define SQL_E(x) _E(SQLITE_OK == (x), x)
 
+static int sqlite_trace_callback(unsigned type, void* ctx, void* p, void* x) {
+  switch (type) {
+    case SQLITE_TRACE_PROFILE:
+      fprintf(stderr, "[SQLite] Statement: %s, Execution Time: %lld ns\n", sqlite3_sql((sqlite3_stmt*)p), *((sqlite3_int64*)x));
+      break;
+  }
+  return 0;
+}
+
 // patternlint-disable-next-line prefer-sized-ints-in-msys
 int main(int argc, char **argv) {
   printf("CQL Mini App Thingy\n");
 
   sqlite3 *db = NULL;
   SQL_E(sqlite3_open(":memory:", &db));
+  sqlite3_trace_v2(db, SQLITE_TRACE_PROFILE, sqlite_trace_callback, NULL);
 
   SQL_E(go(db));
   return 0;

--- a/sources/repl/main.c
+++ b/sources/repl/main.c
@@ -32,7 +32,10 @@ int main(int argc, char **argv) {
 
   sqlite3 *db = NULL;
   SQL_E(sqlite3_open(":memory:", &db));
-  sqlite3_trace_v2(db, SQLITE_TRACE_PROFILE, sqlite_trace_callback, NULL);
+
+  if (argc >= 2 && strcmp(argv[1], "-vvv") == 0) {
+    sqlite3_trace_v2(db, SQLITE_TRACE_PROFILE, sqlite_trace_callback, NULL);
+  }
 
   SQL_E(go(db));
   return 0;


### PR DESCRIPTION
Knowing what happens to sqlite helps to understand how CGSQL works under the hood. A bit easier to digest than reading lua, c or go_json_schema.json. The down side is that it makes the repl a bit more complex.

Unsure if  `-vvv` is necessary but it can get quite verbose.

List of events: https://www.sqlite.org/c3ref/c_trace.html

Example when it's useful:
<img width="837" alt="image" src="https://github.com/ricomariani/CG-SQL-author/assets/1662628/913afffb-ea51-436b-8ae5-700a4e53fedf">

Default go.sql:
<img width="1440" alt="image" src="https://github.com/ricomariani/CG-SQL-author/assets/1662628/9701519e-3130-4d15-883c-5e14c6d10e4a">