### PR TITLE
Fix Playground — benchmark.sql example — Fix objc runtime: cqlrt.h was included in time.c

### DIFF
--- a/sources/playground/utils/timer.c
+++ b/sources/playground/utils/timer.c
@@ -1,4 +1,3 @@
-#include <cqlrt.h>
 #include <stdio.h>
 #include <time.h> 
 


### PR DESCRIPTION
I went very deep but it was a simple include conflicting with objc runtime...