### PR TITLE
Fix — Make links portable

### DIFF
--- a/docs/contributors/dev_notes.md
+++ b/docs/contributors/dev_notes.md
@@ -1,8 +1,8 @@
 # Developer Notes on CQL Development
 
-0. We have extensive documentation at [CQL Internals](https://ricomariani.github.io/CG-SQL-author/developer_guide.html)
-1. If you aren't good with `yacc`/`lex` you probably should do some homework before you start. CQL development is all about building and walking a syntax tree.  It's possible to make local changes without knowing the details but it can be hard to figure out where to make changes without context.
-2. CQL development is basically test driven, to create a new feature:
+1. We have extensive documentation at [CQL Internals](../developer_guide/_index.md)
+2. If you aren't good with `yacc`/`lex` you probably should do some homework before you start. CQL development is all about building and walking a syntax tree.  It's possible to make local changes without knowing the details but it can be hard to figure out where to make changes without context.
+3. CQL development is basically test driven, to create a new feature:
    1. Add the language feature to `test.sql`
    2. run [`test.sh`](testing.md); it will fail due to parse error
    3. Add the syntax to `cql.y` and create the necessary tree pieces in `ast.h`
@@ -25,7 +25,7 @@
    20. run [`cov.sh`](code-coverage.md) to confirm 100% coverage
    21. sanity check the GCC build (I use a linux box for this)
 
-3. Get a solid code review and land as usual.
+4. Get a solid code review and land as usual.
 
 By the time you have done this you will have passed the tests dozens of times and you will know exactly what your code is doing to the entire battery of cql combinations.  Missing tests can be painful and cause downstream regressions so be ruthless about adding enough combinations and validating the essential parts.  The snapshot diffing is helpful but the real gating is done by the pattern matching logic.
 

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -16,7 +16,7 @@ While standing in the `/sources` directory you may use `test.sh` and with these 
 |`cov.sh` | See [Code Coverage](code-coverage.md) |
 
 
-See details in our [CQL Internals documentation](https://ricomariani.github.io/CG-SQL-author/developer_guide.html#part-4-testing)
+See details in our [Developer Guide](../developer_guide/04_testing.md)
 
 >NOTE: For productivity it's not uncommon to tweak `test.sh` so that the test you care about runs first.
 >But don't submit a PR with the tests reordered.  Not that the author has ever made that mistake or

--- a/docs/user_guide/01_introduction.md
+++ b/docs/user_guide/01_introduction.md
@@ -35,7 +35,7 @@ are allowed on which data.  Strict type checking is much more reasonable given C
 ### Getting Started
 
 Before starting this tutorial, make sure you have built the `cql`
-executable first in [Building CG/SQL](../../docs/getting-started.md)
+executable first in [Building CG/SQL](../quick_start/getting-started.md)
 
 The "Hello World" program rendered in CQL looks like this:
 
@@ -51,7 +51,7 @@ end;
 
 This very nearly works exactly as written but we'll need a little bit of glue to wire it all up.
 
-First, assuming you have [built](../../docs/getting-started#building) `cql`, you should have the power to do this:
+First, assuming you have [built](../quick_start/getting-started.md#building) `cql`, you should have the power to do this:
 
 ```bash
 $ cql --in hello.sql --cg hello.h hello.c

--- a/docs/user_guide/02_using_data.md
+++ b/docs/user_guide/02_using_data.md
@@ -475,4 +475,4 @@ Which probably doesn't come up very often but it does illustrate several things:
  * You can use `WITH RECURSIVE` to create table expressions that are sequences of numbers easily, with no reference to any real data
 
 A working version of this code can be found in the `sources/demo` directory of CG/SQL project.
-Additional demo code is available in [Appendix 10](#appendix-10-a-working-example)
+Additional demo code is available in [Appendix 10](docs/user_guide/appendices/10_working_example.md)

--- a/scripts/official_website/layouts/_default/_markup/render-link.html
+++ b/scripts/official_website/layouts/_default/_markup/render-link.html
@@ -1,0 +1,10 @@
+{{ $link := .Destination }}
+{{ $isRemote := strings.HasPrefix $link "http" }}
+{{- if not $isRemote -}}
+{{ $url := urls.Parse .Destination }}
+{{- if $url.Path -}}
+{{ $fragment := "" }}
+{{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+{{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end }}{{ end -}}
+{{- end -}}
+<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
I'll fix the remaining links when I have time but now the links are portable and works both in visual studio / github and the official website