### PR TITLE
Fix cqlrt_common get_object_cql_string_list_count signature

### DIFF
--- a/sources/cqlrt_common.c
+++ b/sources/cqlrt_common.c
@@ -3884,15 +3884,9 @@ cql_object_ref _Nonnull add_object_cql_string_list(cql_object_ref _Nonnull list,
 }
 
 // Returns the number of elements in the given string list
-int32_t get_object_cql_string_list_count(cql_object_ref _Nullable list) {
-  int32_t result = 0;
-
-  if (list) {
-    cql_bytebuf *_Nonnull self = _cql_generic_object_get_data(list);
-    result = self->used / sizeof(cql_string_ref);
-  }
-
-  return result;
+int32_t get_object_cql_string_list_count(cql_object_ref _Nonnull list) {
+  cql_bytebuf *_Nonnull self = _cql_generic_object_get_data(list);
+  return self->used / sizeof(cql_string_ref);
 }
 
 // Returns the nth string from the string list with no extra retain (get semantics)


### PR DESCRIPTION
```
In file included from cqlrt.c:481:
./cqlrt_common.c:3887:67: error: nullability specifier '_Nullable' conflicts with existing specifier '_Nonnull' [-Werror,-Wnullability]
int32_t get_object_cql_string_list_count(cql_object_ref _Nullable list) {
                                                                  ^
./cqlrt_common.h:421:77: note: previous declaration is here
CQL_EXPORT int32_t get_object_cql_string_list_count(cql_object_ref _Nonnull list);
```