### PR TITLE
Using fragment as a nested subquery doesn't automatically define an alias

### DIFF
--- a/sources/sem.c
+++ b/sources/sem.c
@@ -10578,6 +10578,10 @@ static void sem_table_or_subquery(ast_node *ast) {
 
     ast->sem = new_sem(SEM_TYPE_JOIN);
     ast->sem->jptr = sem_join_from_sem_struct(factor->sem->sptr);
+
+    // shared fragment within a subquery doesn't have an alias unless
+    // explicitly declared with opt_as_alias.
+    ast->sem->jptr->names[0] = "select";
     alias_target = &ast->sem->jptr->names[0];
   }
   else if (is_ast_table_function(factor)) {

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -476,6 +476,7 @@ test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0437: common table name shadow
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0437: common table name shadows previously declared table or view 'MyView'
 test/sem_test.sql:XXXX:1: error: in create_proc_stmt : CQL0440: fragments may not have an empty body 'empty_fragment'
 test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0212: too few arguments provided to procedure 'a_shared_frag'
+test/sem_test.sql:XXXX:1: error: in table_star : CQL0054: table not found 'a_shared_frag'
 test/sem_test.sql:XXXX:1: error: in select_nothing_stmt : CQL0496: SELECT NOTHING may only appear in the ELSE clause of a shared fragment
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0057: bogus_cte, all must have the same column count
 test/sem_test.sql:XXXX:1: error: in cte_decl : additional difference diagnostic info:

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -19769,9 +19769,9 @@ SELECT *
   |   | {select_expr_list_con}: select: { x: integer notnull, y: integer notnull, z: real notnull }
   |     | {select_expr_list}: select: { x: integer notnull, y: integer notnull, z: real notnull }
   |     | | {star}: select: { x: integer notnull, y: integer notnull, z: real notnull }
-  |     | {select_from_etc}: TABLE { a_shared_frag: a_shared_frag }
-  |       | {table_or_subquery_list}: TABLE { a_shared_frag: a_shared_frag }
-  |       | | {table_or_subquery}: TABLE { a_shared_frag: a_shared_frag }
+  |     | {select_from_etc}: TABLE { select: a_shared_frag }
+  |       | {table_or_subquery_list}: TABLE { select: a_shared_frag }
+  |       | | {table_or_subquery}: TABLE { select: a_shared_frag }
   |       |   | {shared_cte}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
   |       |     | {call_stmt}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
   |       |       | {name a_shared_frag}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
@@ -19805,6 +19805,37 @@ test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0212: too few arguments provi
   |       |   | {shared_cte}: err
   |       |     | {call_stmt}: err
   |       |       | {name a_shared_frag}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT a_shared_frag.*
+  FROM (CALL a_shared_frag(1, 2));
+
+test/sem_test.sql:XXXX:1: error: in table_star : CQL0054: table not found 'a_shared_frag'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {table_star}: err
+  |     |   | {name a_shared_frag}
+  |     | {select_from_etc}: TABLE { select: a_shared_frag }
+  |       | {table_or_subquery_list}: TABLE { select: a_shared_frag }
+  |       | | {table_or_subquery}: TABLE { select: a_shared_frag }
+  |       |   | {shared_cte}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
+  |       |     | {call_stmt}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
+  |       |       | {name a_shared_frag}: a_shared_frag: { x: integer notnull, y: integer notnull, z: real notnull } dml_proc
+  |       |       | {arg_list}: ok
+  |       |         | {int 1}: integer notnull
+  |       |         | {arg_list}
+  |       |           | {int 2}: integer notnull
   |       | {select_where}
   |         | {select_groupby}
   |           | {select_having}
@@ -73833,9 +73864,9 @@ SELECT *
     |   | {select_expr_list_con}: select: { x: integer notnull }
     |     | {select_expr_list}: select: { x: integer notnull }
     |     | | {star}: select: { x: integer notnull }
-    |     | {select_from_etc}: TABLE { fragtest_0_2: fragtest_0_2 }
-    |       | {table_or_subquery_list}: TABLE { fragtest_0_2: fragtest_0_2 }
-    |       | | {table_or_subquery}: TABLE { fragtest_0_2: fragtest_0_2 }
+    |     | {select_from_etc}: TABLE { select: fragtest_0_2 }
+    |       | {table_or_subquery_list}: TABLE { select: fragtest_0_2 }
+    |       | | {table_or_subquery}: TABLE { select: fragtest_0_2 }
     |       |   | {shared_cte}: fragtest_0_2: { x: integer notnull } dml_proc
     |       |     | {call_stmt}: fragtest_0_2: { x: integer notnull } dml_proc
     |       |     | | {name fragtest_0_2}: fragtest_0_2: { x: integer notnull } dml_proc
@@ -74199,9 +74230,9 @@ SELECT *
     |   | {select_expr_list_con}: select: { x: integer notnull }
     |     | {select_expr_list}: select: { x: integer notnull }
     |     | | {star}: select: { x: integer notnull }
-    |     | {select_from_etc}: TABLE { fragtest_2_1: fragtest_2_1 }
-    |       | {table_or_subquery_list}: TABLE { fragtest_2_1: fragtest_2_1 }
-    |       | | {table_or_subquery}: TABLE { fragtest_2_1: fragtest_2_1 }
+    |     | {select_from_etc}: TABLE { select: fragtest_2_1 }
+    |       | {table_or_subquery_list}: TABLE { select: fragtest_2_1 }
+    |       | | {table_or_subquery}: TABLE { select: fragtest_2_1 }
     |       |   | {shared_cte}: fragtest_2_1: { x: integer notnull } dml_proc
     |       |     | {call_stmt}: fragtest_2_1: { x: integer notnull } dml_proc
     |       |     | | {name fragtest_2_1}: fragtest_2_1: { x: integer notnull } dml_proc
@@ -74268,9 +74299,9 @@ END;
             |   | {select_expr_list_con}: select: { x: integer notnull }
             |     | {select_expr_list}: select: { x: integer notnull }
             |     | | {star}: select: { x: integer notnull }
-            |     | {select_from_etc}: TABLE { fragtest_1_0: fragtest_1_0 }
-            |       | {table_or_subquery_list}: TABLE { fragtest_1_0: fragtest_1_0 }
-            |       | | {table_or_subquery}: TABLE { fragtest_1_0: fragtest_1_0 }
+            |     | {select_from_etc}: TABLE { select: fragtest_1_0 }
+            |       | {table_or_subquery_list}: TABLE { select: fragtest_1_0 }
+            |       | | {table_or_subquery}: TABLE { select: fragtest_1_0 }
             |       |   | {shared_cte}: fragtest_1_0: { x: integer notnull } dml_proc
             |       |     | {call_stmt}: fragtest_1_0: { x: integer notnull } dml_proc
             |       |     | | {name fragtest_1_0}: fragtest_1_0: { x: integer notnull } dml_proc

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -5299,6 +5299,12 @@ select * from (call a_shared_frag(1, 2));
 -- +1 error:
 select * from (call a_shared_frag());
 
+-- TEST: fragment in nested select cannot be referred to without explict alias
+-- + {select_expr_list}: err
+-- + error: % table not found 'a_shared_frag'
+-- +1 error:
+select a_shared_frag.* from (call a_shared_frag(1, 2));
+
 -- TEST: a conditional shared fragment without an else clause is equivalent to
 -- putting "select nothing" in an else clause.
 -- + {select_nothing_stmt}: conditional_no_else: { x: integer notnull }


### PR DESCRIPTION
Fix a bug where you can do this without CQL raising an error:
```
select a_shared_frag.* from (call a_shared_frag(1, 2));
```

This shouldn't be allowed because `a_shared_frag` hasn't actually been defined as an alias.