### PR TITLE
Remove the _ns_ wrapper when using shared fragments in a FROM clause

### DIFF
--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -62,11 +62,6 @@ typedef struct {
    ast_node *arg_list;  // these are the actual arguments
 } proc_params_info;
 
-typedef struct {
-  gen_sql_callbacks *callbacks;
-  bool_t minify_aliases;
-} cte_proc_call_info;
-
 static void cg_emit_proc_params(proc_params_info *info);
 
 // Emits a sql statement with bound args.  Returns temp statement index used if any
@@ -4976,6 +4971,8 @@ static bool_t cg_call_in_cte(ast_node *cte_body, void *context, charbuf *buffer)
 
   CHARBUF_OPEN(wrapper);
   if (is_nested_select) {
+    // We need to keep column names of the generated SELECT
+    // when generating shared fragments as a subquery.
     info->callbacks->minify_aliases = false;
 
     bprintf(&wrapper, "(");

--- a/sources/cg_common.h
+++ b/sources/cg_common.h
@@ -14,6 +14,7 @@
 #include "symtab.h"
 #include "crc64xz.h"
 #include "sha256.h"
+#include "gen_sql.h"
 
 // When emitting code for a sql statement you might need to prepare it expecting
 // to use the sql statement yourself, or you may just want to run the SQL.
@@ -208,6 +209,12 @@ typedef struct cg_expr_dispatch {
   CSTR _Nonnull str;
   int32_t pri_new;
 } cg_expr_dispatch;
+
+// Used by the cte_proc_context attribute in gen_sql_callbacks
+typedef struct {
+  gen_sql_callbacks *_Nonnull callbacks;
+  bool_t minify_aliases;
+} cte_proc_call_info;
 
 // These are pre-loaded with pointers to functions for handling the
 // root statements and functions.

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -2709,7 +2709,12 @@ static void gen_select_nothing_stmt(ast_node *ast) {
     if (i) {
       gen_printf(",");
     }
-    gen_printf("0");
+
+    if (gen_callbacks && gen_callbacks->minify_aliases) {
+      gen_printf("0");
+    } else {
+      gen_printf("0 %s", sptr->names[i]);
+    }
   }
   gen_printf(" WHERE 0");
 }

--- a/sources/sem.h
+++ b/sources/sem.h
@@ -274,7 +274,7 @@ cql_noexport bool_t is_proc_shared_fragment(ast_node *ast);
 cql_noexport bool_t is_alias_ast(ast_node *ast);
 cql_noexport CSTR get_inserted_table_alias_string_override(ast_node *ast);
 
-cql_noexport ast_node *_Nonnull new_str_or_qstr(CSTR _Nonnull name, sem_t sem_type);
+cql_noexport ast_node* new_str_or_qstr(CSTR name, sem_t sem_type);
 cql_noexport CSTR sem_get_name(ast_node *ast);
 cql_noexport ast_node *sem_get_name_ast(ast_node *ast);
 cql_noexport CSTR create_group_id(CSTR group_name, CSTR table_name);

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -4885,87 +4885,66 @@ end;
 
 -- TEST: nested select syntax with complex fragment
 --
--- 10 fragments and 8 variables as expected
+-- 7 fragments and 8 variables as expected
 -- control flow corresponds to the nested selects (manually verified)
 -- see discussion per fragment
--- +  char _preds_1[10];
--- +  char _vpreds_1[8];
--- +  memset(&_preds_1[0], 0, sizeof(_preds_1));
--- +  memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
--- +  _p1_x__ = 1;
--- +  _preds_1[0] = 1;
--- +  _preds_1[1] = 1;
--- +  if (_p1_x__ <= 5) {
--- +    _preds_1[2] = 1;
--- +    _p2_x_ = 1;
--- +    if (_p2_x_ == 1) {
--- +      _preds_1[3] = 1;
--- +      _vpreds_1[0] = 1; // pred 3 known to be 1
--- +    }
--- +    else {
--- +      if (_p2_x_ == 2) {
--- +        _preds_1[4] = 1;
--- +        _vpreds_1[1] = 1; // pred 4 known to be 1
--- +        _vpreds_1[2] = 1; // pred 4 known to be 1
--- +      }
--- +      else {
--- +        _preds_1[5] = 1;
--- +        _vpreds_1[3] = 1; // pred 5 known to be 1
--- +        _vpreds_1[4] = 1; // pred 5 known to be 1
--- +        _vpreds_1[5] = 1; // pred 5 known to be 1
--- +      }
--- +    }
--- +    _preds_1[6] = _preds_1[2];
--- +    _vpreds_1[6] = _preds_1[2];
--- +  }
--- +  else {
--- +    _preds_1[7] = 1;
--- +    _vpreds_1[7] = 1; // pred 7 known to be 1
--- +  }
--- +  _preds_1[8] = 1;
--- +  _preds_1[9] = 1;
--- +  _rc_ = cql_prepare_var(_db_, _result_stmt,
--- +    10, _preds_1,
---
+-- + _p1_x__ = 1;
+-- + _preds_1[0] = 1;
+-- + if (_p1_x__ <= 5) {
+-- +   _preds_1[1] = 1;
+-- +   _p2_x_ = 1;
+-- +   if (_p2_x_ == 1) {
+-- +     _preds_1[2] = 1;
+-- +     _vpreds_1[0] = 1; // pred 2 known to be 1
+-- +   }
+-- +   else {
+-- +     if (_p2_x_ == 2) {
+-- +       _preds_1[3] = 1;
+-- +       _vpreds_1[1] = 1; // pred 3 known to be 1
+-- +       _vpreds_1[2] = 1; // pred 3 known to be 1
+-- +     }
+-- +     else {
+-- +       _preds_1[4] = 1;
+-- +       _vpreds_1[3] = 1; // pred 4 known to be 1
+-- +       _vpreds_1[4] = 1; // pred 4 known to be 1
+-- +       _vpreds_1[5] = 1; // pred 4 known to be 1
+-- +     }
+-- +   }
+-- +   _preds_1[5] = _preds_1[1];
+-- +   _vpreds_1[6] = _preds_1[1];
+-- + }
+-- + else {
+-- +   _preds_1[6] = 1;
+-- +   _vpreds_1[7] = 1; // pred 6 known to be 1
+-- + }
+-- + _preds_1[7] = 1;
+-- + _rc_ = cql_prepare_var(_db_, _result_stmt,
+-- +   8, _preds_1,
 -- fragment 0 always present
--- +  "SELECT x "
--- +      "FROM (",
---
--- fragment 1, the nested wrapper -- always present
--- +  "WITH _ns_(x) AS (",
---
--- fragment 2 present if x <= 5
--- +  "WITH "
--- +    "shared_conditional (x) AS (",
---
--- fragment 3 present if x == 1
+-- + "SELECT x "
+-- +     "FROM (",
+-- fragment 1 present if x <= 5
+-- + "WITH "
+-- +   "shared_conditional (x) AS (",
+-- fragment 2 present if x == 1
 -- first variable binding v[0] = pred[3]
--- +  "SELECT ?",
---
--- fragment 4 present if x == 2
+-- + "SELECT ?",
+-- fragment 3 present if x == 2
 -- second variable binding v[1], v[2] = pred[4]
--- +  "SELECT ? + ?",
---
--- fragment 5 present if x == 3
+-- + "SELECT ? + ?",
+-- fragment 4 present if x == 3
 -- third variable binding v[3], v[4], v[5] = pred[5]
--- +  "SELECT ? + ? + ?",
---
--- fragment 6 the tail of fragment 2, present if x <= 5
+-- + "SELECT ? + ? + ?",
+-- fragment 5 the tail of fragment 1, present if x <= 5
 -- fourth variable binding v[6] = pred[6] = pred[2]
--- +  ") "
--- +    "SELECT x "
--- +      "FROM shared_conditional "
--- +      "WHERE ? = 5",
---
--- fragment 7 present if x > 5
+-- + ") "
+-- +   "SELECT x "
+-- +     "FROM shared_conditional "
+-- +     "WHERE ? = 5",
+-- fragment 6 present if x > 5
 -- fifth variable binding v[7] = pred[7] = !pred[2]
--- +  "SELECT ?",
---
--- fragment 8 present always
--- +  ") SELECT * FROM _ns_",
---
--- fragment 9 present always
--- +  ")"
+-- + "SELECT ? AS x",
+-- + ")"
 create proc use_nested_select_shared_frag_form()
 begin
   select * from (call nested_shared_proc(1));
@@ -4977,9 +4956,7 @@ end;
 -- if we are using nested select or not.
 -- + "SELECT shared_something "
 -- + "FROM (",
--- + "WITH _ns_(shared_something) AS (",
--- + "SELECT 1234",
--- + ") SELECT * FROM _ns_",
+-- + "SELECT 1234 AS shared_something",
 -- + ")"
 @attribute(cql:private)
 create proc simple_shared_frag()
@@ -5005,6 +4982,14 @@ create proc shared_frag_else_nothing_test()
 begin
   with (call shared_frag_else_nothing(5))
   select * from foo;
+end;
+
+-- TEST: select nothing in FROM clause epands into the right number of columns
+-- with column names
+-- + "SELECT 0 id1,0 text1 WHERE 0",
+create proc shared_frag_else_nothing_in_from_clause_test()
+begin
+  select * from (call shared_frag_else_nothing(5));
 end;
 
 declare const group some_constants (

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -504,6 +504,7 @@ extern CQL_WARN_UNUSED cql_code nested_shared_stuff(sqlite3 *_Nonnull _db_, sqli
 extern CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 // static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
+extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 extern cql_blob_ref _Nullable make_blob(void);
 
 // The statement ending at line XXXX
@@ -15864,48 +15865,45 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   cql_error_prepare();
   cql_int32 _p1_x__ = 0;
   cql_int32 _p2_x_ = 0;
-  char _preds_1[10];
+  char _preds_1[8];
   char _vpreds_1[8];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   _p1_x__ = 1;
   _preds_1[0] = 1;
-  _preds_1[1] = 1;
   if (_p1_x__ <= 5) {
-    _preds_1[2] = 1;
+    _preds_1[1] = 1;
     _p2_x_ = 1;
     if (_p2_x_ == 1) {
-      _preds_1[3] = 1;
-      _vpreds_1[0] = 1; // pred 3 known to be 1
+      _preds_1[2] = 1;
+      _vpreds_1[0] = 1; // pred 2 known to be 1
     }
     else {
       if (_p2_x_ == 2) {
-        _preds_1[4] = 1;
-        _vpreds_1[1] = 1; // pred 4 known to be 1
-        _vpreds_1[2] = 1; // pred 4 known to be 1
+        _preds_1[3] = 1;
+        _vpreds_1[1] = 1; // pred 3 known to be 1
+        _vpreds_1[2] = 1; // pred 3 known to be 1
       }
       else {
-        _preds_1[5] = 1;
-        _vpreds_1[3] = 1; // pred 5 known to be 1
-        _vpreds_1[4] = 1; // pred 5 known to be 1
-        _vpreds_1[5] = 1; // pred 5 known to be 1
+        _preds_1[4] = 1;
+        _vpreds_1[3] = 1; // pred 4 known to be 1
+        _vpreds_1[4] = 1; // pred 4 known to be 1
+        _vpreds_1[5] = 1; // pred 4 known to be 1
       }
     }
-    _preds_1[6] = _preds_1[2];
-    _vpreds_1[6] = _preds_1[2];
+    _preds_1[5] = _preds_1[1];
+    _vpreds_1[6] = _preds_1[1];
   }
   else {
-    _preds_1[7] = 1;
-    _vpreds_1[7] = 1; // pred 7 known to be 1
+    _preds_1[6] = 1;
+    _vpreds_1[7] = 1; // pred 6 known to be 1
   }
-  _preds_1[8] = 1;
-  _preds_1[9] = 1;
+  _preds_1[7] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    10, _preds_1,
+    8, _preds_1,
   "SELECT x "
       "FROM (",
-  "WITH _ns_(x) AS (",
   "WITH "
     "shared_conditional (x) AS (",
   "SELECT ?",
@@ -15915,8 +15913,7 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
     "SELECT x "
       "FROM shared_conditional "
       "WHERE ? = 5",
-  "SELECT ?",
-  ") SELECT * FROM _ns_",
+  "SELECT ? AS x",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 8, _vpreds_1,
@@ -15960,12 +15957,10 @@ static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlit
   cql_error_prepare();
 
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    5, NULL,
+    3, NULL,
   "SELECT shared_something "
       "FROM (",
-  "WITH _ns_(shared_something) AS (",
-  "SELECT 1234",
-  ") SELECT * FROM _ns_",
+  "SELECT 1234 AS shared_something",
   ")"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -16083,6 +16078,123 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, s
   ") "
     "SELECT id "
       "FROM foo"
+  );
+  cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,
+                CQL_DATA_TYPE_INT32, &_p1_id__);
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  _rc_ = SQLITE_OK;
+
+cql_cleanup:
+  cql_error_report();
+  if (_rc_ == SQLITE_OK && !*_result_stmt) _rc_ = cql_no_rows_stmt(_db_, _result_stmt);
+  return _rc_;
+}
+#undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC shared_frag_else_nothing_in_from_clause_test ()
+BEGIN
+  SELECT *
+    FROM (CALL shared_frag_else_nothing(5));
+END;
+*/
+
+#define _PROC_ "shared_frag_else_nothing_in_from_clause_test"
+static int32_t shared_frag_else_nothing_in_from_clause_test_perf_index;
+
+cql_string_proc_name(shared_frag_else_nothing_in_from_clause_test_stored_procedure_name, "shared_frag_else_nothing_in_from_clause_test");
+
+typedef struct shared_frag_else_nothing_in_from_clause_test_row {
+  cql_nullable_int32 id1;
+  cql_string_ref _Nonnull text1;
+} shared_frag_else_nothing_in_from_clause_test_row;
+
+cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].id1.is_null;
+}
+
+cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].id1.value;
+}
+
+cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].text1;
+}
+
+uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count] = {
+  CQL_DATA_TYPE_INT32, // id1
+  CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // text1
+};
+
+#define shared_frag_else_nothing_in_from_clause_test_refs_offset cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, text1) // count = 1
+
+static cql_uint16 shared_frag_else_nothing_in_from_clause_test_col_offsets[] = { 2,
+  cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, id1),
+  cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, text1)
+};
+
+cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_count((cql_result_set_ref)result_set);
+}
+
+CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set) {
+  sqlite3_stmt *stmt = NULL;
+  cql_profile_start(CRC_shared_frag_else_nothing_in_from_clause_test, &shared_frag_else_nothing_in_from_clause_test_perf_index);
+  cql_code rc = shared_frag_else_nothing_in_from_clause_test(_db_, &stmt);
+  cql_fetch_info info = {
+    .rc = rc,
+    .db = _db_,
+    .stmt = stmt,
+    .data_types = shared_frag_else_nothing_in_from_clause_test_data_types,
+    .col_offsets = shared_frag_else_nothing_in_from_clause_test_col_offsets,
+    .refs_count = 1,
+    .refs_offset = shared_frag_else_nothing_in_from_clause_test_refs_offset,
+    .encode_context_index = -1,
+    .rowsize = sizeof(shared_frag_else_nothing_in_from_clause_test_row),
+    .crc = CRC_shared_frag_else_nothing_in_from_clause_test,
+    .perf_index = &shared_frag_else_nothing_in_from_clause_test_perf_index,
+  };
+  return cql_fetch_all_results(&info, (cql_result_set_ref *)result_set);
+}
+
+/*
+export:
+DECLARE PROC shared_frag_else_nothing_in_from_clause_test () (id1 INTEGER, text1 TEXT NOT NULL);
+*/
+CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt) {
+  cql_code _rc_ = SQLITE_OK;
+  *_result_stmt = NULL;
+  cql_error_prepare();
+  cql_nullable_bool _tmp_n_bool_0 = { .is_null = 1 };
+  cql_nullable_int32 _p1_id__ = { .is_null = 1 };
+  char _preds_1[4];
+  char _vpreds_1[1];
+
+  memset(&_preds_1[0], 0, sizeof(_preds_1));
+  memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
+  cql_set_notnull(_p1_id__, 5);
+  _preds_1[0] = 1;
+  cql_set_nullable(_tmp_n_bool_0, _p1_id__.is_null, _p1_id__.value > 0);
+  if (cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) {
+    _preds_1[1] = 1;
+    _vpreds_1[0] = 1; // pred 1 known to be 1
+  }
+  else {
+    _preds_1[2] = 1;
+  }
+  _preds_1[3] = 1;
+  _rc_ = cql_prepare_var(_db_, _result_stmt,
+    4, _preds_1,
+  "SELECT id1, text1 "
+      "FROM (",
+  "SELECT ? AS id1, 'x' AS text1",
+  "SELECT 0 id1,0 text1 WHERE 0",
+  ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,
                 CQL_DATA_TYPE_INT32, &_p1_id__);

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -15865,45 +15865,48 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   cql_error_prepare();
   cql_int32 _p1_x__ = 0;
   cql_int32 _p2_x_ = 0;
-  char _preds_1[8];
+  char _preds_1[10];
   char _vpreds_1[8];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   _p1_x__ = 1;
   _preds_1[0] = 1;
+  _preds_1[1] = 1;
   if (_p1_x__ <= 5) {
-    _preds_1[1] = 1;
+    _preds_1[2] = 1;
     _p2_x_ = 1;
     if (_p2_x_ == 1) {
-      _preds_1[2] = 1;
-      _vpreds_1[0] = 1; // pred 2 known to be 1
+      _preds_1[3] = 1;
+      _vpreds_1[0] = 1; // pred 3 known to be 1
     }
     else {
       if (_p2_x_ == 2) {
-        _preds_1[3] = 1;
-        _vpreds_1[1] = 1; // pred 3 known to be 1
-        _vpreds_1[2] = 1; // pred 3 known to be 1
+        _preds_1[4] = 1;
+        _vpreds_1[1] = 1; // pred 4 known to be 1
+        _vpreds_1[2] = 1; // pred 4 known to be 1
       }
       else {
-        _preds_1[4] = 1;
-        _vpreds_1[3] = 1; // pred 4 known to be 1
-        _vpreds_1[4] = 1; // pred 4 known to be 1
-        _vpreds_1[5] = 1; // pred 4 known to be 1
+        _preds_1[5] = 1;
+        _vpreds_1[3] = 1; // pred 5 known to be 1
+        _vpreds_1[4] = 1; // pred 5 known to be 1
+        _vpreds_1[5] = 1; // pred 5 known to be 1
       }
     }
-    _preds_1[5] = _preds_1[1];
-    _vpreds_1[6] = _preds_1[1];
+    _preds_1[6] = _preds_1[2];
+    _vpreds_1[6] = _preds_1[2];
   }
   else {
-    _preds_1[6] = 1;
-    _vpreds_1[7] = 1; // pred 6 known to be 1
+    _preds_1[7] = 1;
+    _vpreds_1[7] = 1; // pred 7 known to be 1
   }
-  _preds_1[7] = 1;
+  _preds_1[8] = 1;
+  _preds_1[9] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    8, _preds_1,
+    10, _preds_1,
   "SELECT x "
       "FROM (",
+  "(",
   "WITH "
     "shared_conditional (x) AS (",
   "SELECT ?",
@@ -15914,6 +15917,7 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
       "FROM shared_conditional "
       "WHERE ? = 5",
   "SELECT ? AS x",
+  ")",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 8, _vpreds_1,
@@ -15957,10 +15961,12 @@ static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlit
   cql_error_prepare();
 
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    3, NULL,
+    5, NULL,
   "SELECT shared_something "
       "FROM (",
+  "(",
   "SELECT 1234 AS shared_something",
+  ")",
   ")"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -16172,28 +16178,32 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_
   cql_error_prepare();
   cql_nullable_bool _tmp_n_bool_0 = { .is_null = 1 };
   cql_nullable_int32 _p1_id__ = { .is_null = 1 };
-  char _preds_1[4];
+  char _preds_1[6];
   char _vpreds_1[1];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   cql_set_notnull(_p1_id__, 5);
   _preds_1[0] = 1;
+  _preds_1[1] = 1;
   cql_set_nullable(_tmp_n_bool_0, _p1_id__.is_null, _p1_id__.value > 0);
   if (cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) {
-    _preds_1[1] = 1;
-    _vpreds_1[0] = 1; // pred 1 known to be 1
+    _preds_1[2] = 1;
+    _vpreds_1[0] = 1; // pred 2 known to be 1
   }
   else {
-    _preds_1[2] = 1;
+    _preds_1[3] = 1;
   }
-  _preds_1[3] = 1;
+  _preds_1[4] = 1;
+  _preds_1[5] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    4, _preds_1,
+    6, _preds_1,
   "SELECT id1, text1 "
       "FROM (",
+  "(",
   "SELECT ? AS id1, 'x' AS text1",
   "SELECT 0 id1,0 text1 WHERE 0",
+  ")",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -3500,6 +3500,30 @@ cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
   row2)
 
 // The statement ending at line XXXX
+#define CRC_shared_frag_else_nothing_in_from_clause_test -470936310725986298L
+
+extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_stored_procedure_name;
+
+#define shared_frag_else_nothing_in_from_clause_test_data_types_count 2
+
+#ifndef result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set
+#define result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set 1
+cql_result_set_type_decl(shared_frag_else_nothing_in_from_clause_test_result_set, shared_frag_else_nothing_in_from_clause_test_result_set_ref);
+#endif
+extern cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set);
+extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set);
+#define shared_frag_else_nothing_in_from_clause_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
+#define shared_frag_else_nothing_in_from_clause_test_row_equal(rs1, row1, rs2, row2) \
+cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
+  (cql_result_set_ref)(rs1), \
+  row1, \
+  (cql_result_set_ref)(rs2), \
+  row2)
+
+// The statement ending at line XXXX
 
 // The statement ending at line XXXX
 extern void slash_star_and_star_slash(void);

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -504,6 +504,7 @@ extern CQL_WARN_UNUSED cql_code nested_shared_stuff(sqlite3 *_Nonnull _db_, sqli
 extern CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 // static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
+extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 extern cql_blob_ref _Nullable make_blob(void);
 
 // The statement ending at line XXXX
@@ -15864,48 +15865,45 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   cql_error_prepare();
   cql_int32 _p1_x__ = 0;
   cql_int32 _p2_x_ = 0;
-  char _preds_1[10];
+  char _preds_1[8];
   char _vpreds_1[8];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   _p1_x__ = 1;
   _preds_1[0] = 1;
-  _preds_1[1] = 1;
   if (_p1_x__ <= 5) {
-    _preds_1[2] = 1;
+    _preds_1[1] = 1;
     _p2_x_ = 1;
     if (_p2_x_ == 1) {
-      _preds_1[3] = 1;
-      _vpreds_1[0] = 1; // pred 3 known to be 1
+      _preds_1[2] = 1;
+      _vpreds_1[0] = 1; // pred 2 known to be 1
     }
     else {
       if (_p2_x_ == 2) {
-        _preds_1[4] = 1;
-        _vpreds_1[1] = 1; // pred 4 known to be 1
-        _vpreds_1[2] = 1; // pred 4 known to be 1
+        _preds_1[3] = 1;
+        _vpreds_1[1] = 1; // pred 3 known to be 1
+        _vpreds_1[2] = 1; // pred 3 known to be 1
       }
       else {
-        _preds_1[5] = 1;
-        _vpreds_1[3] = 1; // pred 5 known to be 1
-        _vpreds_1[4] = 1; // pred 5 known to be 1
-        _vpreds_1[5] = 1; // pred 5 known to be 1
+        _preds_1[4] = 1;
+        _vpreds_1[3] = 1; // pred 4 known to be 1
+        _vpreds_1[4] = 1; // pred 4 known to be 1
+        _vpreds_1[5] = 1; // pred 4 known to be 1
       }
     }
-    _preds_1[6] = _preds_1[2];
-    _vpreds_1[6] = _preds_1[2];
+    _preds_1[5] = _preds_1[1];
+    _vpreds_1[6] = _preds_1[1];
   }
   else {
-    _preds_1[7] = 1;
-    _vpreds_1[7] = 1; // pred 7 known to be 1
+    _preds_1[6] = 1;
+    _vpreds_1[7] = 1; // pred 6 known to be 1
   }
-  _preds_1[8] = 1;
-  _preds_1[9] = 1;
+  _preds_1[7] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    10, _preds_1,
+    8, _preds_1,
   "SELECT x "
       "FROM (",
-  "WITH _ns_(x) AS (",
   "WITH "
     "shared_conditional (x) AS (",
   "SELECT ?",
@@ -15915,8 +15913,7 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
     "SELECT x "
       "FROM shared_conditional "
       "WHERE ? = 5",
-  "SELECT ?",
-  ") SELECT * FROM _ns_",
+  "SELECT ? AS x",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 8, _vpreds_1,
@@ -15960,12 +15957,10 @@ static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlit
   cql_error_prepare();
 
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    5, NULL,
+    3, NULL,
   "SELECT shared_something "
       "FROM (",
-  "WITH _ns_(shared_something) AS (",
-  "SELECT 1234",
-  ") SELECT * FROM _ns_",
+  "SELECT 1234 AS shared_something",
   ")"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -16083,6 +16078,123 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, s
   ") "
     "SELECT id "
       "FROM foo"
+  );
+  cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,
+                CQL_DATA_TYPE_INT32, &_p1_id__);
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  _rc_ = SQLITE_OK;
+
+cql_cleanup:
+  cql_error_report();
+  if (_rc_ == SQLITE_OK && !*_result_stmt) _rc_ = cql_no_rows_stmt(_db_, _result_stmt);
+  return _rc_;
+}
+#undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC shared_frag_else_nothing_in_from_clause_test ()
+BEGIN
+  SELECT *
+    FROM (CALL shared_frag_else_nothing(5));
+END;
+*/
+
+#define _PROC_ "shared_frag_else_nothing_in_from_clause_test"
+static int32_t shared_frag_else_nothing_in_from_clause_test_perf_index;
+
+cql_string_proc_name(shared_frag_else_nothing_in_from_clause_test_stored_procedure_name, "shared_frag_else_nothing_in_from_clause_test");
+
+typedef struct shared_frag_else_nothing_in_from_clause_test_row {
+  cql_nullable_int32 id1;
+  cql_string_ref _Nonnull text1;
+} shared_frag_else_nothing_in_from_clause_test_row;
+
+cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].id1.is_null;
+}
+
+cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].id1.value;
+}
+
+cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].text1;
+}
+
+uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count] = {
+  CQL_DATA_TYPE_INT32, // id1
+  CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // text1
+};
+
+#define shared_frag_else_nothing_in_from_clause_test_refs_offset cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, text1) // count = 1
+
+static cql_uint16 shared_frag_else_nothing_in_from_clause_test_col_offsets[] = { 2,
+  cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, id1),
+  cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, text1)
+};
+
+cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_count((cql_result_set_ref)result_set);
+}
+
+CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set) {
+  sqlite3_stmt *stmt = NULL;
+  cql_profile_start(CRC_shared_frag_else_nothing_in_from_clause_test, &shared_frag_else_nothing_in_from_clause_test_perf_index);
+  cql_code rc = shared_frag_else_nothing_in_from_clause_test(_db_, &stmt);
+  cql_fetch_info info = {
+    .rc = rc,
+    .db = _db_,
+    .stmt = stmt,
+    .data_types = shared_frag_else_nothing_in_from_clause_test_data_types,
+    .col_offsets = shared_frag_else_nothing_in_from_clause_test_col_offsets,
+    .refs_count = 1,
+    .refs_offset = shared_frag_else_nothing_in_from_clause_test_refs_offset,
+    .encode_context_index = -1,
+    .rowsize = sizeof(shared_frag_else_nothing_in_from_clause_test_row),
+    .crc = CRC_shared_frag_else_nothing_in_from_clause_test,
+    .perf_index = &shared_frag_else_nothing_in_from_clause_test_perf_index,
+  };
+  return cql_fetch_all_results(&info, (cql_result_set_ref *)result_set);
+}
+
+/*
+export:
+DECLARE PROC shared_frag_else_nothing_in_from_clause_test () (id1 INTEGER, text1 TEXT NOT NULL);
+*/
+CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt) {
+  cql_code _rc_ = SQLITE_OK;
+  *_result_stmt = NULL;
+  cql_error_prepare();
+  cql_nullable_bool _tmp_n_bool_0 = { .is_null = 1 };
+  cql_nullable_int32 _p1_id__ = { .is_null = 1 };
+  char _preds_1[4];
+  char _vpreds_1[1];
+
+  memset(&_preds_1[0], 0, sizeof(_preds_1));
+  memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
+  cql_set_notnull(_p1_id__, 5);
+  _preds_1[0] = 1;
+  cql_set_nullable(_tmp_n_bool_0, _p1_id__.is_null, _p1_id__.value > 0);
+  if (cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) {
+    _preds_1[1] = 1;
+    _vpreds_1[0] = 1; // pred 1 known to be 1
+  }
+  else {
+    _preds_1[2] = 1;
+  }
+  _preds_1[3] = 1;
+  _rc_ = cql_prepare_var(_db_, _result_stmt,
+    4, _preds_1,
+  "SELECT id1, text1 "
+      "FROM (",
+  "SELECT ? AS id1, 'x' AS text1",
+  "SELECT 0 id1,0 text1 WHERE 0",
+  ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,
                 CQL_DATA_TYPE_INT32, &_p1_id__);

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -15865,45 +15865,48 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   cql_error_prepare();
   cql_int32 _p1_x__ = 0;
   cql_int32 _p2_x_ = 0;
-  char _preds_1[8];
+  char _preds_1[10];
   char _vpreds_1[8];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   _p1_x__ = 1;
   _preds_1[0] = 1;
+  _preds_1[1] = 1;
   if (_p1_x__ <= 5) {
-    _preds_1[1] = 1;
+    _preds_1[2] = 1;
     _p2_x_ = 1;
     if (_p2_x_ == 1) {
-      _preds_1[2] = 1;
-      _vpreds_1[0] = 1; // pred 2 known to be 1
+      _preds_1[3] = 1;
+      _vpreds_1[0] = 1; // pred 3 known to be 1
     }
     else {
       if (_p2_x_ == 2) {
-        _preds_1[3] = 1;
-        _vpreds_1[1] = 1; // pred 3 known to be 1
-        _vpreds_1[2] = 1; // pred 3 known to be 1
+        _preds_1[4] = 1;
+        _vpreds_1[1] = 1; // pred 4 known to be 1
+        _vpreds_1[2] = 1; // pred 4 known to be 1
       }
       else {
-        _preds_1[4] = 1;
-        _vpreds_1[3] = 1; // pred 4 known to be 1
-        _vpreds_1[4] = 1; // pred 4 known to be 1
-        _vpreds_1[5] = 1; // pred 4 known to be 1
+        _preds_1[5] = 1;
+        _vpreds_1[3] = 1; // pred 5 known to be 1
+        _vpreds_1[4] = 1; // pred 5 known to be 1
+        _vpreds_1[5] = 1; // pred 5 known to be 1
       }
     }
-    _preds_1[5] = _preds_1[1];
-    _vpreds_1[6] = _preds_1[1];
+    _preds_1[6] = _preds_1[2];
+    _vpreds_1[6] = _preds_1[2];
   }
   else {
-    _preds_1[6] = 1;
-    _vpreds_1[7] = 1; // pred 6 known to be 1
+    _preds_1[7] = 1;
+    _vpreds_1[7] = 1; // pred 7 known to be 1
   }
-  _preds_1[7] = 1;
+  _preds_1[8] = 1;
+  _preds_1[9] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    8, _preds_1,
+    10, _preds_1,
   "SELECT x "
       "FROM (",
+  "(",
   "WITH "
     "shared_conditional (x) AS (",
   "SELECT ?",
@@ -15914,6 +15917,7 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
       "FROM shared_conditional "
       "WHERE ? = 5",
   "SELECT ? AS x",
+  ")",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 8, _vpreds_1,
@@ -15957,10 +15961,12 @@ static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlit
   cql_error_prepare();
 
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    3, NULL,
+    5, NULL,
   "SELECT shared_something "
       "FROM (",
+  "(",
   "SELECT 1234 AS shared_something",
+  ")",
   ")"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -16172,28 +16178,32 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_
   cql_error_prepare();
   cql_nullable_bool _tmp_n_bool_0 = { .is_null = 1 };
   cql_nullable_int32 _p1_id__ = { .is_null = 1 };
-  char _preds_1[4];
+  char _preds_1[6];
   char _vpreds_1[1];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   cql_set_notnull(_p1_id__, 5);
   _preds_1[0] = 1;
+  _preds_1[1] = 1;
   cql_set_nullable(_tmp_n_bool_0, _p1_id__.is_null, _p1_id__.value > 0);
   if (cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) {
-    _preds_1[1] = 1;
-    _vpreds_1[0] = 1; // pred 1 known to be 1
+    _preds_1[2] = 1;
+    _vpreds_1[0] = 1; // pred 2 known to be 1
   }
   else {
-    _preds_1[2] = 1;
+    _preds_1[3] = 1;
   }
-  _preds_1[3] = 1;
+  _preds_1[4] = 1;
+  _preds_1[5] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    4, _preds_1,
+    6, _preds_1,
   "SELECT id1, text1 "
       "FROM (",
+  "(",
   "SELECT ? AS id1, 'x' AS text1",
   "SELECT 0 id1,0 text1 WHERE 0",
+  ")",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,

--- a/sources/test/cg_test_c_with_header.h.ref
+++ b/sources/test/cg_test_c_with_header.h.ref
@@ -3500,6 +3500,30 @@ cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
   row2)
 
 // The statement ending at line XXXX
+#define CRC_shared_frag_else_nothing_in_from_clause_test -470936310725986298L
+
+extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_stored_procedure_name;
+
+#define shared_frag_else_nothing_in_from_clause_test_data_types_count 2
+
+#ifndef result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set
+#define result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set 1
+cql_result_set_type_decl(shared_frag_else_nothing_in_from_clause_test_result_set, shared_frag_else_nothing_in_from_clause_test_result_set_ref);
+#endif
+extern cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set);
+extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set);
+#define shared_frag_else_nothing_in_from_clause_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
+#define shared_frag_else_nothing_in_from_clause_test_row_equal(rs1, row1, rs2, row2) \
+cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
+  (cql_result_set_ref)(rs1), \
+  row1, \
+  (cql_result_set_ref)(rs2), \
+  row2)
+
+// The statement ending at line XXXX
 
 // The statement ending at line XXXX
 extern void slash_star_and_star_slash(void);

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -504,6 +504,7 @@ extern CQL_WARN_UNUSED cql_code nested_shared_stuff(sqlite3 *_Nonnull _db_, sqli
 extern CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 // static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
+extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 extern cql_blob_ref _Nullable make_blob(void);
 
 // The statement ending at line XXXX
@@ -15864,48 +15865,45 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   cql_error_prepare();
   cql_int32 _p1_x__ = 0;
   cql_int32 _p2_x_ = 0;
-  char _preds_1[10];
+  char _preds_1[8];
   char _vpreds_1[8];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   _p1_x__ = 1;
   _preds_1[0] = 1;
-  _preds_1[1] = 1;
   if (_p1_x__ <= 5) {
-    _preds_1[2] = 1;
+    _preds_1[1] = 1;
     _p2_x_ = 1;
     if (_p2_x_ == 1) {
-      _preds_1[3] = 1;
-      _vpreds_1[0] = 1; // pred 3 known to be 1
+      _preds_1[2] = 1;
+      _vpreds_1[0] = 1; // pred 2 known to be 1
     }
     else {
       if (_p2_x_ == 2) {
-        _preds_1[4] = 1;
-        _vpreds_1[1] = 1; // pred 4 known to be 1
-        _vpreds_1[2] = 1; // pred 4 known to be 1
+        _preds_1[3] = 1;
+        _vpreds_1[1] = 1; // pred 3 known to be 1
+        _vpreds_1[2] = 1; // pred 3 known to be 1
       }
       else {
-        _preds_1[5] = 1;
-        _vpreds_1[3] = 1; // pred 5 known to be 1
-        _vpreds_1[4] = 1; // pred 5 known to be 1
-        _vpreds_1[5] = 1; // pred 5 known to be 1
+        _preds_1[4] = 1;
+        _vpreds_1[3] = 1; // pred 4 known to be 1
+        _vpreds_1[4] = 1; // pred 4 known to be 1
+        _vpreds_1[5] = 1; // pred 4 known to be 1
       }
     }
-    _preds_1[6] = _preds_1[2];
-    _vpreds_1[6] = _preds_1[2];
+    _preds_1[5] = _preds_1[1];
+    _vpreds_1[6] = _preds_1[1];
   }
   else {
-    _preds_1[7] = 1;
-    _vpreds_1[7] = 1; // pred 7 known to be 1
+    _preds_1[6] = 1;
+    _vpreds_1[7] = 1; // pred 6 known to be 1
   }
-  _preds_1[8] = 1;
-  _preds_1[9] = 1;
+  _preds_1[7] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    10, _preds_1,
+    8, _preds_1,
   "SELECT x "
       "FROM (",
-  "WITH _ns_(x) AS (",
   "WITH "
     "shared_conditional (x) AS (",
   "SELECT ?",
@@ -15915,8 +15913,7 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
     "SELECT x "
       "FROM shared_conditional "
       "WHERE ? = 5",
-  "SELECT ?",
-  ") SELECT * FROM _ns_",
+  "SELECT ? AS x",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 8, _vpreds_1,
@@ -15960,12 +15957,10 @@ static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlit
   cql_error_prepare();
 
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    5, NULL,
+    3, NULL,
   "SELECT shared_something "
       "FROM (",
-  "WITH _ns_(shared_something) AS (",
-  "SELECT 1234",
-  ") SELECT * FROM _ns_",
+  "SELECT 1234 AS shared_something",
   ")"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -16083,6 +16078,123 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, s
   ") "
     "SELECT id "
       "FROM foo"
+  );
+  cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,
+                CQL_DATA_TYPE_INT32, &_p1_id__);
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  _rc_ = SQLITE_OK;
+
+cql_cleanup:
+  cql_error_report();
+  if (_rc_ == SQLITE_OK && !*_result_stmt) _rc_ = cql_no_rows_stmt(_db_, _result_stmt);
+  return _rc_;
+}
+#undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC shared_frag_else_nothing_in_from_clause_test ()
+BEGIN
+  SELECT *
+    FROM (CALL shared_frag_else_nothing(5));
+END;
+*/
+
+#define _PROC_ "shared_frag_else_nothing_in_from_clause_test"
+static int32_t shared_frag_else_nothing_in_from_clause_test_perf_index;
+
+cql_string_proc_name(shared_frag_else_nothing_in_from_clause_test_stored_procedure_name, "shared_frag_else_nothing_in_from_clause_test");
+
+typedef struct shared_frag_else_nothing_in_from_clause_test_row {
+  cql_nullable_int32 id1;
+  cql_string_ref _Nonnull text1;
+} shared_frag_else_nothing_in_from_clause_test_row;
+
+cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].id1.is_null;
+}
+
+cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].id1.value;
+}
+
+cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data[row].text1;
+}
+
+uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count] = {
+  CQL_DATA_TYPE_INT32, // id1
+  CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // text1
+};
+
+#define shared_frag_else_nothing_in_from_clause_test_refs_offset cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, text1) // count = 1
+
+static cql_uint16 shared_frag_else_nothing_in_from_clause_test_col_offsets[] = { 2,
+  cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, id1),
+  cql_offsetof(shared_frag_else_nothing_in_from_clause_test_row, text1)
+};
+
+cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_count((cql_result_set_ref)result_set);
+}
+
+CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set) {
+  sqlite3_stmt *stmt = NULL;
+  cql_profile_start(CRC_shared_frag_else_nothing_in_from_clause_test, &shared_frag_else_nothing_in_from_clause_test_perf_index);
+  cql_code rc = shared_frag_else_nothing_in_from_clause_test(_db_, &stmt);
+  cql_fetch_info info = {
+    .rc = rc,
+    .db = _db_,
+    .stmt = stmt,
+    .data_types = shared_frag_else_nothing_in_from_clause_test_data_types,
+    .col_offsets = shared_frag_else_nothing_in_from_clause_test_col_offsets,
+    .refs_count = 1,
+    .refs_offset = shared_frag_else_nothing_in_from_clause_test_refs_offset,
+    .encode_context_index = -1,
+    .rowsize = sizeof(shared_frag_else_nothing_in_from_clause_test_row),
+    .crc = CRC_shared_frag_else_nothing_in_from_clause_test,
+    .perf_index = &shared_frag_else_nothing_in_from_clause_test_perf_index,
+  };
+  return cql_fetch_all_results(&info, (cql_result_set_ref *)result_set);
+}
+
+/*
+export:
+DECLARE PROC shared_frag_else_nothing_in_from_clause_test () (id1 INTEGER, text1 TEXT NOT NULL);
+*/
+CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt) {
+  cql_code _rc_ = SQLITE_OK;
+  *_result_stmt = NULL;
+  cql_error_prepare();
+  cql_nullable_bool _tmp_n_bool_0 = { .is_null = 1 };
+  cql_nullable_int32 _p1_id__ = { .is_null = 1 };
+  char _preds_1[4];
+  char _vpreds_1[1];
+
+  memset(&_preds_1[0], 0, sizeof(_preds_1));
+  memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
+  cql_set_notnull(_p1_id__, 5);
+  _preds_1[0] = 1;
+  cql_set_nullable(_tmp_n_bool_0, _p1_id__.is_null, _p1_id__.value > 0);
+  if (cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) {
+    _preds_1[1] = 1;
+    _vpreds_1[0] = 1; // pred 1 known to be 1
+  }
+  else {
+    _preds_1[2] = 1;
+  }
+  _preds_1[3] = 1;
+  _rc_ = cql_prepare_var(_db_, _result_stmt,
+    4, _preds_1,
+  "SELECT id1, text1 "
+      "FROM (",
+  "SELECT ? AS id1, 'x' AS text1",
+  "SELECT 0 id1,0 text1 WHERE 0",
+  ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,
                 CQL_DATA_TYPE_INT32, &_p1_id__);

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -15865,45 +15865,48 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   cql_error_prepare();
   cql_int32 _p1_x__ = 0;
   cql_int32 _p2_x_ = 0;
-  char _preds_1[8];
+  char _preds_1[10];
   char _vpreds_1[8];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   _p1_x__ = 1;
   _preds_1[0] = 1;
+  _preds_1[1] = 1;
   if (_p1_x__ <= 5) {
-    _preds_1[1] = 1;
+    _preds_1[2] = 1;
     _p2_x_ = 1;
     if (_p2_x_ == 1) {
-      _preds_1[2] = 1;
-      _vpreds_1[0] = 1; // pred 2 known to be 1
+      _preds_1[3] = 1;
+      _vpreds_1[0] = 1; // pred 3 known to be 1
     }
     else {
       if (_p2_x_ == 2) {
-        _preds_1[3] = 1;
-        _vpreds_1[1] = 1; // pred 3 known to be 1
-        _vpreds_1[2] = 1; // pred 3 known to be 1
+        _preds_1[4] = 1;
+        _vpreds_1[1] = 1; // pred 4 known to be 1
+        _vpreds_1[2] = 1; // pred 4 known to be 1
       }
       else {
-        _preds_1[4] = 1;
-        _vpreds_1[3] = 1; // pred 4 known to be 1
-        _vpreds_1[4] = 1; // pred 4 known to be 1
-        _vpreds_1[5] = 1; // pred 4 known to be 1
+        _preds_1[5] = 1;
+        _vpreds_1[3] = 1; // pred 5 known to be 1
+        _vpreds_1[4] = 1; // pred 5 known to be 1
+        _vpreds_1[5] = 1; // pred 5 known to be 1
       }
     }
-    _preds_1[5] = _preds_1[1];
-    _vpreds_1[6] = _preds_1[1];
+    _preds_1[6] = _preds_1[2];
+    _vpreds_1[6] = _preds_1[2];
   }
   else {
-    _preds_1[6] = 1;
-    _vpreds_1[7] = 1; // pred 6 known to be 1
+    _preds_1[7] = 1;
+    _vpreds_1[7] = 1; // pred 7 known to be 1
   }
-  _preds_1[7] = 1;
+  _preds_1[8] = 1;
+  _preds_1[9] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    8, _preds_1,
+    10, _preds_1,
   "SELECT x "
       "FROM (",
+  "(",
   "WITH "
     "shared_conditional (x) AS (",
   "SELECT ?",
@@ -15914,6 +15917,7 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
       "FROM shared_conditional "
       "WHERE ? = 5",
   "SELECT ? AS x",
+  ")",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 8, _vpreds_1,
@@ -15957,10 +15961,12 @@ static CQL_WARN_UNUSED cql_code simple_shared_frag(sqlite3 *_Nonnull _db_, sqlit
   cql_error_prepare();
 
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    3, NULL,
+    5, NULL,
   "SELECT shared_something "
       "FROM (",
+  "(",
   "SELECT 1234 AS shared_something",
+  ")",
   ")"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -16172,28 +16178,32 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test(sqlite3 *_
   cql_error_prepare();
   cql_nullable_bool _tmp_n_bool_0 = { .is_null = 1 };
   cql_nullable_int32 _p1_id__ = { .is_null = 1 };
-  char _preds_1[4];
+  char _preds_1[6];
   char _vpreds_1[1];
 
   memset(&_preds_1[0], 0, sizeof(_preds_1));
   memset(&_vpreds_1[0], 0, sizeof(_vpreds_1));
   cql_set_notnull(_p1_id__, 5);
   _preds_1[0] = 1;
+  _preds_1[1] = 1;
   cql_set_nullable(_tmp_n_bool_0, _p1_id__.is_null, _p1_id__.value > 0);
   if (cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) {
-    _preds_1[1] = 1;
-    _vpreds_1[0] = 1; // pred 1 known to be 1
+    _preds_1[2] = 1;
+    _vpreds_1[0] = 1; // pred 2 known to be 1
   }
   else {
-    _preds_1[2] = 1;
+    _preds_1[3] = 1;
   }
-  _preds_1[3] = 1;
+  _preds_1[4] = 1;
+  _preds_1[5] = 1;
   _rc_ = cql_prepare_var(_db_, _result_stmt,
-    4, _preds_1,
+    6, _preds_1,
   "SELECT id1, text1 "
       "FROM (",
+  "(",
   "SELECT ? AS id1, 'x' AS text1",
   "SELECT 0 id1,0 text1 WHERE 0",
+  ")",
   ")"
   );
   cql_multibind_var(&_rc_, _db_, _result_stmt, 1, _vpreds_1,

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -3500,6 +3500,30 @@ cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
   row2)
 
 // The statement ending at line XXXX
+#define CRC_shared_frag_else_nothing_in_from_clause_test -470936310725986298L
+
+extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_stored_procedure_name;
+
+#define shared_frag_else_nothing_in_from_clause_test_data_types_count 2
+
+#ifndef result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set
+#define result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set 1
+cql_result_set_type_decl(shared_frag_else_nothing_in_from_clause_test_result_set, shared_frag_else_nothing_in_from_clause_test_result_set_ref);
+#endif
+extern cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+extern cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set);
+extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set);
+#define shared_frag_else_nothing_in_from_clause_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
+#define shared_frag_else_nothing_in_from_clause_test_row_equal(rs1, row1, rs2, row2) \
+cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
+  (cql_result_set_ref)(rs1), \
+  row1, \
+  (cql_result_set_ref)(rs2), \
+  row2)
+
+// The statement ending at line XXXX
 
 // The statement ending at line XXXX
 extern void slash_star_and_star_slash(void);

--- a/sources/test/cg_test_exports.out.ref
+++ b/sources/test/cg_test_exports.out.ref
@@ -224,6 +224,7 @@ DECLARE PROC shared_conditional_user (x INTEGER NOT NULL) (id INTEGER NOT NULL, 
 DECLARE PROC nested_shared_stuff () (x INTEGER NOT NULL);
 DECLARE PROC use_nested_select_shared_frag_form () (x INTEGER NOT NULL);
 DECLARE PROC shared_frag_else_nothing_test () (id INTEGER NOT NULL);
+DECLARE PROC shared_frag_else_nothing_in_from_clause_test () (id1 INTEGER, text1 TEXT NOT NULL);
 DECLARE PROC slash_star_and_star_slash ();
 DECLARE PROC blob_serialization_test () USING TRANSACTION;
 DECLARE PROC deserialize_func () USING TRANSACTION;

--- a/sources/test/cg_test_lua.lua.ref
+++ b/sources/test/cg_test_lua.lua.ref
@@ -7779,14 +7779,14 @@ function use_nested_select_shared_frag_form(_db_)
     10, _preds_1,
     {
     "SELECT x FROM (",
-    "WITH _ns_(x) AS (",
+    "(",
     "WITH shared_conditional (x) AS (",
     "SELECT ?",
     "SELECT ? + ?",
     "SELECT ? + ? + ?",
     ") SELECT x FROM shared_conditional WHERE ? = 5",
-    "SELECT ?",
-    ") SELECT * FROM _ns_",
+    "SELECT ? AS x",
+    ")",
     ")"
     }
   )
@@ -7832,9 +7832,9 @@ function simple_shared_frag(_db_)
     5, nil,
     {
     "SELECT shared_something FROM (",
-    "WITH _ns_(shared_something) AS (",
-    "SELECT 1234",
-    ") SELECT * FROM _ns_",
+    "(",
+    "SELECT 1234 AS shared_something",
+    ")",
     ")"
     }
   )

--- a/sources/test/cg_test_lua.sql
+++ b/sources/test/cg_test_lua.sql
@@ -4723,7 +4723,7 @@ end;
 -- +  "SELECT x FROM (",
 --
 -- fragment 1, the nested wrapper -- always present
--- +  "WITH _ns_(x) AS (",
+-- +  "(",
 --
 -- fragment 2 present if x <= 5
 -- +  "WITH shared_conditional (x) AS (",
@@ -4749,7 +4749,7 @@ end;
 -- +  "SELECT ?",
 --
 -- fragment 8 present always
--- +  ") SELECT * FROM _ns_",
+-- +  ")",
 --
 -- fragment 9 present always
 -- +  ")"
@@ -4763,9 +4763,9 @@ end;
 -- accomplishes this.  We do it this way so that the text of the fragment is the same
 -- if we are using nested select or not.
 -- + "SELECT shared_something FROM (",
--- + "WITH _ns_(shared_something) AS (",
--- + "SELECT 1234",
--- + ") SELECT * FROM _ns_",
+-- + "(",
+-- + "SELECT 1234 as shared_something",
+-- + ")",
 -- + ")"
 @attribute(cql:private)
 create proc simple_shared_frag()

--- a/sources/test/cg_test_objc.out.ref
+++ b/sources/test/cg_test_objc.out.ref
@@ -4256,6 +4256,50 @@ static inline BOOL CGBSharedFragElseNothingTestRowEqual(CGBSharedFragElseNothing
   return CGCSharedFragElseNothingTestRowEqual(CGCSharedFragElseNothingTestFromCGBSharedFragElseNothingTest(resultSet1), row1, CGCSharedFragElseNothingTestFromCGBSharedFragElseNothingTest(resultSet2), row2);
 }
 
+@class CGBSharedFragElseNothingInFromClauseTest;
+
+#ifdef CQL_EMIT_OBJC_INTERFACES
+@interface CGBSharedFragElseNothingInFromClauseTest
+@end
+#endif
+
+static inline CGBSharedFragElseNothingInFromClauseTest *CGBSharedFragElseNothingInFromClauseTestFromCGCSharedFragElseNothingInFromClauseTest(CGCSharedFragElseNothingInFromClauseTestResultSetRef resultSet)
+{
+  return (__bridge CGBSharedFragElseNothingInFromClauseTest *)resultSet;
+}
+
+static inline CGCSharedFragElseNothingInFromClauseTestResultSetRef CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(CGBSharedFragElseNothingInFromClauseTest *resultSet)
+{
+  return (__bridge CGCSharedFragElseNothingInFromClauseTestResultSetRef)resultSet;
+}
+
+static inline NSNumber *_Nullable CGBSharedFragElseNothingInFromClauseTestGetId1(CGBSharedFragElseNothingInFromClauseTest *resultSet, int32_t row)
+{
+  CGCSharedFragElseNothingInFromClauseTestResultSetRef cResultSet = CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(resultSet);
+  return CGCSharedFragElseNothingInFromClauseTestGetId1IsNull(cResultSet, row) ? nil : @(CGCSharedFragElseNothingInFromClauseTestGetId1Value(cResultSet, row));
+}
+
+static inline NSString *CGBSharedFragElseNothingInFromClauseTestGetText1(CGBSharedFragElseNothingInFromClauseTest *resultSet, int32_t row)
+{
+  CGCSharedFragElseNothingInFromClauseTestResultSetRef cResultSet = CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(resultSet);
+  return (__bridge NSString *)CGCSharedFragElseNothingInFromClauseTestGetText1(cResultSet, row);
+}
+
+static inline int32_t CGBSharedFragElseNothingInFromClauseTestResultCount(CGBSharedFragElseNothingInFromClauseTest *resultSet)
+{
+  return CGCSharedFragElseNothingInFromClauseTestResultCount(CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(resultSet));
+}
+
+static inline NSUInteger CGBSharedFragElseNothingInFromClauseTestRowHash(CGBSharedFragElseNothingInFromClauseTest *resultSet, int32_t row)
+{
+  return CGCSharedFragElseNothingInFromClauseTestRowHash(CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(resultSet), row);
+}
+
+static inline BOOL CGBSharedFragElseNothingInFromClauseTestRowEqual(CGBSharedFragElseNothingInFromClauseTest *resultSet1, int32_t row1, CGBSharedFragElseNothingInFromClauseTest *resultSet2, int32_t row2)
+{
+  return CGCSharedFragElseNothingInFromClauseTestRowEqual(CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(resultSet1), row1, CGCSharedFragElseNothingInFromClauseTestFromCGBSharedFragElseNothingInFromClauseTest(resultSet2), row2);
+}
+
 @class CGBSomeRedeclaredOutProc;
 
 #ifdef CQL_EMIT_OBJC_INTERFACES


### PR DESCRIPTION
The `_ns_` wrapper seems to have been added to avoid generating two different generated sql strings for the same fragment (with and without column aliases). But in practice the cost of creating an extra cte wrapper around a subquery can be quite high (in memory usage and runtime), so it's probably worth the tradeoff to remove the wrapper for some small overhead in codegen when the same fragment is used both in a WITH and FROM clause.