### PR TITLE
Allow conditional shared fragments to be written without an ELSE clause

### DIFF
--- a/docs/user_guide/14_shared_fragments.md
+++ b/docs/user_guide/14_shared_fragments.md
@@ -345,11 +345,44 @@ entirely different between the branches removing unnecessary code,
 or swapping in a new experimental cache in your test environment, or
 anything like that.
 
+#### Conditionals without ELSE clauses
+When a condiitional is specified without an else clause, the fragment would return a result with no rows if none of the specified conditionals are truthy.
+
+For example:
+```sql
+[[shared_fragment]]
+PROC maybe_empty(cond BOOL NOT NULL)
+BEGIN
+  IF cond THEN
+    SELECT 1 a, 2 b, 3 c;
+  END IF;
+END;
+```
+
+Internally, this is actually equivalent to the following:
+```sql
+[[shared_fragment]]
+PROC maybe_empty(cond BOOL NOT NULL)
+BEGIN
+  IF cond THEN
+    SELECT 1 a, 2 b, 3 c;
+  ELSE
+    SELECT NOTHING;
+  END IF;
+END;
+```
+
+The `SELECT NOTHING` expands to the a query that returns no rows, like this:
+```sql
+SELECT 0,0,0 WHERE 0; -- number of columns match the query returned by the main conditional.
+```
+
+#### Summary
+
 The generalization is simply this:
 
 * instead of just one select statement there is one top level "IF" statement
 * each statement list of the IF must be exactly one select statement
-* there must be an ELSE clause
 * the select statements must be type compatible, just like in a normal procedure
 * any table parameters with the same name in different branches must have the same type
   * otherwise it would be impossible to provide a single actual table for those table parameters

--- a/docs/user_guide/appendices/04_error_codes.md
+++ b/docs/user_guide/appendices/04_error_codes.md
@@ -3872,33 +3872,6 @@ There are no other valid options.
 
 -----
 
-### CQL0442: shared fragments with conditionals must include an else clause 'procedure_name'
-
-In shared fragment with conditionals (i.e. it has an IF statement at the top) the fragment
-must have an ELSE block so that it is guaranteed to create chunk of SQL text in its expansion.
-When no rows are required you can do so with something like:
-
-```
-IF ... THEN
-  ...
-ELSE
-   select 1 x, '2' y WHERE 0;
-END IF;
-```
-
-If the `ELSE` condition indicates that some join should not happen you might generate default values
-or NULLs for the join result like so:
-
-```
-IF ... THEN
-  ...
-ELSE
-  select input_stuff.*, NULL x, -1 y;
-END IF;
-```
-
------
-
 ### CQL0443: shared fragments with conditionals must have exactly one SELECT or WITH...SELECT in each statement list 'procedure_name'
 
 In a shared fragment with conditionals the top level statement is an "IF".  All of the statement lists in

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -18729,11 +18729,18 @@ static void sem_shared_fragment(ast_node *misc_attrs, ast_node *create_proc_stmt
     symtab_delete(bind_info.names);
 
     if (info.missing_else) {
-      report_error(info.missing_else, "CQL0442: shared fragments with conditionals must include an else clause", proc_name);
-      record_error(misc_attrs);
-      record_error(stmt_list);
-      record_error(create_proc_stmt);
-      return;
+      Invariant(is_ast_if_stmt(info.missing_else));
+      ast_node *ast = info.missing_else;
+      EXTRACT_NOTNULL(if_alt, ast->right);
+
+      AST_REWRITE_INFO_SET(ast->lineno, ast->filename);
+      ast_node *select_nothing_ast = new_ast_select_nothing_stmt();
+      ast_node *stmt_list_ast = new_ast_stmt_list(select_nothing_ast, NULL);
+      if_alt->right = new_ast_else(stmt_list_ast);
+  
+      sem_select_nothing_stmt(select_nothing_ast);
+      
+      AST_REWRITE_INFO_RESET();
     }
 
     if (info.bad_statement_form) {

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -476,7 +476,6 @@ test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0437: common table name shadow
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0437: common table name shadows previously declared table or view 'MyView'
 test/sem_test.sql:XXXX:1: error: in create_proc_stmt : CQL0440: fragments may not have an empty body 'empty_fragment'
 test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0212: too few arguments provided to procedure 'a_shared_frag'
-test/sem_test.sql:XXXX:1: error: in if_stmt : CQL0442: shared fragments with conditionals must include an else clause 'bogus_conditional_no_else'
 test/sem_test.sql:XXXX:1: error: in select_nothing_stmt : CQL0496: SELECT NOTHING may only appear in the ELSE clause of a shared fragment
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0057: bogus_cte, all must have the same column count
 test/sem_test.sql:XXXX:1: error: in cte_decl : additional difference diagnostic info:

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -19815,25 +19815,25 @@ test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0212: too few arguments provi
 The statement ending at line XXXX
 
 @ATTRIBUTE(cql:shared_fragment)
-CREATE PROC bogus_conditional_no_else ()
+CREATE PROC conditional_no_else ()
 BEGIN
   IF 1 THEN
     SELECT 1 AS x;
+  ELSE
+    SELECT NOTHING;
   END IF;
 END;
 
-test/sem_test.sql:XXXX:1: error: in if_stmt : CQL0442: shared fragments with conditionals must include an else clause 'bogus_conditional_no_else'
-
-  {stmt_and_attr}: err
-  | {misc_attrs}: err
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
   | | {misc_attr}
   |   | {dot}
   |     | {name cql}
   |     | {name shared_fragment}
-  | {create_proc_stmt}: err
-    | {name bogus_conditional_no_else}: err
+  | {create_proc_stmt}: conditional_no_else: { x: integer notnull } dml_proc
+    | {name conditional_no_else}: conditional_no_else: { x: integer notnull } dml_proc
     | {proc_params_stmts}
-      | {stmt_list}: err
+      | {stmt_list}: ok
         | {if_stmt}: integer notnull
           | {cond_action}: integer notnull
           | | {int 1}: integer notnull
@@ -19855,6 +19855,9 @@ test/sem_test.sql:XXXX:1: error: in if_stmt : CQL0442: shared fragments with con
           |       | {select_limit}
           |         | {select_offset}
           | {if_alt}: ok
+            | {else}
+              | {stmt_list}
+                | {select_nothing_stmt}: conditional_no_else: { x: integer notnull } dml_proc
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -5299,12 +5299,12 @@ select * from (call a_shared_frag(1, 2));
 -- +1 error:
 select * from (call a_shared_frag());
 
--- TEST: create a conditional fragment with no else
--- + {create_proc_stmt}: err
--- + error: % shared fragments with conditionals must include an else clause 'bogus_conditional_no_else'
--- +1 error:
+-- TEST: a conditional shared fragment without an else clause is equivalent to
+-- putting "select nothing" in an else clause.
+-- + {select_nothing_stmt}: conditional_no_else: { x: integer notnull }
+-- - error
 @attribute(cql:shared_fragment)
-create proc bogus_conditional_no_else()
+create proc conditional_no_else()
 begin
   if 1 then
     select 1 x;


### PR DESCRIPTION
Make it possible to write a shared fragment that doesn't have an else clause like this:
```sql
[[shared_fragment]]
proc my_frag(cond_ bool not null)
begin
  if cond_ then
    select 1 a, 2 b, 3 c;
  end if;
end;
```

This simply rewrites into:
```sql
[[shared_fragment]]
proc my_frag(cond_ bool not null)
begin
  if cond_ then
    select 1 a, 2 b, 3 c;
  else
    SELECT NOTHING;
  end if;
end;
```