### PR TITLE
Fix `./play.sh build-cql-compiler`

### DIFF
--- a/sources/playground/play.sh
+++ b/sources/playground/play.sh
@@ -713,7 +713,7 @@ if [[ $rest != "" ]]; then
     exit 1
 fi
 
-if ! is_dependency_satisfied cql_compiler; then
+if [[ $sub_command != "build_cql_compiler" ]] && ! is_dependency_satisfied cql_compiler; then
     hello
     exit 1
 fi


### PR DESCRIPTION
When the compiler dependency was not satisfied, executing the command `./play.sh build-cql-compiler` was listing the dependencies instead of building cql