### PR TITLE
Feature: Introduce new Error: CQL0501 WHEN expression must not be a constant NULL but can be of a nullable type

### DIFF
--- a/CQL_Guide/x4.md
+++ b/CQL_Guide/x4.md
@@ -4558,3 +4558,20 @@ declare function bar() int
 ```
 
 All subsequent calls to `bar()` in CQL will call the `foo()` function.
+
+### CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type
+
+In a `CASE` statement each `WHEN` expression must not be a constant NULL. For example:
+```sql
+  declare hex text;
+  set hex := case color
+    when NULL    then "#FFFFFF" -- error
+    when "red"   then "#FF0000"
+    when "green" then "#00FF00"
+    when "blue"  then "#0000FF"
+    else "#000000"
+  end;
+```
+
+When the case expression `color` evaluates to NULL, it does not match with an expression that evaluates to NULL.
+Consequently, the CASE statement will default to the ELSE clause, provided it is defined.

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -1978,11 +1978,6 @@ static void cg_case_list(ast_node *head, CSTR expr, CSTR result, sem_t sem_type_
     EXTRACT_ANY_NOTNULL(case_expr, when->left);
     EXTRACT_ANY_NOTNULL(then_expr, when->right);
 
-    // null can't ever match anything, waste of time.
-    if (is_ast_null(case_expr)) {
-      continue;
-    }
-
     // WHEN [case_expr] THEN [then_expr]
 
     sem_t sem_type_case_expr = case_expr->sem->sem_type;

--- a/sources/cg_lua.c
+++ b/sources/cg_lua.c
@@ -1101,11 +1101,6 @@ static void cg_lua_case_list(ast_node *head, CSTR expr, CSTR result, sem_t sem_t
     EXTRACT_ANY_NOTNULL(case_expr, when->left);
     EXTRACT_ANY_NOTNULL(then_expr, when->right);
 
-    // null can't ever match anything, waste of time.
-    if (is_ast_null(case_expr)) {
-      continue;
-    }
-
     // WHEN [case_expr] THEN [then_expr]
 
     sem_t sem_type_then_expr = then_expr->sem->sem_type;

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -6633,31 +6633,31 @@ static void sem_case_list(
 
   for (ast_node *ast = head; ast; ast = ast->right) {
     EXTRACT_NOTNULL(when, ast->left);
-    // WHEN [case_expr] THEN [then_expr]
-    EXTRACT_ANY_NOTNULL(case_expr, when->left);
+    // WHEN [when_expr] THEN [then_expr]
+    EXTRACT_ANY_NOTNULL(when_expr, when->left);
     EXTRACT_ANY_NOTNULL(then_expr, when->right);
 
-    sem_expr(case_expr);
-    if (is_error(case_expr)) {
+    sem_expr(when_expr);
+    if (is_error(when_expr)) {
       record_error(ast);
       record_error(head);
       return;
     }
 
-    if (is_null_type(case_expr->sem->sem_type)) {
+    if (is_null_type(when_expr->sem->sem_type)) {
       report_error(ast, "CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type", NULL);
       record_error(ast);
       return;
     }
 
-    if (!sem_verify_compat(case_expr, sem_type_required_for_when, case_expr->sem->sem_type, is_iif ? "iif" : "when")) {
+    if (!sem_verify_compat(when_expr, sem_type_required_for_when, when_expr->sem->sem_type, is_iif ? "iif" : "when")) {
       record_error(ast);
       record_error(head);
       return;
     }
 
-    sem_combine_kinds(case_expr, kind_required_for_when);
-    if (is_error(case_expr)) {
+    sem_combine_kinds(when_expr, kind_required_for_when);
+    if (is_error(when_expr)) {
       record_error(ast);
       record_error(head);
       return;
@@ -6665,7 +6665,7 @@ static void sem_case_list(
 
     FLOW_PUSH_CONTEXT_BRANCH();
     if (!has_expression_to_match) {
-      sem_set_improvements_for_true_condition(case_expr);
+      sem_set_improvements_for_true_condition(when_expr);
     }
     sem_expr(then_expr);
     FLOW_POP_CONTEXT_BRANCH();
@@ -6676,9 +6676,9 @@ static void sem_case_list(
       return;
     }
 
-    sem_set_improvements_for_false_condition(case_expr);
+    sem_set_improvements_for_false_condition(when_expr);
 
-    sem_sensitive |= sensitive_flag(case_expr->sem->sem_type);
+    sem_sensitive |= sensitive_flag(when_expr->sem->sem_type);
     sem_sensitive |= sensitive_flag(then_expr->sem->sem_type);
 
     if (sem_type_result == SEM_TYPE_PENDING) {

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -6644,6 +6644,12 @@ static void sem_case_list(
       return;
     }
 
+    if (is_null_type(case_expr->sem->sem_type)) {
+      report_error(ast, "CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type", NULL);
+      record_error(ast);
+      return;
+    }
+
     if (!sem_verify_compat(case_expr, sem_type_required_for_when, case_expr->sem->sem_type, is_iif ? "iif" : "when")) {
       record_error(ast);
       record_error(head);

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -560,7 +560,7 @@ end;
 -- +  }
 -- +  i2 = 300;
 -- + } while (0);
-set i2 := case when 1 then 100 when 2 then 200 when null then 500 else 300 end;
+set i2 := case when 1 then 100 when 2 then 200 else 300 end;
 
 -- TEST: a simple in expression
 -- + do {

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -19642,7 +19642,6 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := CASE WHEN 1 THEN 100
   WHEN 2 THEN 200
-  WHEN NULL THEN 500
   ELSE 300
   END;
   */

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -19642,7 +19642,6 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := CASE WHEN 1 THEN 100
   WHEN 2 THEN 200
-  WHEN NULL THEN 500
   ELSE 300
   END;
   */

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -19642,7 +19642,6 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := CASE WHEN 1 THEN 100
   WHEN 2 THEN 200
-  WHEN NULL THEN 500
   ELSE 300
   END;
   */

--- a/sources/test/cg_test_lua.lua.ref
+++ b/sources/test/cg_test_lua.lua.ref
@@ -9259,7 +9259,6 @@ function cql_startup(_db_)
   --[[
   SET i2 := CASE WHEN 1 THEN 100
   WHEN 2 THEN 200
-  WHEN NULL THEN 500
   ELSE 300
   END;
   --]]

--- a/sources/test/cg_test_lua.sql
+++ b/sources/test/cg_test_lua.sql
@@ -513,7 +513,7 @@ end;
 -- +   end
 -- +   i2 = 300
 -- + until true
-set i2 := case when 1 then 100 when 2 then 200 when null then 500 else 300 end;
+set i2 := case when 1 then 100 when 2 then 200 else 300 end;
 
 -- TEST: a simple in expression
 -- +  repeat

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -3559,11 +3559,8 @@ BEGIN_TEST(const_folding)
   EXPECT(const(case (1==0) when (1==1) then 10 else 20 end) == 20);
   EXPECT(const(case (1==1) when (0==1) then 10 else 20 end) == 20);
   EXPECT(const(case (1==0) when (0==1) then 10 else 20 end) == 10);
-  EXPECT(const(case (1==0) when null then 10 else 20 end) == 20);
-  EXPECT(const(case (1==0) when null then 10 end ) is null);
 
   EXPECT(const(case 5L when 1 then 10 when 2 then 20 end) is NULL);
-  EXPECT(const(case when NULL then 1 else 2 end) == 2);
 
   EXPECT(const(0x10) == 16);
   EXPECT(const(0x10 + 0xf) == 31);

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -52,6 +52,8 @@ test/sem_test.sql:XXXX:1: error: in eq : CQL0009: incompatible types in expressi
 test/sem_test.sql:XXXX:1: error: in num : CQL0043: right operand must be a string in 'LIKE'
 test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in expression 'then'
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'when'
+test/sem_test.sql:XXXX:1: error: in case_list : CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type
+test/sem_test.sql:XXXX:1: error: in case_list : CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'when'
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'else'
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -2921,6 +2921,81 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in express
 
 The statement ending at line XXXX
 
+SELECT CASE "x" WHEN NULL THEN 'foo'
+WHEN "x" THEN 'foo'
+WHEN "y" THEN 'bar'
+END;
+
+test/sem_test.sql:XXXX:1: error: in case_list : CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: err
+  |     |   | {case_expr}: err
+  |     |     | {strlit 'x'}: text notnull
+  |     |     | {connector}
+  |     |       | {case_list}: err
+  |     |         | {when}
+  |     |         | | {null}: null
+  |     |         | | {strlit 'foo'}
+  |     |         | {case_list}
+  |     |           | {when}
+  |     |           | | {strlit 'x'}
+  |     |           | | {strlit 'foo'}
+  |     |           | {case_list}
+  |     |             | {when}
+  |     |               | {strlit 'y'}
+  |     |               | {strlit 'bar'}
+  |     | {select_from_etc}: ok
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT CASE WHEN NULL THEN 'foo'
+WHEN "x" THEN 'foo'
+WHEN "y" THEN 'bar'
+END;
+
+test/sem_test.sql:XXXX:1: error: in case_list : CQL0501: WHEN expression must not be a constant NULL but can be of a nullable type
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: err
+  |     |   | {case_expr}: err
+  |     |     | {connector}
+  |     |       | {case_list}: err
+  |     |         | {when}
+  |     |         | | {null}: null
+  |     |         | | {strlit 'foo'}
+  |     |         | {case_list}
+  |     |           | {when}
+  |     |           | | {strlit 'x'}
+  |     |           | | {strlit 'foo'}
+  |     |           | {case_list}
+  |     |             | {when}
+  |     |               | {strlit 'y'}
+  |     |               | {strlit 'bar'}
+  |     | {select_from_etc}: ok
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
 SELECT CASE 'x' WHEN 'y' THEN 1
 WHEN 'z' THEN 2
 END;

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -671,6 +671,30 @@ select case
   when 'x' then 'foo'
 end;
 
+-- TEST: when expression cannot be a constant null — Not to be confused with else
+-- + error: % WHEN expression must not be a constant NULL but can be of a nullable type
+-- +1 error:
+-- + {select_stmt}: err
+-- + {case_expr}: err
+-- + {null}: null
+select case "x"
+  when null then 'foo'
+  when "x" then 'foo'
+  when "y" then 'bar'
+end;
+
+-- TEST: when expression cannot be a constant null — Not to be confused with else
+-- + error: % WHEN expression must not be a constant NULL but can be of a nullable type
+-- +1 error:
+-- + {select_stmt}: err
+-- + {case_expr}: err
+-- + {null}: null
+select case
+  when null then 'foo'
+  when "x" then 'foo'
+  when "y" then 'bar'
+end;
+
 -- TEST: ok to compare strings to each other
 -- - error:
 -- note the result type is nullable, there was no else case!


### PR DESCRIPTION
In a `CASE` statement each `WHEN` expression must not be a constant NULL. For example:
```sql
  declare hex text;
  set hex := case color
    when NULL    then "#FFFFFF" -- error
    when "red"   then "#FF0000"
    when "green" then "#00FF00"
    when "blue"  then "#0000FF"
    else "#000000"
  end;
```

When the case expression `color` evaluates to NULL, it does not match with an expression that evaluates to NULL.
Consequently, the CASE statement will default to the ELSE clause, provided it is defined.

TODO:
- [ ] Generate doc files
- [ ] Run tests
- [ ] I can revert the naming if it's incorrect