### PR TITLE
Playground — Introduce cql_sqlite_schema output

### DIFF
--- a/sources/playground/README.md
+++ b/sources/playground/README.md
@@ -93,6 +93,7 @@ Multiple outputs are available. They all serve a wide range of different purpose
 - **preprocessed** — The preprocessed version of the sql file
 - **cql_json_schema** — A JSON output for codegen tools
 - **cql_sql_schema** - A normalized version of the cql_json_schema (.sql)
+- **cql_sqlite_schema** - SQLite database of the cql_sql_schema.sql (.sqlite)
 - **table_diagram_dot** — Table Diagram
 - **table_diagram_dot_pdf** — Table Diagram as PDF file
 - **region_diagram_dot** — Region Diagram


### PR DESCRIPTION
It creates an sqlite database from the sql_schema.

Fun sad fact: the sqlite output cannot be used in a CQL app because there is a table called `column` which is part of the grammar so there is a conflict.