### PR TITLE
There were many cases where the CQL echoing could do better layout

### DIFF
--- a/sources/cg_lua.c
+++ b/sources/cg_lua.c
@@ -2584,7 +2584,7 @@ static bool_t cg_lua_capture_variables(ast_node *ast, void *context, charbuf *bu
   list_item **head = (list_item**)context;
   add_item_to_list(head, ast);
 
-  bprintf(buffer, "?");
+  gen_printf("?");
   return true;
 }
 
@@ -2619,7 +2619,7 @@ static bool_t cg_lua_table_rename(ast_node *ast, void *context, charbuf *buffer)
   if (entry) {
     EXTRACT(cte_binding, entry->val);
     EXTRACT_STRING(actual, cte_binding->left);
-    bprintf(buffer, "%s", actual);
+    gen_printf("%s", actual);
     handled = true;
   }
 
@@ -2868,7 +2868,7 @@ static bool_t cg_lua_inline_func(ast_node *call_ast, void *context, charbuf *buf
   proc_arg_aliases = NULL;
   proc_cte_aliases = NULL;
 
-  bprintf(buffer, "(");
+  gen_printf("(");
 
   // Emit a fragment from a statement, note that this can nest
   cg_lua_fragment_stmt(stmt, buffer);
@@ -2883,7 +2883,7 @@ static bool_t cg_lua_inline_func(ast_node *call_ast, void *context, charbuf *buf
     // args are evaluated once which could be important if there
     // are SQL functions with side-effects being used (highly rare)
     // or expensive functions.
-    bprintf(buffer, " FROM (SELECT ");
+    gen_printf(" FROM (SELECT ");
 
     while (params) {
       Invariant(is_ast_params(params));
@@ -2897,19 +2897,19 @@ static bool_t cg_lua_inline_func(ast_node *call_ast, void *context, charbuf *buf
       EXTRACT_STRING(param_name, param_name_ast);
 
       gen_root_expr(expr);
-      bprintf(buffer, " %s", param_name);
+      gen_printf(" %s", param_name);
       if (params->right) {
-        bprintf(buffer, ", ");
+        gen_printf(", ");
       }
 
       // guaranteed to stay in lock step
       params = params->right;
       arg_list = arg_list->right;
     }
-    bprintf(buffer, ")");
+    gen_printf(")");
   }
 
-  bprintf(buffer, ")");
+  gen_printf(")");
   cg_lua_emit_one_frag(buffer);
 
   return true;

--- a/sources/charbuf.c
+++ b/sources/charbuf.c
@@ -117,6 +117,16 @@ cql_noexport void bputc(charbuf *b, char c) {
  b->ptr[b->used++] = 0; // put a new null in place, for sure room for this
 }
 
+cql_noexport void bindent_if_many(charbuf *output, charbuf *input, int32_t indent) {
+  if (indent && strchr(input->ptr, '\n')) {
+    bputc(output, '\n');
+    bindent(output, input, indent);
+  }
+  else {
+    bprintf(output, "%s", input->ptr);
+  }
+}
+
 cql_noexport void bindent(charbuf *output, charbuf *input, int32_t indent) {
   if (indent == 0) {
     bprintf(output, "%s", input->ptr);

--- a/sources/charbuf.c
+++ b/sources/charbuf.c
@@ -117,16 +117,6 @@ cql_noexport void bputc(charbuf *b, char c) {
  b->ptr[b->used++] = 0; // put a new null in place, for sure room for this
 }
 
-cql_noexport void bindent_if_many(charbuf *output, charbuf *input, int32_t indent) {
-  if (indent && strchr(input->ptr, '\n')) {
-    bputc(output, '\n');
-    bindent(output, input, indent);
-  }
-  else {
-    bprintf(output, "%s", input->ptr);
-  }
-}
-
 cql_noexport void bindent(charbuf *output, charbuf *input, int32_t indent) {
   if (indent == 0) {
     bprintf(output, "%s", input->ptr);

--- a/sources/charbuf.h
+++ b/sources/charbuf.h
@@ -37,7 +37,6 @@ cql_noexport void bprintf(charbuf *b, const char *format, ...);
 cql_noexport CSTR dup_printf(const char *format, ...);
 cql_noexport void bputc(charbuf *b, char c);
 cql_noexport void bindent(charbuf *output, charbuf *input, int32_t indent);
-cql_noexport void bindent_if_many(charbuf *output, charbuf *input, int32_t indent);
 cql_noexport bool_t breadline(charbuf *output, CSTR *data);
 
 #define CHARBUF_OPEN(x) \

--- a/sources/charbuf.h
+++ b/sources/charbuf.h
@@ -37,6 +37,7 @@ cql_noexport void bprintf(charbuf *b, const char *format, ...);
 cql_noexport CSTR dup_printf(const char *format, ...);
 cql_noexport void bputc(charbuf *b, char c);
 cql_noexport void bindent(charbuf *output, charbuf *input, int32_t indent);
+cql_noexport void bindent_if_many(charbuf *output, charbuf *input, int32_t indent);
 cql_noexport bool_t breadline(charbuf *output, CSTR *data);
 
 #define CHARBUF_OPEN(x) \
@@ -67,4 +68,3 @@ cql_noexport bool_t breadline(charbuf *output, CSTR *data);
   output = name##_saved; \
   bindent(output, &name, name##_level); \
   CHARBUF_CLOSE(name);
-

--- a/sources/gen_sql.h
+++ b/sources/gen_sql.h
@@ -15,6 +15,7 @@ cql_data_decl( int32_t gen_stmt_level );
 
 cql_noexport void gen_init(void);
 cql_noexport void gen_cleanup(void);
+cql_noexport void gen_printf(const char *_Nonnull format, ...);
 cql_noexport void gen_set_output_buffer(struct charbuf *_Nonnull buffer);
 
 typedef void (*_Nonnull gen_func)(ast_node *_Nonnull ast);

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -1227,7 +1227,8 @@ begin
 end;
 
 -- TEST: insert or replace form
--- +  "INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5)"
+-- + "INSERT OR REPLACE INTO bar(id, type) "
+-- +   "VALUES(1, 5)");
 insert or replace into bar(id, type) values (1,5);
 
 -- TEST: insert default from
@@ -1235,7 +1236,8 @@ insert or replace into bar(id, type) values (1,5);
 insert into foo default values;
 
 -- TEST: insert from stored procedure
--- + "INSERT INTO bar(id, type) VALUES(?, ?)"
+-- + "INSERT INTO bar(id, type) "
+-- +   "VALUES(?, ?)");
 -- + cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cql_nullable_int32 type_) {
 create proc insert_values(id_ integer not null, type_ integer)
 begin
@@ -1305,10 +1307,13 @@ begin
 end;
 
 -- TEST: simple DML statements for json_schema cg
--- +2 "INSERT INTO foo(id) VALUES(NULL)"
+-- + "INSERT INTO foo(id) "
+-- +   "VALUES(NULL)");
+-- + "INSERT INTO foo(id) "
+-- +   "VALUES(NULL)");
 -- + "UPDATE bar "
--- + "SET name = 'bar' "
--- + "DELETE FROM foo WHERE id = 1"
+-- +   "SET name = 'bar' "
+-- +     "WHERE name = 'baz'");
 create proc misc_dml_proc()
 begin
   insert into foo values(NULL);
@@ -1485,8 +1490,10 @@ declare blob_var_notnull blob not null;
 set blob_var_notnull := blob_notnull_func();
 
 -- TEST: bind a nullable blob and a not null blob
--- + INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
--- + "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)"
+-- + INSERT INTO blob_table(blob_id, b_nullable, b_notnull)
+-- +   VALUES(0, blob_var, blob_var_notnull);
+-- + "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) "
+-- +   "VALUES(0, ?, ?)");
 -- + cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
 -- +               CQL_DATA_TYPE_BLOB, blob_var,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
@@ -1850,17 +1857,23 @@ end;
 -- TEST: use with-insert form
 -- +  _rc_ = cql_exec(_db_,
 -- + "WITH "
--- + "x (a) AS (SELECT 111) "
--- + "INSERT INTO foo(id) VALUES(ifnull(( SELECT a "
--- + "FROM x ), 0))");
+-- +   "x (a) AS ( "
+-- +     "SELECT 111 "
+-- +   ") "
+-- + "INSERT INTO foo(id) "
+-- +   "VALUES(ifnull(( SELECT a "
+-- +     "FROM x ), 0))");
 with x(a) as (select 111)
 insert into foo values ( ifnull((select a from x), 0));
 
 -- TEST: use insert from select (put this in a proc to force the schema utils to walk it)
 -- + "WITH "
--- + "x (a) AS (SELECT 111) "
--- + "INSERT INTO foo(id) SELECT a "
--- + "FROM x"
+-- +   "x (a) AS ( "
+-- +     "SELECT 111 "
+-- +   ") "
+-- + "INSERT INTO foo(id) "
+-- +   "SELECT a "
+-- +     "FROM x");
 create proc with_inserter()
 begin
   with x(a) as (select 111)
@@ -2291,10 +2304,12 @@ end;
 
 -- TEST: with delete form
 -- + _rc_ = cql_exec(_db_,
--- +   "WITH "
--- +   "x (a) AS (SELECT 111) "
--- +   "DELETE FROM foo WHERE id IN (SELECT a "
--- +     "FROM x)");
+-- + "WITH "
+-- +   "x (a) AS ( "
+-- +     "SELECT 111 "
+-- +   ") "
+-- + "DELETE FROM foo WHERE id IN (SELECT a "
+-- +   "FROM x)");
 create proc with_deleter()
 begin
   with x(a) as (select 111)
@@ -2303,12 +2318,14 @@ end;
 
 -- TEST: with update form
 -- + _rc_ = cql_exec(_db_,
--- +  "WITH "
--- +  "x (a) AS (SELECT 111) "
--- +  "UPDATE bar "
--- +  "SET name = 'xyzzy' "
--- +    "WHERE id IN (SELECT a "
--- +    "FROM x)");
+-- + "WITH "
+-- +   "x (a) AS ( "
+-- +     "SELECT 111 "
+-- +   ") "
+-- + "UPDATE bar "
+-- +   "SET name = 'xyzzy' "
+-- +     "WHERE id IN (SELECT a "
+-- +     "FROM x)");
 create proc with_updater()
 begin
   with x(a) as (select 111)
@@ -2438,10 +2455,10 @@ END;
 
 -- TEST: try to use a WITH_SELECT form in a select expression
 -- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
--- +   "WITH "
--- +   "threads2 (count) AS (SELECT 1) "
--- +   "SELECT COUNT(*) "
--- +     "FROM threads2");
+-- + "WITH "
+-- +   "threads2 (count) AS ( "
+-- +     "SELECT 1 "
+-- +   ") "
 create proc use_with_select()
 begin
    declare x integer;
@@ -2460,12 +2477,13 @@ begin
 end;
 
 -- TEST: codegen upsert statement with update statement
--- + "INSERT INTO foo(id) SELECT id "
--- + "FROM bar "
--- + "WHERE 1 "
+-- + "INSERT INTO foo(id) "
+-- +   "SELECT id "
+-- +     "FROM bar "
+-- +     "WHERE 1 "
 -- + "ON CONFLICT (id) DO UPDATE "
--- + "SET id = 10 "
--- + "WHERE id <> 10"
+-- +   "SET id = 10 "
+-- +     "WHERE id <> 10");
 -- + cql_code upsert_do_something(sqlite3 *_Nonnull _db_) {
 create proc upsert_do_something()
 BEGIN
@@ -2475,13 +2493,16 @@ END;
 -- TEST: codegen with upsert statement form
 -- + cql_code with_upsert_form(sqlite3 *_Nonnull _db_) {
 -- + "WITH "
--- + "names (id) AS (VALUES(1), (5), (3), (12)) "
--- + "INSERT INTO foo(id) SELECT id "
--- +   "FROM names "
--- +   "WHERE 1 "
+-- +   "names (id) AS ( "
+-- +     "VALUES(1), (5), (3), (12) "
+-- +   ") "
+-- + "INSERT INTO foo(id) "
+-- +   "SELECT id "
+-- +     "FROM names "
+-- +     "WHERE 1 "
 -- + "ON CONFLICT (id) DO UPDATE "
--- + "SET id = 10 "
--- +   "WHERE id <> 10");
+-- +   "SET id = 10 "
+-- +     "WHERE id <> 10");
 create proc with_upsert_form()
 BEGIN
  with names(id) as (values (1), (5), (3), (12))
@@ -2489,8 +2510,9 @@ BEGIN
 END;
 
 -- TEST: codegen upsert statement with do nothing
--- + "INSERT INTO foo(id) VALUES(?) "
--- + "ON CONFLICT DO NOTHING"
+-- + "INSERT INTO foo(id) "
+-- +   "VALUES(?) "
+-- +  "ON CONFLICT DO NOTHING");
 -- + cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_) {
 create proc upsert_do_nothing(id_ integer not null)
 BEGIN
@@ -2501,9 +2523,11 @@ END;
 -- + _seed_ = 1337;
 -- + _rc_ = cql_exec(_db_,
 -- + "WITH "
--- + "some_cte (id) AS (SELECT 1 AS id) "
+-- +   "some_cte (id) AS ( "
+-- +     "SELECT 1 AS id "
+-- +   ") "
 -- + "INSERT INTO bar(id) VALUES(ifnull(( SELECT id "
--- + "FROM some_cte ), 0))");
+-- +   "FROM some_cte ), 0))");
 -- + if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 with some_cte(id) as (select 1 id)
 insert into bar(id)
@@ -2831,14 +2855,16 @@ end;
 -- in particular the newline would get messed up because we thought
 -- it was a line break in non-quoted SQL which can be replaced with a space
 -- note the newline is escaped and present
--- + "INSERT INTO bar(id, name) VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
+-- + "INSERT INTO bar(id, name) "
+-- +   "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
 create proc pretty_print_with_quote()
 begin
   insert into bar(id, name) values(1, "it's high noon\r\n\f\b\t\v");
 end;
 
 -- TEST: string literal with hex forms
--- + "INSERT INTO bar(id, name) VALUES(1, '\x01\x02\xa1\x1bg')");
+-- + "INSERT INTO bar(id, name) "
+-- +   "VALUES(1, '\x01\x02\xa1\x1bg')");
 create proc hex_quote()
 begin
   insert into bar(id, name) values(1, "\x01\x02\xA1\x1b\x00\xg");
@@ -3767,13 +3793,14 @@ end;
 
 -- TEST: insert into the table, verify autoexpand is correct there, too
 -- only "y" should be inserted here
--- + _rc_ = cql_exec(_db_,
--- + "INSERT INTO virtual_with_hidden(vy) VALUES(1)");
+-- + "INSERT INTO virtual_with_hidden(vy) "
+-- +   "VALUES(1)");
 insert into virtual_with_hidden values(1);
 
 -- TEST: you can use the hidden column if you do it by name
 -- + _rc_ = cql_exec(_db_,
--- + "INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2)");
+-- + "INSERT INTO virtual_with_hidden(vx, vy) "
+-- +    "VALUES(1, 2)");
 insert into virtual_with_hidden(vx, vy) values(1,2);
 
 -- TEST: get row from the bar table or else -1
@@ -4801,8 +4828,10 @@ end;
 --
 -- root fragment 0 always present
 -- + "WITH "
--- +   "some_cte (id) AS (SELECT ?), "
--- +   "shared_conditional (x) AS (",
+-- +    "some_cte (id) AS ( "
+-- +      "SELECT ? "
+-- +    "), "
+-- +    "shared_conditional (x) AS (",
 --
 -- option 1 fragment 1
 -- + "SELECT ?",
@@ -4935,7 +4964,7 @@ end;
 -- +  "(",
 --
 -- fragment 2 present if x <= 5
--- +  "WITH "
+-- +  "  WITH "
 -- +    "shared_conditional (x) AS (",
 --
 -- fragment 3 present if x == 1
@@ -5355,7 +5384,13 @@ create table backed2(
 );
 
 -- TEST: cql_blob_get should expand to the correct calls and hash codes
--- + "SELECT bgetkey(k, 0), bgetval(v, 1055660242183705531), bgetval(v, -7635294210585028660), bgetval(v, -9155171551243524439), bgetval(v, -6946718245010482247), bgetval(v, -3683705396192132539) "
+-- + SELECT
+-- + bgetkey(k, 0),
+-- + bgetval(v, 1055660242183705531),
+-- + bgetval(v, -7635294210585028660),
+-- + bgetval(v, -9155171551243524439),
+-- + bgetval(v, -6946718245010482247),
+-- + bgetval(v, -3683705396192132539)
 create proc use_cql_blob_get_backed()
 begin
   declare C cursor for select
@@ -5368,7 +5403,12 @@ begin
 end;
 
 -- TEST: cql_blob_get should expand to the correct calls and hash codes
--- + "SELECT bgetkey(k, 1), bgetkey(k, 0), bgetval(v, -9155171551243524439), bgetval(v, 4605090824299507084), bgetval(v, -6946718245010482247) "
+-- + SELECT
+-- + bgetkey(k, 1),
+-- + bgetkey(k, 0),
+-- + bgetval(v, -9155171551243524439),
+-- + bgetval(v, 4605090824299507084),
+-- + bgetval(v, -6946718245010482247)
 create proc use_cql_blob_get_backed2()
 begin
   declare C cursor for select
@@ -5454,8 +5494,12 @@ begin
 end;
 
 -- TEST: we swap in the shared fragment and get the columns from it
--- + one (x) AS (SELECT 1),
--- + two (x) AS (SELECT 2)
+-- + one (x) AS (
+-- + SELECT 1
+-- + ),
+-- + two (x) AS (
+-- + SELECT 2
+-- + )
 -- + backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
 -- + SELECT rowid,
 -- + bgetkey(T.k, 0)
@@ -5477,8 +5521,12 @@ begin
 end;
 
 -- TEST: we swap in the shared fragment and get the columns from it
--- + one (x) AS (SELECT 1),
--- + two (x) AS (SELECT 2)
+-- + one (x) AS (
+-- + SELECT 1
+-- + ),
+-- + two (x) AS (
+-- + SELECT 2
+-- + )
 -- + backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
 -- + SELECT rowid
 -- + bgetkey(T.k, 0)
@@ -5502,13 +5550,14 @@ end;
 
 -- TEST: select expression with backed table
 -- + backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
--- + SELECT rowid
--- + bgetkey(T.k, 0)
+-- + SELECT
+-- + rowid,
 -- + bgetval(T.v, 1055660242183705531),
 -- + bgetval(T.v, -9155171551243524439),
 -- + bgetval(T.v, -6946718245010482247),
 -- + bgetval(T.v, -3683705396192132539),
--- + bgetval(T.v, -7635294210585028660
+-- + bgetval(T.v, -7635294210585028660),
+-- + bgetkey(T.k, 0)
 -- + FROM backing AS T
 -- + SELECT flag
 -- + FROM backed
@@ -5545,7 +5594,14 @@ end;
 @blob_get_val bgetval offset;
 
 -- TEST: we should get value indexes 0, 1, 2, 3, 4 not hashes
--- + SELECT rowid, bgetval(T.v, 0), bgetval(T.v, 1), bgetval(T.v, 2), bgetval(T.v, 3), bgetval(T.v, 4), bgetkey(T.k, 0)
+-- + SELECT
+-- + rowid,
+-- + bgetval(T.v, 0),
+-- + bgetval(T.v, 1),
+-- + bgetval(T.v, 2),
+-- + bgetval(T.v, 3),
+-- + bgetval(T.v, 4),
+-- + bgetkey(T.k, 0)
 create proc use_backed_table_select_expr_value_offsets(out x bool not null)
 begin
   set x := (select flag from backed);
@@ -5562,8 +5618,11 @@ create table small_backed(
 );
 
 -- TEST: simple insert with values
--- + _vals (pk, x, y) AS (VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7))
--- + INSERT INTO backing(k, v) SELECT
+-- + _vals (pk, x, y) AS (
+-- + VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7)
+-- + )
+-- + INSERT INTO backing(k, v)
+-- + SELECT
 -- + bcreatekey(-4190907309554122430, V.pk, 1),
 -- + bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3)
 -- + FROM _vals AS V
@@ -5573,11 +5632,18 @@ begin
 end;
 
 -- TEST: simple with-insert using values
--- + U (x, y, z) AS (VALUES(1, '2', 3.14))
--- + V (x, y, z) AS (VALUES(1, '2', 3.14))
--- + _vals (pk, x, y) AS (SELECT x, y, z
--- + FROM V)
--- + INSERT INTO backing(k, v) SELECT
+-- + U (x, y, z) AS (
+-- + VALUES(1, '2', 3.14)
+-- + )
+-- + V (x, y, z) AS (
+-- + VALUES(1, '2', 3.14)
+-- + )
+-- + _vals (pk, x, y) AS (
+-- + SELECT x, y, z
+-- + FROM V
+-- + )
+-- + INSERT INTO backing(k, v)
+-- + SELECT
 -- + bcreatekey(-4190907309554122430, V.pk, 1)
 -- + bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
 -- + FROM _vals AS V
@@ -5590,8 +5656,11 @@ begin
 end;
 
 -- TEST: simple insert using form
--- + _vals (pk, x, y) AS (VALUES(1, '2', 3.14))
--- + INSERT INTO backing(k, v) SELECT
+-- + _vals (pk, x, y) AS (
+-- + VALUES(1, '2', 3.14)
+-- + )
+-- + INSERT INTO backing(k, v)
+-- + SELECT
 -- + bcreatekey(-4190907309554122430, V.pk, 1)
 -- + bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3)
 -- + FROM _vals AS V
@@ -5602,12 +5671,19 @@ end;
 
 -- TEST: insert from a select
 -- + small_backed (rowid, pk, x, y) AS (
--- + SELECT rowid, bgetkey(T.k, 0) AS pk, bgetval(T.v, 7953209610392031882) AS x, bgetval(T.v, 3032304244189539277) AS y
+-- + SELECT
+-- + rowid,
+-- + bgetkey(T.k, 0) AS pk,
+-- + bgetval(T.v, 7953209610392031882) AS x,
+-- + bgetval(T.v, 3032304244189539277) AS y
 -- + FROM backing AS T
 -- + WHERE bgetkey_type(T.k) = -4190907309554122430
--- + _vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50
--- + FROM small_backed AS B)
--- + INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3)
+-- + _vals (pk, x, y) AS (
+-- + SELECT pk + 1000, B.x || 'x', B.y + 50
+-- + FROM small_backed AS B
+-- + )
+-- + INSERT INTO backing(k, v)
+-- + SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3)
 -- + bcreatekey(-4190907309554122430, V.pk, 1)
 -- + bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
 -- + FROM _vals AS V
@@ -5630,7 +5706,9 @@ end;
 -- + small_backed (rowid, pk, x, y)
 -- + DELETE FROM backing WHERE rowid IN (SELECT rowid
 -- + FROM small_backed)
--- + v (x) AS (VALUES(1)
+-- + v (x) AS (
+-- +  VALUES(1
+-- + )
 create proc delete_from_backed_no_where_clause()
 begin
   with v(x) as (values(1)) -- force the with select form
@@ -5660,7 +5738,9 @@ begin
 end;
 
 -- TEST: simple update into backed table value only, using with clause
--- + V (x) AS (VALUES(1))
+-- + V (x) AS (
+-- +   VALUES(1)
+-- + )
 -- + UPDATE backing
 -- + SET v = bupdateval(v, -6946718245010482247, 'goo', 4)
 -- + WHERE rowid IN (SELECT rowid

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -2856,7 +2856,8 @@ end;
 -- it was a line break in non-quoted SQL which can be replaced with a space
 -- note the newline is escaped and present
 -- + "INSERT INTO bar(id, name) "
--- +   "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
+-- note that the newline has no extra spaces after it even though we are indenting
+-- +   "VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
 create proc pretty_print_with_quote()
 begin
   insert into bar(id, name) values(1, "it's high noon\r\n\f\b\t\v");

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -1357,13 +1357,15 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC easy_fetch ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   FETCH C;
   CALL printf("%d %s\n", C.id, C.name);
-  DECLARE C2 CURSOR FOR SELECT *
-    FROM bar
-    WHERE C AND id = C.id;
+  DECLARE C2 CURSOR FOR
+    SELECT *
+      FROM bar
+      WHERE C AND id = C.id;
 END;
 */
 
@@ -1524,7 +1526,8 @@ DECLARE PROC xyzzy (id INTEGER) (A INTEGER NOT NULL);
 /*
 CREATE PROC xyzzy_test ()
 BEGIN
-  DECLARE xyzzy_cursor CURSOR FOR CALL xyzzy(1);
+  DECLARE xyzzy_cursor CURSOR FOR
+    CALL xyzzy(1);
 END;
 */
 
@@ -1562,7 +1565,13 @@ DECLARE PROC plugh (id INTEGER);
 /*
 CREATE PROC complex_return ()
 BEGIN
-  SELECT TRUE AS _bool, 2 AS _integer, CAST(3 AS LONG_INT) AS _longint, 3.0 AS _real, 'xyz' AS _text, CAST(NULL AS BOOL) AS _nullable_bool;
+  SELECT 
+      TRUE AS _bool,
+      2 AS _integer,
+      CAST(3 AS LONG_INT) AS _longint,
+      3.0 AS _real,
+      'xyz' AS _text,
+      CAST(NULL AS BOOL) AS _nullable_bool;
 END;
 */
 
@@ -1669,7 +1678,13 @@ CQL_WARN_UNUSED cql_code complex_return(sqlite3 *_Nonnull _db_, sqlite3_stmt *_N
   cql_error_prepare();
 
   _rc_ = cql_prepare(_db_, _result_stmt,
-    "SELECT 1, 2, CAST(3 AS LONG_INT), 3.0, 'xyz', NULL");
+    "SELECT  "
+        "1, "
+        "2, "
+        "CAST(3 AS LONG_INT), "
+        "3.0, "
+        "'xyz', "
+        "NULL");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -2113,10 +2128,13 @@ cql_cleanup:
 /*
 CREATE PROC with_stmt_using_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
-  SELECT *
-    FROM X;
+  DECLARE C CURSOR FOR
+    WITH
+      X (a, b, c) AS (
+        SELECT 1, 2, 3
+      )
+    SELECT *
+      FROM X;
   FETCH C;
 END;
 */
@@ -2143,7 +2161,9 @@ CQL_WARN_UNUSED cql_code with_stmt_using_cursor(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_prepare(_db_, &C_stmt,
     "WITH "
-    "X (a, b, c) AS (SELECT 1, 2, 3) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2169,7 +2189,9 @@ cql_cleanup:
 CREATE PROC with_stmt ()
 BEGIN
   WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+    )
   SELECT *
     FROM X;
 END;
@@ -2246,7 +2268,9 @@ CQL_WARN_UNUSED cql_code with_stmt(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullab
 
   _rc_ = cql_prepare(_db_, _result_stmt,
     "WITH "
-    "X (a, b, c) AS (SELECT 1, 2, 3) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2265,9 +2289,11 @@ cql_cleanup:
 CREATE PROC with_recursive_stmt ()
 BEGIN
   WITH RECURSIVE
-  X (a, b, c) AS (SELECT 1, 2, 3
-  UNION ALL
-  SELECT 4, 5, 6)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+      UNION ALL
+      SELECT 4, 5, 6
+    )
   SELECT *
     FROM X;
 END;
@@ -2344,9 +2370,11 @@ CQL_WARN_UNUSED cql_code with_recursive_stmt(sqlite3 *_Nonnull _db_, sqlite3_stm
 
   _rc_ = cql_prepare(_db_, _result_stmt,
     "WITH RECURSIVE "
-    "X (a, b, c) AS (SELECT 1, 2, 3 "
-    "UNION ALL "
-    "SELECT 4, 5, 6) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+        "UNION ALL "
+        "SELECT 4, 5, 6 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2544,7 +2572,8 @@ cql_cleanup:
 /*
 CREATE PROC outint_nullable (OUT output INTEGER, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -2589,7 +2618,8 @@ cql_cleanup:
 /*
 CREATE PROC outint_notnull (OUT output INTEGER NOT NULL, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -2832,7 +2862,8 @@ void echo_test(void) {
 /*
 CREATE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER)
 BEGIN
-  INSERT INTO bar(id, type) VALUES(id_, type_);
+  INSERT INTO bar(id, type)
+    VALUES(id_, type_);
 END;
 */
 
@@ -2847,7 +2878,8 @@ CQL_WARN_UNUSED cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cq
   sqlite3_stmt *_temp_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO bar(id, type) VALUES(?, ?)");
+    "INSERT INTO bar(id, type) "
+      "VALUES(?, ?)");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_,
                 CQL_DATA_TYPE_INT32, &type_);
@@ -3085,11 +3117,13 @@ cql_cleanup:
 /*
 CREATE PROC misc_dml_proc ()
 BEGIN
-  INSERT INTO foo(id) VALUES(NULL);
-  INSERT INTO foo(id) VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
   UPDATE bar
-  SET name = 'bar'
-    WHERE name = 'baz';
+    SET name = 'bar'
+      WHERE name = 'baz';
   DELETE FROM foo WHERE id = 1;
 END;
 */
@@ -3104,15 +3138,17 @@ CQL_WARN_UNUSED cql_code misc_dml_proc(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) VALUES(NULL)");
+    "INSERT INTO foo(id) "
+      "VALUES(NULL)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) VALUES(NULL)");
+    "INSERT INTO foo(id) "
+      "VALUES(NULL)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
     "UPDATE bar "
-    "SET name = 'bar' "
-      "WHERE name = 'baz'");
+      "SET name = 'bar' "
+        "WHERE name = 'baz'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
     "DELETE FROM foo WHERE id = 1");
@@ -3389,8 +3425,9 @@ void voidproc(void) {
 /*
 CREATE PROC out_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
+      FROM bar;
   FETCH C;
   OUT C;
 END;
@@ -3713,7 +3750,7 @@ CREATE PROC thread_theme_info_list (thread_key_ LONG_INT NOT NULL)
 BEGIN
   SELECT *
     FROM (SELECT thread_key
-    FROM threads) AS T;
+        FROM threads) AS T;
 END;
 */
 
@@ -3773,7 +3810,7 @@ CQL_WARN_UNUSED cql_code thread_theme_info_list(sqlite3 *_Nonnull _db_, sqlite3_
   _rc_ = cql_prepare(_db_, _result_stmt,
     "SELECT thread_key "
       "FROM (SELECT thread_key "
-      "FROM threads) AS T");
+          "FROM threads) AS T");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -3930,7 +3967,8 @@ void c_literal(cql_string_ref _Nullable *_Nonnull x) {
 CREATE PROC no_cleanup_label_needed_proc ()
 BEGIN
   BEGIN TRY
-    DECLARE C CURSOR FOR SELECT 1 AS N;
+    DECLARE C CURSOR FOR
+      SELECT 1 AS N;
     FETCH C;
   END TRY;
   BEGIN CATCH
@@ -4686,9 +4724,12 @@ void blob_no_else(void) {
 CREATE PROC with_inserter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) SELECT *
-    FROM x;
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    SELECT *
+      FROM x;
 END;
 */
 
@@ -4703,9 +4744,12 @@ CQL_WARN_UNUSED cql_code with_inserter(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
-    "INSERT INTO foo(id) SELECT a "
-      "FROM x");
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
+    "INSERT INTO foo(id) "
+      "SELECT a "
+        "FROM x");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -4873,7 +4917,8 @@ void fetch_to_cursor_from_cursor(fetch_to_cursor_from_cursor_row *_Nonnull _resu
 /*
 CREATE PROC loop_statement_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.A);
@@ -4925,7 +4970,8 @@ cql_cleanup:
 /*
 CREATE PROC loop_statement_not_auto_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   DECLARE A_ INTEGER NOT NULL;
   LOOP FETCH C INTO A_
   BEGIN
@@ -5009,7 +5055,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -5066,7 +5113,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -5125,7 +5173,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     DECLARE box OBJECT<C CURSOR>;
     SET box FROM CURSOR C;
     DECLARE D CURSOR FOR box;
@@ -5259,7 +5308,8 @@ void out_union_helper_fetch_results(out_union_helper_result_set_ref _Nullable *_
 /*
 CREATE PROC out_union_dml_helper ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   OUT UNION C;
 END;
@@ -5348,7 +5398,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL out_union_helper();
+    DECLARE C CURSOR FOR
+      CALL out_union_helper();
     FETCH C;
   END;
 END;
@@ -5986,7 +6037,8 @@ cql_cleanup:
 @ATTRIBUTE(cql:identity=(id))
 CREATE PROC out_cursor_identity ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 2 AS data;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 2 AS data;
   FETCH C;
   OUT C;
 END;
@@ -6183,7 +6235,9 @@ cql_cleanup:
 CREATE PROC with_deleter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   DELETE FROM foo WHERE id IN (SELECT *
     FROM x);
 END;
@@ -6200,7 +6254,9 @@ CQL_WARN_UNUSED cql_code with_deleter(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
     "DELETE FROM foo WHERE id IN (SELECT a "
       "FROM x)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -6218,11 +6274,13 @@ cql_cleanup:
 CREATE PROC with_updater ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   UPDATE bar
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 */
 
@@ -6237,11 +6295,13 @@ CQL_WARN_UNUSED cql_code with_updater(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
     "UPDATE bar "
-    "SET name = 'xyzzy' "
-      "WHERE id IN (SELECT a "
-      "FROM x)");
+      "SET name = 'xyzzy' "
+        "WHERE id IN (SELECT a "
+        "FROM x)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6530,12 +6590,13 @@ cql_cleanup:
 /*
 CREATE PROC settings_info ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
-    FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
-    FROM unread_pending_threads AS P
-  UNION ALL
-  SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
-    FROM switch_account_badges AS S) AS A;
+  DECLARE C CURSOR FOR
+    SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
+      FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
+          FROM unread_pending_threads AS P
+        UNION ALL
+        SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
+          FROM switch_account_badges AS S) AS A;
 END;
 */
 
@@ -6552,10 +6613,10 @@ CQL_WARN_UNUSED cql_code settings_info(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_prepare(_db_, &C_stmt,
     "SELECT SUM(A.unread_pending_thread_count), SUM(A.switch_account_badge_count) "
       "FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count "
-      "FROM unread_pending_threads AS P "
-    "UNION ALL "
-    "SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count "
-      "FROM switch_account_badges AS S) AS A");
+          "FROM unread_pending_threads AS P "
+        "UNION ALL "
+        "SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count "
+          "FROM switch_account_badges AS S) AS A");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6750,8 +6811,10 @@ cql_cleanup:
 CREATE PROC use_with_select ()
 BEGIN
   DECLARE x INTEGER;
-  SET x := ( WITH
-  threads2 (count) AS (SELECT 1 AS foo)
+  SET x := (   WITH
+    threads2 (count) AS (
+      SELECT 1 AS foo
+    )
   SELECT COUNT(*)
     FROM threads2 );
 END;
@@ -6771,7 +6834,9 @@ CQL_WARN_UNUSED cql_code use_with_select(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "WITH "
-    "threads2 (count) AS (SELECT 1) "
+      "threads2 (count) AS ( "
+        "SELECT 1 "
+      ") "
     "SELECT COUNT(*) "
       "FROM threads2");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -6794,8 +6859,9 @@ cql_cleanup:
 /*
 CREATE PROC rowset_object_reader (rowset OBJECT<rowset>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM ReadFromRowset(rowset);
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM ReadFromRowset(rowset);
 END;
 */
 
@@ -6829,12 +6895,13 @@ cql_cleanup:
 /*
 CREATE PROC upsert_do_something ()
 BEGIN
-  INSERT INTO foo(id) SELECT id
-    FROM bar
-    WHERE 1
+  INSERT INTO foo(id)
+    SELECT id
+      FROM bar
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 */
 
@@ -6848,12 +6915,13 @@ CQL_WARN_UNUSED cql_code upsert_do_something(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) SELECT id "
-      "FROM bar "
-      "WHERE 1 "
+    "INSERT INTO foo(id) "
+      "SELECT id "
+        "FROM bar "
+        "WHERE 1 "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10 "
-      "WHERE id <> 10");
+      "SET id = 10 "
+        "WHERE id <> 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6869,13 +6937,16 @@ cql_cleanup:
 CREATE PROC with_upsert_form ()
 BEGIN
   WITH
-  names (id) AS (VALUES(1), (5), (3), (12))
-  INSERT INTO foo(id) SELECT id
-    FROM names
-    WHERE 1
+    names (id) AS (
+      VALUES(1), (5), (3), (12)
+    )
+  INSERT INTO foo(id)
+    SELECT id
+      FROM names
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 */
 
@@ -6890,13 +6961,16 @@ CQL_WARN_UNUSED cql_code with_upsert_form(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "names (id) AS (VALUES(1), (5), (3), (12)) "
-    "INSERT INTO foo(id) SELECT id "
-      "FROM names "
-      "WHERE 1 "
+      "names (id) AS ( "
+        "VALUES(1), (5), (3), (12) "
+      ") "
+    "INSERT INTO foo(id) "
+      "SELECT id "
+        "FROM names "
+        "WHERE 1 "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10 "
-      "WHERE id <> 10");
+      "SET id = 10 "
+        "WHERE id <> 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6911,7 +6985,8 @@ cql_cleanup:
 /*
 CREATE PROC upsert_do_nothing (id_ INTEGER NOT NULL)
 BEGIN
-  INSERT INTO foo(id) VALUES(id_)
+  INSERT INTO foo(id)
+    VALUES(id_)
   ON CONFLICT DO NOTHING;
 END;
 */
@@ -6927,7 +7002,8 @@ CQL_WARN_UNUSED cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_
   sqlite3_stmt *_temp_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO foo(id) VALUES(?) "
+    "INSERT INTO foo(id) "
+      "VALUES(?) "
     "ON CONFLICT DO NOTHING");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_);
@@ -7171,7 +7247,8 @@ void out_union_two_fetch_results(out_union_two_result_set_ref _Nullable *_Nonnul
 /*
 CREATE PROC out_union_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_two();
+  DECLARE c CURSOR FOR
+    CALL out_union_two();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -7230,7 +7307,8 @@ CQL_WARN_UNUSED cql_code out_union_reader(sqlite3 *_Nonnull _db_) {
 /*
 CREATE PROC out_union_from_select ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x, '2' AS y;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x, '2' AS y;
   FETCH C;
   OUT UNION C;
   OUT UNION C;
@@ -7335,7 +7413,8 @@ cql_cleanup:
 /*
 CREATE PROC out_union_dml_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_from_select();
+  DECLARE c CURSOR FOR
+    CALL out_union_from_select();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -7473,7 +7552,8 @@ void out_union_values_fetch_results(out_union_values_result_set_ref _Nullable *_
 /*
 CREATE PROC read_out_union_values (a INTEGER NOT NULL, b INTEGER NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_values(a, b);
+  DECLARE C CURSOR FOR
+    CALL out_union_values(a, b);
   FETCH C;
 END;
 */
@@ -7521,8 +7601,9 @@ CQL_WARN_UNUSED cql_code read_out_union_values(sqlite3 *_Nonnull _db_, cql_int32
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml ()
 BEGIN
-  DECLARE x CURSOR FOR SELECT *
-    FROM radioactive;
+  DECLARE x CURSOR FOR
+    SELECT *
+      FROM radioactive;
   FETCH x;
   OUT UNION x;
 END;
@@ -7630,7 +7711,8 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml_for_call ()
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_dml();
+  DECLARE C CURSOR FOR
+    CALL out_union_dml();
   FETCH C;
 END;
 */
@@ -8009,7 +8091,8 @@ BEGIN
   WHILE 1
   BEGIN
   END;
-  DECLARE c CURSOR FOR SELECT 1 AS x;
+  DECLARE c CURSOR FOR
+    SELECT 1 AS x;
   LOOP FETCH c
   BEGIN
   END;
@@ -8133,7 +8216,8 @@ CQL_WARN_UNUSED cql_code tail_catch(sqlite3 *_Nonnull _db_) {
 /*
 CREATE PROC pretty_print_with_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "it's high noon\r\n\f\b\t\v");
+  INSERT INTO bar(id, name)
+    VALUES(1, "it's high noon\r\n\f\b\t\v");
 END;
 */
 
@@ -8147,7 +8231,8 @@ CQL_WARN_UNUSED cql_code pretty_print_with_quote(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO bar(id, name) VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
+    "INSERT INTO bar(id, name) "
+      "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -8162,7 +8247,8 @@ cql_cleanup:
 /*
 CREATE PROC hex_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "\x01\x02\xa1\x1bg");
+  INSERT INTO bar(id, name)
+    VALUES(1, "\x01\x02\xa1\x1bg");
 END;
 */
 
@@ -8176,7 +8262,8 @@ CQL_WARN_UNUSED cql_code hex_quote(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO bar(id, name) VALUES(1, '\x01\x02\xa1\x1bg')");
+    "INSERT INTO bar(id, name) "
+      "VALUES(1, '\x01\x02\xa1\x1bg')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -9016,7 +9103,8 @@ cql_cleanup:
 /*
 CREATE PROC early_out_rc_cleared (OUT x INTEGER)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   IF C THEN
     RETURN;
@@ -9701,8 +9789,9 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC vault_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT name
-    FROM vault_mixed_sensitive;
+  DECLARE C CURSOR FOR
+    SELECT name
+      FROM vault_mixed_sensitive;
   FETCH c;
 END;
 */
@@ -10093,8 +10182,9 @@ cql_cleanup:
 /*
 CREATE PROC try_boxing (OUT result OBJECT<bar CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET result FROM CURSOR C;
 END;
 */
@@ -13119,7 +13209,8 @@ void c_proc_with_alt_prefix(cql_nullable_int32 *_Nonnull x) {
 /*
 CREATE PROC use_private_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL private_out_union();
+  DECLARE C CURSOR FOR
+    CALL private_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13235,7 +13326,8 @@ void no_getters_out_union_fetch_results(no_getters_out_union_result_set_ref _Nul
 /*
 CREATE PROC use_no_getters_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL no_getters_out_union();
+  DECLARE C CURSOR FOR
+    CALL no_getters_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13351,7 +13443,8 @@ void suppress_results_out_union_fetch_results(suppress_results_out_union_result_
 /*
 CREATE PROC use_suppress_results_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL suppress_results_out_union();
+  DECLARE C CURSOR FOR
+    CALL suppress_results_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13595,8 +13688,9 @@ void various_lets(void) {
 /*
 CREATE PROC try_catch_rc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 'foo' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT 'foo' AS extra2
+      FROM bar;
   BEGIN TRY
     FETCH C;
   END TRY;
@@ -14423,8 +14517,9 @@ cql_bool false_test = 0;
 /*
 CREATE PROC BigFormat ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM big_data;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM big_data;
   LOOP FETCH C
   BEGIN
     LET s := cql_cursor_format(C);
@@ -15374,7 +15469,7 @@ END;
 CREATE PROC foo ()
 BEGIN
   WITH
-  shared_frag (shared_something) AS (CALL shared_frag())
+    shared_frag (shared_something) AS (CALL shared_frag())
   SELECT *
     FROM shared_frag;
 END;
@@ -15436,7 +15531,7 @@ CQL_WARN_UNUSED cql_code foo(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_N
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "shared_frag (shared_something) AS (",
+      "shared_frag (shared_something) AS (",
   "SELECT 1234",
   ") "
     "SELECT shared_something "
@@ -15474,8 +15569,10 @@ END;
 CREATE PROC shared_conditional_user (x INTEGER NOT NULL)
 BEGIN
   WITH
-  some_cte (id) AS (SELECT x),
-  shared_conditional (x) AS (CALL shared_conditional(1))
+    some_cte (id) AS (
+      SELECT x
+    ),
+    shared_conditional (x) AS (CALL shared_conditional(1))
   SELECT bar.*
     FROM bar
     INNER JOIN some_cte ON x = 5;
@@ -15616,8 +15713,10 @@ CQL_WARN_UNUSED cql_code shared_conditional_user(sqlite3 *_Nonnull _db_, sqlite3
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     5, _preds_1,
   "WITH "
-    "some_cte (id) AS (SELECT ?), "
-    "shared_conditional (x) AS (",
+      "some_cte (id) AS ( "
+        "SELECT ? "
+      "), "
+      "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
@@ -15653,7 +15752,7 @@ CREATE PROC nested_shared_proc (x_ INTEGER NOT NULL)
 BEGIN
   IF x_ <= 5 THEN
     WITH
-    shared_conditional (x) AS (CALL shared_conditional(1))
+      shared_conditional (x) AS (CALL shared_conditional(1))
     SELECT *
       FROM shared_conditional
       WHERE x_ = 5;
@@ -15669,7 +15768,7 @@ END;
 CREATE PROC nested_shared_stuff ()
 BEGIN
   WITH
-  nested_shared_proc (x) AS (CALL nested_shared_proc(1))
+    nested_shared_proc (x) AS (CALL nested_shared_proc(1))
   SELECT *
     FROM nested_shared_proc;
 END;
@@ -15767,16 +15866,16 @@ CQL_WARN_UNUSED cql_code nested_shared_stuff(sqlite3 *_Nonnull _db_, sqlite3_stm
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     8, _preds_1,
   "WITH "
-    "nested_shared_proc (x) AS (",
-  "WITH "
-    "shared_conditional (x) AS (",
+      "nested_shared_proc (x) AS (",
+  "  WITH "
+        "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
   ") "
-    "SELECT x "
-      "FROM shared_conditional "
-      "WHERE ? = 5",
+      "SELECT x "
+        "FROM shared_conditional "
+        "WHERE ? = 5",
   "SELECT ?",
   ") "
     "SELECT x "
@@ -15907,15 +16006,15 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   "SELECT x "
       "FROM (",
   "(",
-  "WITH "
-    "shared_conditional (x) AS (",
+  "  WITH "
+        "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
   ") "
-    "SELECT x "
-      "FROM shared_conditional "
-      "WHERE ? = 5",
+      "SELECT x "
+        "FROM shared_conditional "
+        "WHERE ? = 5",
   "SELECT ? AS x",
   ")",
   ")"
@@ -15999,7 +16098,7 @@ END;
 CREATE PROC shared_frag_else_nothing_test ()
 BEGIN
   WITH
-  shared_frag_else_nothing (id1, text1) AS (CALL shared_frag_else_nothing(5))
+    shared_frag_else_nothing (id1, text1) AS (CALL shared_frag_else_nothing(5))
   SELECT *
     FROM foo;
 END;
@@ -16078,7 +16177,7 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, s
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     4, _preds_1,
   "WITH "
-    "shared_frag_else_nothing (id1, text1) AS (",
+      "shared_frag_else_nothing (id1, text1) AS (",
   "SELECT ?, 'x'",
   "SELECT 0,0 WHERE 0",
   ") "
@@ -16246,7 +16345,8 @@ void slash_star_and_star_slash(void) {
 /*
 CREATE PROC blob_serialization_test ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'foo' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'foo' AS name;
   FETCH C;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
@@ -16570,7 +16670,8 @@ DECLARE PROC some_redeclared_out_proc () OUT (x INTEGER) USING TRANSACTION;
 /*
 CREATE PROC some_redeclared_out_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT c;
 END;
@@ -16675,7 +16776,8 @@ DECLARE PROC some_redeclared_out_union_proc () OUT UNION (x INTEGER) USING TRANS
 /*
 CREATE PROC some_redeclared_out_union_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT UNION c;
 END;
@@ -16908,7 +17010,8 @@ void mutated_in_arg2(cql_string_ref _Nullable _in__x) {
 /*
 CREATE PROC mutated_in_arg3 (x TEXT)
 BEGIN
-  DECLARE C CURSOR FOR SELECT "x" AS x;
+  DECLARE C CURSOR FOR
+    SELECT "x" AS x;
   FETCH C INTO x;
 END;
 */
@@ -17322,8 +17425,15 @@ cql_cleanup:
 /*
 CREATE PROC use_cql_blob_get_backed ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT cql_blob_get(k, backed.pk), cql_blob_get(v, backed.flag), cql_blob_get(v, backed.storage), cql_blob_get(v, backed.id), cql_blob_get(v, backed.name), cql_blob_get(v, backed.age)
-    FROM backing;
+  DECLARE C CURSOR FOR
+    SELECT 
+        cql_blob_get(k, backed.pk),
+        cql_blob_get(v, backed.flag),
+        cql_blob_get(v, backed.storage),
+        cql_blob_get(v, backed.id),
+        cql_blob_get(v, backed.name),
+        cql_blob_get(v, backed.age)
+      FROM backing;
 END;
 */
 
@@ -17338,7 +17448,13 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT bgetkey(k, 0), bgetval(v, 1055660242183705531), bgetval(v, -7635294210585028660), bgetval(v, -9155171551243524439), bgetval(v, -6946718245010482247), bgetval(v, -3683705396192132539) "
+    "SELECT  "
+        "bgetkey(k, 0), "
+        "bgetval(v, 1055660242183705531), "
+        "bgetval(v, -7635294210585028660), "
+        "bgetval(v, -9155171551243524439), "
+        "bgetval(v, -6946718245010482247), "
+        "bgetval(v, -3683705396192132539) "
       "FROM backing");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17355,8 +17471,14 @@ cql_cleanup:
 /*
 CREATE PROC use_cql_blob_get_backed2 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT cql_blob_get(k, backed2.pk1), cql_blob_get(k, backed2.pk2), cql_blob_get(v, backed2.id), cql_blob_get(v, backed2.extra), cql_blob_get(v, backed2.name)
-    FROM backing;
+  DECLARE C CURSOR FOR
+    SELECT 
+        cql_blob_get(k, backed2.pk1),
+        cql_blob_get(k, backed2.pk2),
+        cql_blob_get(v, backed2.id),
+        cql_blob_get(v, backed2.extra),
+        cql_blob_get(v, backed2.name)
+      FROM backing;
 END;
 */
 
@@ -17371,7 +17493,12 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed2(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT bgetkey(k, 1), bgetkey(k, 0), bgetval(v, -9155171551243524439), bgetval(v, 4605090824299507084), bgetval(v, -6946718245010482247) "
+    "SELECT  "
+        "bgetkey(k, 1), "
+        "bgetkey(k, 0), "
+        "bgetval(v, -9155171551243524439), "
+        "bgetval(v, 4605090824299507084), "
+        "bgetval(v, -6946718245010482247) "
       "FROM backing");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17389,9 +17516,12 @@ cql_cleanup:
 CREATE PROC insert_into_backed2 ()
 BEGIN
   WITH
-  _vals (pk1, pk2, flag, id, name, extra) AS (VALUES(1, 2, TRUE, 1000, 'hi', 5))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(backed2, V.pk2, backed2.pk2, V.pk1, backed2.pk1), cql_blob_create(backed2, V.flag, backed2.flag, V.id, backed2.id, V.name, backed2.name, V.extra, backed2.extra)
-    FROM _vals AS V;
+    _vals (pk1, pk2, flag, id, name, extra) AS (
+      VALUES(1, 2, TRUE, 1000, 'hi', 5)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(backed2, V.pk2, backed2.pk2, V.pk1, backed2.pk1), cql_blob_create(backed2, V.flag, backed2.flag, V.id, backed2.id, V.name, backed2.name, V.extra, backed2.extra)
+      FROM _vals AS V;
 END;
 */
 
@@ -17406,9 +17536,12 @@ CQL_WARN_UNUSED cql_code insert_into_backed2(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk1, pk2, flag, id, name, extra) AS (VALUES(1, 2, 1, 1000, 'hi', 5)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(3942979045122214775, V.pk2, 1, V.pk1, 1), bcreateval(3942979045122214775, 1055660242183705531, V.flag, 0, -9155171551243524439, V.id, 2, -6946718245010482247, V.name, 4, 4605090824299507084, V.extra, 1) "
-      "FROM _vals AS V");
+      "_vals (pk1, pk2, flag, id, name, extra) AS ( "
+        "VALUES(1, 2, 1, 1000, 'hi', 5) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(3942979045122214775, V.pk2, 1, V.pk1, 1), bcreateval(3942979045122214775, 1055660242183705531, V.flag, 0, -9155171551243524439, V.id, 2, -6946718245010482247, V.name, 4, 4605090824299507084, V.extra, 1) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -17424,12 +17557,12 @@ cql_cleanup:
 CREATE PROC update_backed2 ()
 BEGIN
   WITH
-  backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (CALL _backed2())
+    backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (CALL _backed2())
   UPDATE backing
-  SET k = cql_blob_update(k, 5, backed2.pk1, 7, backed2.pk2)
-    WHERE rowid IN (SELECT rowid
-    FROM backed2
-    WHERE pk1 = 3 AND pk2 = 11);
+    SET k = cql_blob_update(k, 5, backed2.pk1, 7, backed2.pk2)
+      WHERE rowid IN (SELECT rowid
+      FROM backed2
+      WHERE pk1 = 3 AND pk2 = 11);
 END;
 */
 
@@ -17445,16 +17578,23 @@ CQL_WARN_UNUSED cql_code update_backed2(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
-  "SELECT rowid, bgetkey(T.k, 1), bgetkey(T.k, 0), bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, 4605090824299507084) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = 3942979045122214775",
+      "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 1), "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, 4605090824299507084) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = 3942979045122214775",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 1, 5, 0, 7) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed2 "
-      "WHERE pk1 = 3 AND pk2 = 11)"
+      "SET k = bupdatekey(k, 1, 5, 0, 7) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed2 "
+        "WHERE pk1 = 3 AND pk2 = 11)"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17471,7 +17611,7 @@ cql_cleanup:
 CREATE PROC use_generated_fragment ()
 BEGIN
   WITH
-  _backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    _backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM _backed;
 END;
@@ -17595,10 +17735,17 @@ CQL_WARN_UNUSED cql_code use_generated_fragment(sqlite3 *_Nonnull _db_, sqlite3_
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "_backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "_backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM _backed"
@@ -17619,7 +17766,7 @@ cql_cleanup:
 CREATE PROC use_backed_table_directly ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -17743,10 +17890,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly(sqlite3 *_Nonnull _db_, sqlit
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -17766,10 +17920,11 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_with_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
-  SELECT *
-    FROM backed;
+  DECLARE C CURSOR FOR
+    WITH
+      backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    SELECT *
+      FROM backed;
 END;
 */
 
@@ -17786,10 +17941,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_cursor(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_prepare_var(_db_, &C_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -17810,9 +17972,13 @@ cql_cleanup:
 CREATE PROC use_backed_table_directly_in_with_select ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  one (x) AS (SELECT 1 AS x),
-  two (x) AS (SELECT 2 AS x)
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+    one (x) AS (
+      SELECT 1 AS x
+    ),
+    two (x) AS (
+      SELECT 2 AS x
+    )
   SELECT *
     FROM backed;
 END;
@@ -17936,13 +18102,24 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select(sqlite3 *_Nonn
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "one (x) AS (SELECT 1), "
-    "two (x) AS (SELECT 2) "
+      "one (x) AS ( "
+        "SELECT 1 "
+      "), "
+      "two (x) AS ( "
+        "SELECT 2 "
+      ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
   );
@@ -17961,12 +18138,17 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_with_select_and_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  one (x) AS (SELECT 1 AS x),
-  two (x) AS (SELECT 2 AS x)
-  SELECT *
-    FROM backed;
+  DECLARE C CURSOR FOR
+    WITH
+      backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+      one (x) AS (
+        SELECT 1 AS x
+      ),
+      two (x) AS (
+        SELECT 2 AS x
+      )
+    SELECT *
+      FROM backed;
 END;
 */
 
@@ -17983,13 +18165,24 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_select_and_cursor(sqlite3 *_Nonnu
   _rc_ = cql_prepare_var(_db_, &C_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "one (x) AS (SELECT 1), "
-    "two (x) AS (SELECT 2) "
+      "one (x) AS ( "
+        "SELECT 1 "
+      "), "
+      "two (x) AS ( "
+        "SELECT 2 "
+      ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
   );
@@ -18008,8 +18201,8 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_select_expr (OUT x BOOL NOT NULL)
 BEGIN
-  SET x := ( WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+  SET x := (   WITH
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT flag
     FROM backed );
 END;
@@ -18031,10 +18224,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
   _rc_ = cql_prepare_var(_db_, &_temp_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT flag "
       "FROM backed"
@@ -18061,7 +18261,7 @@ CREATE PROC explain_query_plan_backed (OUT x BOOL NOT NULL)
 BEGIN
   EXPLAIN QUERY PLAN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -18082,10 +18282,17 @@ static CQL_WARN_UNUSED cql_code explain_query_plan_backed(sqlite3 *_Nonnull _db_
     3, NULL,
   "EXPLAIN QUERY PLAN "
     "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -18105,8 +18312,8 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_select_expr_value_offsets (OUT x BOOL NOT NULL)
 BEGIN
-  SET x := ( WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+  SET x := (   WITH
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT flag
     FROM backed );
 END;
@@ -18128,10 +18335,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
   _rc_ = cql_prepare_var(_db_, &_temp_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 0), bgetval(T.v, 1), bgetval(T.v, 2), bgetval(T.v, 3), bgetval(T.v, 4), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 0), "
+          "bgetval(T.v, 1), "
+          "bgetval(T.v, 2), "
+          "bgetval(T.v, 3), "
+          "bgetval(T.v, 4), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT flag "
       "FROM backed"
@@ -18156,9 +18370,12 @@ cql_cleanup:
 CREATE PROC insert_backed_values ()
 BEGIN
   WITH
-  _vals (pk, x, y) AS (VALUES(1, "2", 3.14), (4, "5", 6), (7, "8", 9.7))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    _vals (pk, x, y) AS (
+      VALUES(1, "2", 3.14), (4, "5", 6), (7, "8", 9.7)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18173,9 +18390,12 @@ CQL_WARN_UNUSED cql_code insert_backed_values(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk, x, y) AS (VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "_vals (pk, x, y) AS ( "
+        "VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18191,12 +18411,19 @@ cql_cleanup:
 CREATE PROC insert_backed_values_using_with ()
 BEGIN
   WITH
-  U (x, y, z) AS (VALUES(1, "2", 3.14)),
-  V (x, y, z) AS (VALUES(1, "2", 3.14)),
-  _vals (pk, x, y) AS (SELECT *
-    FROM V)
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    U (x, y, z) AS (
+      VALUES(1, "2", 3.14)
+    ),
+    V (x, y, z) AS (
+      VALUES(1, "2", 3.14)
+    ),
+    _vals (pk, x, y) AS (
+      SELECT *
+        FROM V
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18211,12 +18438,19 @@ CQL_WARN_UNUSED cql_code insert_backed_values_using_with(sqlite3 *_Nonnull _db_)
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "U (x, y, z) AS (VALUES(1, '2', 3.14)), "
-    "V (x, y, z) AS (VALUES(1, '2', 3.14)), "
-    "_vals (pk, x, y) AS (SELECT x, y, z "
-      "FROM V) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "U (x, y, z) AS ( "
+        "VALUES(1, '2', 3.14) "
+      "), "
+      "V (x, y, z) AS ( "
+        "VALUES(1, '2', 3.14) "
+      "), "
+      "_vals (pk, x, y) AS ( "
+        "SELECT x, y, z "
+          "FROM V "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18232,9 +18466,12 @@ cql_cleanup:
 CREATE PROC insert_backed_values_using_form ()
 BEGIN
   WITH
-  _vals (pk, x, y) AS (VALUES(1, "2", 3.14))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    _vals (pk, x, y) AS (
+      VALUES(1, "2", 3.14)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18249,9 +18486,12 @@ CQL_WARN_UNUSED cql_code insert_backed_values_using_form(sqlite3 *_Nonnull _db_)
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk, x, y) AS (VALUES(1, '2', 3.14)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "_vals (pk, x, y) AS ( "
+        "VALUES(1, '2', 3.14) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18267,11 +18507,14 @@ cql_cleanup:
 CREATE PROC inserted_backed_from_select ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
-  _vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50
-    FROM small_backed AS B)
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
+    _vals (pk, x, y) AS (
+      SELECT pk + 1000, B.x || 'x', B.y + 50
+        FROM small_backed AS B
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18287,15 +18530,22 @@ CQL_WARN_UNUSED cql_code inserted_backed_from_select(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0) AS pk, bgetval(T.v, 7953209610392031882) AS x, bgetval(T.v, 3032304244189539277) AS y "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0) AS pk, "
+          "bgetval(T.v, 7953209610392031882) AS x, "
+          "bgetval(T.v, 3032304244189539277) AS y "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   "), "
-    "_vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50 "
-      "FROM small_backed AS B) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V"
+      "_vals (pk, x, y) AS ( "
+        "SELECT pk + 1000, B.x || 'x', B.y + 50 "
+          "FROM small_backed AS B "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18312,7 +18562,7 @@ cql_cleanup:
 CREATE PROC delete_from_backed ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed())
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed())
   DELETE FROM backing WHERE rowid IN (SELECT rowid
     FROM small_backed
     WHERE pk = 12345);
@@ -18331,10 +18581,14 @@ CQL_WARN_UNUSED cql_code delete_from_backed(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0), bgetval(T.v, 7953209610392031882), bgetval(T.v, 3032304244189539277) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 7953209610392031882), "
+          "bgetval(T.v, 3032304244189539277) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   ") "
     "DELETE FROM backing WHERE rowid IN (SELECT rowid "
       "FROM small_backed "
@@ -18355,8 +18609,10 @@ cql_cleanup:
 CREATE PROC delete_from_backed_no_where_clause ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
-  v (x) AS (VALUES(1))
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
+    v (x) AS (
+      VALUES(1)
+    )
   DELETE FROM backing WHERE rowid IN (SELECT rowid
     FROM small_backed);
 END;
@@ -18374,12 +18630,18 @@ CQL_WARN_UNUSED cql_code delete_from_backed_no_where_clause(sqlite3 *_Nonnull _d
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0), bgetval(T.v, 7953209610392031882), bgetval(T.v, 3032304244189539277) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 7953209610392031882), "
+          "bgetval(T.v, 3032304244189539277) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   "), "
-    "v (x) AS (VALUES(1)) "
+      "v (x) AS ( "
+        "VALUES(1) "
+      ") "
     "DELETE FROM backing WHERE rowid IN (SELECT rowid "
       "FROM small_backed)"
   );
@@ -18452,12 +18714,12 @@ cql_cleanup:
 CREATE PROC update_backed_set_value ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET v = cql_blob_update(v, 'foo', backed.name)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'one');
+    SET v = cql_blob_update(v, 'foo', backed.name)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'one');
 END;
 */
 
@@ -18473,16 +18735,23 @@ CQL_WARN_UNUSED cql_code update_backed_set_value(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET v = bupdateval(v, -6946718245010482247, 'foo', 4) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'one')"
+      "SET v = bupdateval(v, -6946718245010482247, 'foo', 4) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'one')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18499,13 +18768,15 @@ cql_cleanup:
 CREATE PROC update_backed_with_clause ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  V (x) AS (VALUES(1))
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+    V (x) AS (
+      VALUES(1)
+    )
   UPDATE backing
-  SET v = cql_blob_update(v, 'goo', backed.name)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'with_update');
+    SET v = cql_blob_update(v, 'goo', backed.name)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'with_update');
 END;
 */
 
@@ -18521,17 +18792,26 @@ CQL_WARN_UNUSED cql_code update_backed_with_clause(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "V (x) AS (VALUES(1)) "
+      "V (x) AS ( "
+        "VALUES(1) "
+      ") "
     "UPDATE backing "
-    "SET v = bupdateval(v, -6946718245010482247, 'goo', 4) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'with_update')"
+      "SET v = bupdateval(v, -6946718245010482247, 'goo', 4) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'with_update')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18548,12 +18828,12 @@ cql_cleanup:
 CREATE PROC update_backed_set_key ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET k = cql_blob_update(k, 100, backed.pk)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'two');
+    SET k = cql_blob_update(k, 100, backed.pk)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'two');
 END;
 */
 
@@ -18569,16 +18849,23 @@ CQL_WARN_UNUSED cql_code update_backed_set_key(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 0, 100) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'two')"
+      "SET k = bupdatekey(k, 0, 100) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'two')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18595,15 +18882,14 @@ cql_cleanup:
 CREATE PROC update_backed_set_both ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET k = cql_blob_update(k, 100, backed.pk),
-  v = cql_blob_update(v, 77, backed.age)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'three'
-  ORDER BY age
-  LIMIT 7);
+    SET k = cql_blob_update(k, 100, backed.pk), v = cql_blob_update(v, 77, backed.age)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'three'
+    ORDER BY age
+    LIMIT 7);
 END;
 */
 
@@ -18619,19 +18905,25 @@ CQL_WARN_UNUSED cql_code update_backed_set_both(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 0, 100), "
-    "v = bupdateval(v, -3683705396192132539, 77, 3) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'three' "
-    "ORDER BY age "
-    "LIMIT 7)"
+      "SET k = bupdatekey(k, 0, 100), v = bupdateval(v, -3683705396192132539, 77, 3) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'three' "
+      "ORDER BY age "
+      "LIMIT 7)"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18654,7 +18946,7 @@ BEGIN
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 */
 
@@ -18691,7 +18983,7 @@ CQL_WARN_UNUSED cql_code stmt_in_loop(sqlite3 *_Nonnull _db_) {
   }
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT 1 "
-      "FROM foo)");
+        "FROM foo)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -18715,14 +19007,15 @@ BEGIN
   LET i := 0;
   WHILE i < 10
   BEGIN
-    DECLARE C CURSOR FOR SELECT *
-      FROM foo
-      WHERE id = i;
+    DECLARE C CURSOR FOR
+      SELECT *
+        FROM foo
+        WHERE id = i;
     FETCH C;
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 */
 
@@ -18767,7 +19060,7 @@ CQL_WARN_UNUSED cql_code cursor_in_loop(sqlite3 *_Nonnull _db_) {
   }
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT 1 "
-      "FROM foo)");
+        "FROM foo)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -19095,8 +19388,9 @@ cql_cleanup:
 /*
 CREATE PROC qid_t1 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM `xyz``abc`;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM `xyz``abc`;
   LOOP FETCH C
   BEGIN
     CALL printf("%d %d", C.x, C.`a b`);
@@ -19151,8 +19445,9 @@ cql_cleanup:
 /*
 CREATE PROC qid_t2 ()
 BEGIN
-  DECLARE D CURSOR FOR SELECT `xyz``abc`.*
-    FROM `xyz``abc`;
+  DECLARE D CURSOR FOR
+    SELECT `xyz``abc`.*
+      FROM `xyz``abc`;
   LOOP FETCH D
   BEGIN
     CALL printf("%d %d", D.x, D.`a b`);
@@ -20009,9 +20304,10 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE foo_cursor CURSOR FOR SELECT id, i2
-    FROM foo
-    WHERE id = i0_nullable;
+  DECLARE foo_cursor CURSOR FOR
+    SELECT id, i2
+      FROM foo
+      WHERE id = i0_nullable;
   */
   _rc_ = cql_prepare(_db_, &foo_cursor_stmt,
     "SELECT id, ? "
@@ -20037,7 +20333,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE basic_cursor CURSOR FOR SELECT 1, 2.5;
+  DECLARE basic_cursor CURSOR FOR
+    SELECT 1, 2.5;
   */
   _rc_ = cql_prepare(_db_, &basic_cursor_stmt,
     "SELECT 1, 2.5");
@@ -20079,7 +20376,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE exchange_cursor CURSOR FOR SELECT arg2, arg1;
+  DECLARE exchange_cursor CURSOR FOR
+    SELECT arg2, arg1;
   */
   _rc_ = cql_prepare(_db_, &exchange_cursor_stmt,
     "SELECT ?, ?");
@@ -20706,10 +21004,12 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5);
+  INSERT OR REPLACE INTO bar(id, type)
+    VALUES(1, 5);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5)");
+    "INSERT OR REPLACE INTO bar(id, type) "
+      "VALUES(1, 5)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -20725,11 +21025,11 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   SET b2 := ( SELECT EXISTS (SELECT *
-    FROM bar) );
+      FROM bar) );
   */
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT * "
-      "FROM bar)");
+        "FROM bar)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -20739,8 +21039,9 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE expanded_select CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE expanded_select CURSOR FOR
+    SELECT *
+      FROM bar;
   */
   _rc_ = cql_prepare(_db_, &expanded_select_stmt,
     "SELECT id, name, rate, type, size "
@@ -20750,8 +21051,9 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE table_expanded_select CURSOR FOR SELECT bar.*
-    FROM bar;
+  DECLARE table_expanded_select CURSOR FOR
+    SELECT bar.*
+      FROM bar;
   */
   _rc_ = cql_prepare(_db_, &table_expanded_select_stmt,
     "SELECT bar.id, bar.name, bar.rate, bar.type, bar.size "
@@ -21000,10 +21302,12 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
+  INSERT INTO blob_table(blob_id, b_nullable, b_notnull)
+    VALUES(0, blob_var, blob_var_notnull);
   */
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)");
+    "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) "
+      "VALUES(0, ?, ?)");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
                 CQL_DATA_TYPE_BLOB, blob_var,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
@@ -21055,15 +21359,21 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) VALUES(ifnull(( SELECT a
-    FROM x ), 0));
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    VALUES(ifnull(( SELECT a
+      FROM x ), 0));
   */
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
-    "INSERT INTO foo(id) VALUES(ifnull(( SELECT a "
-      "FROM x ), 0))");
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
+    "INSERT INTO foo(id) "
+      "VALUES(ifnull(( SELECT a "
+        "FROM x ), 0))");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -21082,7 +21392,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE global_cursor CURSOR FOR SELECT 1 AS a, 2 AS b;
+  DECLARE global_cursor CURSOR FOR
+    SELECT 1 AS a, 2 AS b;
   */
   _rc_ = cql_prepare(_db_, &global_cursor_stmt,
     "SELECT 1, 2");
@@ -21202,14 +21513,18 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   WITH
-  some_cte (id) AS (SELECT 1 AS id)
+    some_cte (id) AS (
+      SELECT 1 AS id
+    )
   INSERT INTO bar(id) VALUES(ifnull(( SELECT id
     FROM some_cte ), 0)) @DUMMY_SEED(1337);
   */
   _seed_ = 1337;
   _rc_ = cql_exec(_db_,
     "WITH "
-    "some_cte (id) AS (SELECT 1 AS id) "
+      "some_cte (id) AS ( "
+        "SELECT 1 AS id "
+      ") "
     "INSERT INTO bar(id) VALUES(ifnull(( SELECT id "
       "FROM some_cte ), 0))");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -21219,13 +21534,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   INSERT INTO bar(id) VALUES(1) @DUMMY_SEED(1338)
   ON CONFLICT (id) DO UPDATE
-  SET id = 10;
+    SET id = 10;
   */
   _seed_ = 1338;
   _rc_ = cql_exec(_db_,
     "INSERT INTO bar(id) VALUES(1) "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10");
+      "SET id = 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -21485,19 +21800,23 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO virtual_with_hidden(vy) VALUES(1);
+  INSERT INTO virtual_with_hidden(vy)
+    VALUES(1);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT INTO virtual_with_hidden(vy) VALUES(1)");
+    "INSERT INTO virtual_with_hidden(vy) "
+      "VALUES(1)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2);
+  INSERT INTO virtual_with_hidden(vx, vy)
+    VALUES(1, 2);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2)");
+    "INSERT INTO virtual_with_hidden(vx, vy) "
+      "VALUES(1, 2)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -1565,7 +1565,7 @@ DECLARE PROC plugh (id INTEGER);
 /*
 CREATE PROC complex_return ()
 BEGIN
-  SELECT 
+  SELECT
       TRUE AS _bool,
       2 AS _integer,
       CAST(3 AS LONG_INT) AS _longint,
@@ -1678,7 +1678,7 @@ CQL_WARN_UNUSED cql_code complex_return(sqlite3 *_Nonnull _db_, sqlite3_stmt *_N
   cql_error_prepare();
 
   _rc_ = cql_prepare(_db_, _result_stmt,
-    "SELECT  "
+    "SELECT "
         "1, "
         "2, "
         "CAST(3 AS LONG_INT), "
@@ -8232,7 +8232,7 @@ CQL_WARN_UNUSED cql_code pretty_print_with_quote(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "INSERT INTO bar(id, name) "
-      "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
+      "VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -17426,7 +17426,7 @@ cql_cleanup:
 CREATE PROC use_cql_blob_get_backed ()
 BEGIN
   DECLARE C CURSOR FOR
-    SELECT 
+    SELECT
         cql_blob_get(k, backed.pk),
         cql_blob_get(v, backed.flag),
         cql_blob_get(v, backed.storage),
@@ -17448,7 +17448,7 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT  "
+    "SELECT "
         "bgetkey(k, 0), "
         "bgetval(v, 1055660242183705531), "
         "bgetval(v, -7635294210585028660), "
@@ -17472,7 +17472,7 @@ cql_cleanup:
 CREATE PROC use_cql_blob_get_backed2 ()
 BEGIN
   DECLARE C CURSOR FOR
-    SELECT 
+    SELECT
         cql_blob_get(k, backed2.pk1),
         cql_blob_get(k, backed2.pk2),
         cql_blob_get(v, backed2.id),
@@ -17493,7 +17493,7 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed2(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT  "
+    "SELECT "
         "bgetkey(k, 1), "
         "bgetkey(k, 0), "
         "bgetval(v, -9155171551243524439), "
@@ -17579,7 +17579,7 @@ CQL_WARN_UNUSED cql_code update_backed2(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 1), "
           "bgetkey(T.k, 0), "
@@ -17736,7 +17736,7 @@ CQL_WARN_UNUSED cql_code use_generated_fragment(sqlite3 *_Nonnull _db_, sqlite3_
     3, NULL,
   "WITH "
       "_backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -17891,7 +17891,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly(sqlite3 *_Nonnull _db_, sqlit
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -17942,7 +17942,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_cursor(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18103,7 +18103,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select(sqlite3 *_Nonn
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18166,7 +18166,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_select_and_cursor(sqlite3 *_Nonnu
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18225,7 +18225,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18283,7 +18283,7 @@ static CQL_WARN_UNUSED cql_code explain_query_plan_backed(sqlite3 *_Nonnull _db_
   "EXPLAIN QUERY PLAN "
     "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18336,7 +18336,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 0), "
           "bgetval(T.v, 1), "
@@ -18531,7 +18531,7 @@ CQL_WARN_UNUSED cql_code inserted_backed_from_select(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0) AS pk, "
           "bgetval(T.v, 7953209610392031882) AS x, "
@@ -18582,7 +18582,7 @@ CQL_WARN_UNUSED cql_code delete_from_backed(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0), "
           "bgetval(T.v, 7953209610392031882), "
@@ -18631,7 +18631,7 @@ CQL_WARN_UNUSED cql_code delete_from_backed_no_where_clause(sqlite3 *_Nonnull _d
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0), "
           "bgetval(T.v, 7953209610392031882), "
@@ -18736,7 +18736,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_value(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18793,7 +18793,7 @@ CQL_WARN_UNUSED cql_code update_backed_with_clause(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18850,7 +18850,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_key(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18906,7 +18906,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_both(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -1357,13 +1357,15 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC easy_fetch ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   FETCH C;
   CALL printf("%d %s\n", C.id, C.name);
-  DECLARE C2 CURSOR FOR SELECT *
-    FROM bar
-    WHERE C AND id = C.id;
+  DECLARE C2 CURSOR FOR
+    SELECT *
+      FROM bar
+      WHERE C AND id = C.id;
 END;
 */
 
@@ -1524,7 +1526,8 @@ DECLARE PROC xyzzy (id INTEGER) (A INTEGER NOT NULL);
 /*
 CREATE PROC xyzzy_test ()
 BEGIN
-  DECLARE xyzzy_cursor CURSOR FOR CALL xyzzy(1);
+  DECLARE xyzzy_cursor CURSOR FOR
+    CALL xyzzy(1);
 END;
 */
 
@@ -1562,7 +1565,13 @@ DECLARE PROC plugh (id INTEGER);
 /*
 CREATE PROC complex_return ()
 BEGIN
-  SELECT TRUE AS _bool, 2 AS _integer, CAST(3 AS LONG_INT) AS _longint, 3.0 AS _real, 'xyz' AS _text, CAST(NULL AS BOOL) AS _nullable_bool;
+  SELECT 
+      TRUE AS _bool,
+      2 AS _integer,
+      CAST(3 AS LONG_INT) AS _longint,
+      3.0 AS _real,
+      'xyz' AS _text,
+      CAST(NULL AS BOOL) AS _nullable_bool;
 END;
 */
 
@@ -1669,7 +1678,13 @@ CQL_WARN_UNUSED cql_code complex_return(sqlite3 *_Nonnull _db_, sqlite3_stmt *_N
   cql_error_prepare();
 
   _rc_ = cql_prepare(_db_, _result_stmt,
-    "SELECT 1, 2, CAST(3 AS LONG_INT), 3.0, 'xyz', NULL");
+    "SELECT  "
+        "1, "
+        "2, "
+        "CAST(3 AS LONG_INT), "
+        "3.0, "
+        "'xyz', "
+        "NULL");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -2113,10 +2128,13 @@ cql_cleanup:
 /*
 CREATE PROC with_stmt_using_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
-  SELECT *
-    FROM X;
+  DECLARE C CURSOR FOR
+    WITH
+      X (a, b, c) AS (
+        SELECT 1, 2, 3
+      )
+    SELECT *
+      FROM X;
   FETCH C;
 END;
 */
@@ -2143,7 +2161,9 @@ CQL_WARN_UNUSED cql_code with_stmt_using_cursor(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_prepare(_db_, &C_stmt,
     "WITH "
-    "X (a, b, c) AS (SELECT 1, 2, 3) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2169,7 +2189,9 @@ cql_cleanup:
 CREATE PROC with_stmt ()
 BEGIN
   WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+    )
   SELECT *
     FROM X;
 END;
@@ -2246,7 +2268,9 @@ CQL_WARN_UNUSED cql_code with_stmt(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullab
 
   _rc_ = cql_prepare(_db_, _result_stmt,
     "WITH "
-    "X (a, b, c) AS (SELECT 1, 2, 3) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2265,9 +2289,11 @@ cql_cleanup:
 CREATE PROC with_recursive_stmt ()
 BEGIN
   WITH RECURSIVE
-  X (a, b, c) AS (SELECT 1, 2, 3
-  UNION ALL
-  SELECT 4, 5, 6)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+      UNION ALL
+      SELECT 4, 5, 6
+    )
   SELECT *
     FROM X;
 END;
@@ -2344,9 +2370,11 @@ CQL_WARN_UNUSED cql_code with_recursive_stmt(sqlite3 *_Nonnull _db_, sqlite3_stm
 
   _rc_ = cql_prepare(_db_, _result_stmt,
     "WITH RECURSIVE "
-    "X (a, b, c) AS (SELECT 1, 2, 3 "
-    "UNION ALL "
-    "SELECT 4, 5, 6) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+        "UNION ALL "
+        "SELECT 4, 5, 6 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2544,7 +2572,8 @@ cql_cleanup:
 /*
 CREATE PROC outint_nullable (OUT output INTEGER, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -2589,7 +2618,8 @@ cql_cleanup:
 /*
 CREATE PROC outint_notnull (OUT output INTEGER NOT NULL, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -2832,7 +2862,8 @@ void echo_test(void) {
 /*
 CREATE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER)
 BEGIN
-  INSERT INTO bar(id, type) VALUES(id_, type_);
+  INSERT INTO bar(id, type)
+    VALUES(id_, type_);
 END;
 */
 
@@ -2847,7 +2878,8 @@ CQL_WARN_UNUSED cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cq
   sqlite3_stmt *_temp_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO bar(id, type) VALUES(?, ?)");
+    "INSERT INTO bar(id, type) "
+      "VALUES(?, ?)");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_,
                 CQL_DATA_TYPE_INT32, &type_);
@@ -3085,11 +3117,13 @@ cql_cleanup:
 /*
 CREATE PROC misc_dml_proc ()
 BEGIN
-  INSERT INTO foo(id) VALUES(NULL);
-  INSERT INTO foo(id) VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
   UPDATE bar
-  SET name = 'bar'
-    WHERE name = 'baz';
+    SET name = 'bar'
+      WHERE name = 'baz';
   DELETE FROM foo WHERE id = 1;
 END;
 */
@@ -3104,15 +3138,17 @@ CQL_WARN_UNUSED cql_code misc_dml_proc(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) VALUES(NULL)");
+    "INSERT INTO foo(id) "
+      "VALUES(NULL)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) VALUES(NULL)");
+    "INSERT INTO foo(id) "
+      "VALUES(NULL)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
     "UPDATE bar "
-    "SET name = 'bar' "
-      "WHERE name = 'baz'");
+      "SET name = 'bar' "
+        "WHERE name = 'baz'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
     "DELETE FROM foo WHERE id = 1");
@@ -3389,8 +3425,9 @@ void voidproc(void) {
 /*
 CREATE PROC out_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
+      FROM bar;
   FETCH C;
   OUT C;
 END;
@@ -3713,7 +3750,7 @@ CREATE PROC thread_theme_info_list (thread_key_ LONG_INT NOT NULL)
 BEGIN
   SELECT *
     FROM (SELECT thread_key
-    FROM threads) AS T;
+        FROM threads) AS T;
 END;
 */
 
@@ -3773,7 +3810,7 @@ CQL_WARN_UNUSED cql_code thread_theme_info_list(sqlite3 *_Nonnull _db_, sqlite3_
   _rc_ = cql_prepare(_db_, _result_stmt,
     "SELECT thread_key "
       "FROM (SELECT thread_key "
-      "FROM threads) AS T");
+          "FROM threads) AS T");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -3930,7 +3967,8 @@ void c_literal(cql_string_ref _Nullable *_Nonnull x) {
 CREATE PROC no_cleanup_label_needed_proc ()
 BEGIN
   BEGIN TRY
-    DECLARE C CURSOR FOR SELECT 1 AS N;
+    DECLARE C CURSOR FOR
+      SELECT 1 AS N;
     FETCH C;
   END TRY;
   BEGIN CATCH
@@ -4686,9 +4724,12 @@ void blob_no_else(void) {
 CREATE PROC with_inserter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) SELECT *
-    FROM x;
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    SELECT *
+      FROM x;
 END;
 */
 
@@ -4703,9 +4744,12 @@ CQL_WARN_UNUSED cql_code with_inserter(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
-    "INSERT INTO foo(id) SELECT a "
-      "FROM x");
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
+    "INSERT INTO foo(id) "
+      "SELECT a "
+        "FROM x");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -4873,7 +4917,8 @@ void fetch_to_cursor_from_cursor(fetch_to_cursor_from_cursor_row *_Nonnull _resu
 /*
 CREATE PROC loop_statement_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.A);
@@ -4925,7 +4970,8 @@ cql_cleanup:
 /*
 CREATE PROC loop_statement_not_auto_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   DECLARE A_ INTEGER NOT NULL;
   LOOP FETCH C INTO A_
   BEGIN
@@ -5009,7 +5055,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -5066,7 +5113,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -5125,7 +5173,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     DECLARE box OBJECT<C CURSOR>;
     SET box FROM CURSOR C;
     DECLARE D CURSOR FOR box;
@@ -5259,7 +5308,8 @@ void out_union_helper_fetch_results(out_union_helper_result_set_ref _Nullable *_
 /*
 CREATE PROC out_union_dml_helper ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   OUT UNION C;
 END;
@@ -5348,7 +5398,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL out_union_helper();
+    DECLARE C CURSOR FOR
+      CALL out_union_helper();
     FETCH C;
   END;
 END;
@@ -5986,7 +6037,8 @@ cql_cleanup:
 @ATTRIBUTE(cql:identity=(id))
 CREATE PROC out_cursor_identity ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 2 AS data;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 2 AS data;
   FETCH C;
   OUT C;
 END;
@@ -6183,7 +6235,9 @@ cql_cleanup:
 CREATE PROC with_deleter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   DELETE FROM foo WHERE id IN (SELECT *
     FROM x);
 END;
@@ -6200,7 +6254,9 @@ CQL_WARN_UNUSED cql_code with_deleter(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
     "DELETE FROM foo WHERE id IN (SELECT a "
       "FROM x)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -6218,11 +6274,13 @@ cql_cleanup:
 CREATE PROC with_updater ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   UPDATE bar
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 */
 
@@ -6237,11 +6295,13 @@ CQL_WARN_UNUSED cql_code with_updater(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
     "UPDATE bar "
-    "SET name = 'xyzzy' "
-      "WHERE id IN (SELECT a "
-      "FROM x)");
+      "SET name = 'xyzzy' "
+        "WHERE id IN (SELECT a "
+        "FROM x)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6530,12 +6590,13 @@ cql_cleanup:
 /*
 CREATE PROC settings_info ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
-    FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
-    FROM unread_pending_threads AS P
-  UNION ALL
-  SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
-    FROM switch_account_badges AS S) AS A;
+  DECLARE C CURSOR FOR
+    SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
+      FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
+          FROM unread_pending_threads AS P
+        UNION ALL
+        SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
+          FROM switch_account_badges AS S) AS A;
 END;
 */
 
@@ -6552,10 +6613,10 @@ CQL_WARN_UNUSED cql_code settings_info(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_prepare(_db_, &C_stmt,
     "SELECT SUM(A.unread_pending_thread_count), SUM(A.switch_account_badge_count) "
       "FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count "
-      "FROM unread_pending_threads AS P "
-    "UNION ALL "
-    "SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count "
-      "FROM switch_account_badges AS S) AS A");
+          "FROM unread_pending_threads AS P "
+        "UNION ALL "
+        "SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count "
+          "FROM switch_account_badges AS S) AS A");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6750,8 +6811,10 @@ cql_cleanup:
 CREATE PROC use_with_select ()
 BEGIN
   DECLARE x INTEGER;
-  SET x := ( WITH
-  threads2 (count) AS (SELECT 1 AS foo)
+  SET x := (   WITH
+    threads2 (count) AS (
+      SELECT 1 AS foo
+    )
   SELECT COUNT(*)
     FROM threads2 );
 END;
@@ -6771,7 +6834,9 @@ CQL_WARN_UNUSED cql_code use_with_select(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "WITH "
-    "threads2 (count) AS (SELECT 1) "
+      "threads2 (count) AS ( "
+        "SELECT 1 "
+      ") "
     "SELECT COUNT(*) "
       "FROM threads2");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -6794,8 +6859,9 @@ cql_cleanup:
 /*
 CREATE PROC rowset_object_reader (rowset OBJECT<rowset>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM ReadFromRowset(rowset);
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM ReadFromRowset(rowset);
 END;
 */
 
@@ -6829,12 +6895,13 @@ cql_cleanup:
 /*
 CREATE PROC upsert_do_something ()
 BEGIN
-  INSERT INTO foo(id) SELECT id
-    FROM bar
-    WHERE 1
+  INSERT INTO foo(id)
+    SELECT id
+      FROM bar
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 */
 
@@ -6848,12 +6915,13 @@ CQL_WARN_UNUSED cql_code upsert_do_something(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) SELECT id "
-      "FROM bar "
-      "WHERE 1 "
+    "INSERT INTO foo(id) "
+      "SELECT id "
+        "FROM bar "
+        "WHERE 1 "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10 "
-      "WHERE id <> 10");
+      "SET id = 10 "
+        "WHERE id <> 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6869,13 +6937,16 @@ cql_cleanup:
 CREATE PROC with_upsert_form ()
 BEGIN
   WITH
-  names (id) AS (VALUES(1), (5), (3), (12))
-  INSERT INTO foo(id) SELECT id
-    FROM names
-    WHERE 1
+    names (id) AS (
+      VALUES(1), (5), (3), (12)
+    )
+  INSERT INTO foo(id)
+    SELECT id
+      FROM names
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 */
 
@@ -6890,13 +6961,16 @@ CQL_WARN_UNUSED cql_code with_upsert_form(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "names (id) AS (VALUES(1), (5), (3), (12)) "
-    "INSERT INTO foo(id) SELECT id "
-      "FROM names "
-      "WHERE 1 "
+      "names (id) AS ( "
+        "VALUES(1), (5), (3), (12) "
+      ") "
+    "INSERT INTO foo(id) "
+      "SELECT id "
+        "FROM names "
+        "WHERE 1 "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10 "
-      "WHERE id <> 10");
+      "SET id = 10 "
+        "WHERE id <> 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6911,7 +6985,8 @@ cql_cleanup:
 /*
 CREATE PROC upsert_do_nothing (id_ INTEGER NOT NULL)
 BEGIN
-  INSERT INTO foo(id) VALUES(id_)
+  INSERT INTO foo(id)
+    VALUES(id_)
   ON CONFLICT DO NOTHING;
 END;
 */
@@ -6927,7 +7002,8 @@ CQL_WARN_UNUSED cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_
   sqlite3_stmt *_temp_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO foo(id) VALUES(?) "
+    "INSERT INTO foo(id) "
+      "VALUES(?) "
     "ON CONFLICT DO NOTHING");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_);
@@ -7171,7 +7247,8 @@ void out_union_two_fetch_results(out_union_two_result_set_ref _Nullable *_Nonnul
 /*
 CREATE PROC out_union_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_two();
+  DECLARE c CURSOR FOR
+    CALL out_union_two();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -7230,7 +7307,8 @@ CQL_WARN_UNUSED cql_code out_union_reader(sqlite3 *_Nonnull _db_) {
 /*
 CREATE PROC out_union_from_select ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x, '2' AS y;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x, '2' AS y;
   FETCH C;
   OUT UNION C;
   OUT UNION C;
@@ -7335,7 +7413,8 @@ cql_cleanup:
 /*
 CREATE PROC out_union_dml_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_from_select();
+  DECLARE c CURSOR FOR
+    CALL out_union_from_select();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -7473,7 +7552,8 @@ void out_union_values_fetch_results(out_union_values_result_set_ref _Nullable *_
 /*
 CREATE PROC read_out_union_values (a INTEGER NOT NULL, b INTEGER NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_values(a, b);
+  DECLARE C CURSOR FOR
+    CALL out_union_values(a, b);
   FETCH C;
 END;
 */
@@ -7521,8 +7601,9 @@ CQL_WARN_UNUSED cql_code read_out_union_values(sqlite3 *_Nonnull _db_, cql_int32
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml ()
 BEGIN
-  DECLARE x CURSOR FOR SELECT *
-    FROM radioactive;
+  DECLARE x CURSOR FOR
+    SELECT *
+      FROM radioactive;
   FETCH x;
   OUT UNION x;
 END;
@@ -7630,7 +7711,8 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml_for_call ()
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_dml();
+  DECLARE C CURSOR FOR
+    CALL out_union_dml();
   FETCH C;
 END;
 */
@@ -8009,7 +8091,8 @@ BEGIN
   WHILE 1
   BEGIN
   END;
-  DECLARE c CURSOR FOR SELECT 1 AS x;
+  DECLARE c CURSOR FOR
+    SELECT 1 AS x;
   LOOP FETCH c
   BEGIN
   END;
@@ -8133,7 +8216,8 @@ CQL_WARN_UNUSED cql_code tail_catch(sqlite3 *_Nonnull _db_) {
 /*
 CREATE PROC pretty_print_with_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "it's high noon\r\n\f\b\t\v");
+  INSERT INTO bar(id, name)
+    VALUES(1, "it's high noon\r\n\f\b\t\v");
 END;
 */
 
@@ -8147,7 +8231,8 @@ CQL_WARN_UNUSED cql_code pretty_print_with_quote(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO bar(id, name) VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
+    "INSERT INTO bar(id, name) "
+      "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -8162,7 +8247,8 @@ cql_cleanup:
 /*
 CREATE PROC hex_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "\x01\x02\xa1\x1bg");
+  INSERT INTO bar(id, name)
+    VALUES(1, "\x01\x02\xa1\x1bg");
 END;
 */
 
@@ -8176,7 +8262,8 @@ CQL_WARN_UNUSED cql_code hex_quote(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO bar(id, name) VALUES(1, '\x01\x02\xa1\x1bg')");
+    "INSERT INTO bar(id, name) "
+      "VALUES(1, '\x01\x02\xa1\x1bg')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -9016,7 +9103,8 @@ cql_cleanup:
 /*
 CREATE PROC early_out_rc_cleared (OUT x INTEGER)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   IF C THEN
     RETURN;
@@ -9701,8 +9789,9 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC vault_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT name
-    FROM vault_mixed_sensitive;
+  DECLARE C CURSOR FOR
+    SELECT name
+      FROM vault_mixed_sensitive;
   FETCH c;
 END;
 */
@@ -10093,8 +10182,9 @@ cql_cleanup:
 /*
 CREATE PROC try_boxing (OUT result OBJECT<bar CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET result FROM CURSOR C;
 END;
 */
@@ -13119,7 +13209,8 @@ void c_proc_with_alt_prefix(cql_nullable_int32 *_Nonnull x) {
 /*
 CREATE PROC use_private_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL private_out_union();
+  DECLARE C CURSOR FOR
+    CALL private_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13235,7 +13326,8 @@ void no_getters_out_union_fetch_results(no_getters_out_union_result_set_ref _Nul
 /*
 CREATE PROC use_no_getters_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL no_getters_out_union();
+  DECLARE C CURSOR FOR
+    CALL no_getters_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13351,7 +13443,8 @@ void suppress_results_out_union_fetch_results(suppress_results_out_union_result_
 /*
 CREATE PROC use_suppress_results_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL suppress_results_out_union();
+  DECLARE C CURSOR FOR
+    CALL suppress_results_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13595,8 +13688,9 @@ void various_lets(void) {
 /*
 CREATE PROC try_catch_rc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 'foo' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT 'foo' AS extra2
+      FROM bar;
   BEGIN TRY
     FETCH C;
   END TRY;
@@ -14423,8 +14517,9 @@ cql_bool false_test = 0;
 /*
 CREATE PROC BigFormat ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM big_data;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM big_data;
   LOOP FETCH C
   BEGIN
     LET s := cql_cursor_format(C);
@@ -15374,7 +15469,7 @@ END;
 CREATE PROC foo ()
 BEGIN
   WITH
-  shared_frag (shared_something) AS (CALL shared_frag())
+    shared_frag (shared_something) AS (CALL shared_frag())
   SELECT *
     FROM shared_frag;
 END;
@@ -15436,7 +15531,7 @@ CQL_WARN_UNUSED cql_code foo(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_N
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "shared_frag (shared_something) AS (",
+      "shared_frag (shared_something) AS (",
   "SELECT 1234",
   ") "
     "SELECT shared_something "
@@ -15474,8 +15569,10 @@ END;
 CREATE PROC shared_conditional_user (x INTEGER NOT NULL)
 BEGIN
   WITH
-  some_cte (id) AS (SELECT x),
-  shared_conditional (x) AS (CALL shared_conditional(1))
+    some_cte (id) AS (
+      SELECT x
+    ),
+    shared_conditional (x) AS (CALL shared_conditional(1))
   SELECT bar.*
     FROM bar
     INNER JOIN some_cte ON x = 5;
@@ -15616,8 +15713,10 @@ CQL_WARN_UNUSED cql_code shared_conditional_user(sqlite3 *_Nonnull _db_, sqlite3
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     5, _preds_1,
   "WITH "
-    "some_cte (id) AS (SELECT ?), "
-    "shared_conditional (x) AS (",
+      "some_cte (id) AS ( "
+        "SELECT ? "
+      "), "
+      "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
@@ -15653,7 +15752,7 @@ CREATE PROC nested_shared_proc (x_ INTEGER NOT NULL)
 BEGIN
   IF x_ <= 5 THEN
     WITH
-    shared_conditional (x) AS (CALL shared_conditional(1))
+      shared_conditional (x) AS (CALL shared_conditional(1))
     SELECT *
       FROM shared_conditional
       WHERE x_ = 5;
@@ -15669,7 +15768,7 @@ END;
 CREATE PROC nested_shared_stuff ()
 BEGIN
   WITH
-  nested_shared_proc (x) AS (CALL nested_shared_proc(1))
+    nested_shared_proc (x) AS (CALL nested_shared_proc(1))
   SELECT *
     FROM nested_shared_proc;
 END;
@@ -15767,16 +15866,16 @@ CQL_WARN_UNUSED cql_code nested_shared_stuff(sqlite3 *_Nonnull _db_, sqlite3_stm
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     8, _preds_1,
   "WITH "
-    "nested_shared_proc (x) AS (",
-  "WITH "
-    "shared_conditional (x) AS (",
+      "nested_shared_proc (x) AS (",
+  "  WITH "
+        "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
   ") "
-    "SELECT x "
-      "FROM shared_conditional "
-      "WHERE ? = 5",
+      "SELECT x "
+        "FROM shared_conditional "
+        "WHERE ? = 5",
   "SELECT ?",
   ") "
     "SELECT x "
@@ -15907,15 +16006,15 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   "SELECT x "
       "FROM (",
   "(",
-  "WITH "
-    "shared_conditional (x) AS (",
+  "  WITH "
+        "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
   ") "
-    "SELECT x "
-      "FROM shared_conditional "
-      "WHERE ? = 5",
+      "SELECT x "
+        "FROM shared_conditional "
+        "WHERE ? = 5",
   "SELECT ? AS x",
   ")",
   ")"
@@ -15999,7 +16098,7 @@ END;
 CREATE PROC shared_frag_else_nothing_test ()
 BEGIN
   WITH
-  shared_frag_else_nothing (id1, text1) AS (CALL shared_frag_else_nothing(5))
+    shared_frag_else_nothing (id1, text1) AS (CALL shared_frag_else_nothing(5))
   SELECT *
     FROM foo;
 END;
@@ -16078,7 +16177,7 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, s
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     4, _preds_1,
   "WITH "
-    "shared_frag_else_nothing (id1, text1) AS (",
+      "shared_frag_else_nothing (id1, text1) AS (",
   "SELECT ?, 'x'",
   "SELECT 0,0 WHERE 0",
   ") "
@@ -16246,7 +16345,8 @@ void slash_star_and_star_slash(void) {
 /*
 CREATE PROC blob_serialization_test ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'foo' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'foo' AS name;
   FETCH C;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
@@ -16570,7 +16670,8 @@ DECLARE PROC some_redeclared_out_proc () OUT (x INTEGER) USING TRANSACTION;
 /*
 CREATE PROC some_redeclared_out_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT c;
 END;
@@ -16675,7 +16776,8 @@ DECLARE PROC some_redeclared_out_union_proc () OUT UNION (x INTEGER) USING TRANS
 /*
 CREATE PROC some_redeclared_out_union_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT UNION c;
 END;
@@ -16908,7 +17010,8 @@ void mutated_in_arg2(cql_string_ref _Nullable _in__x) {
 /*
 CREATE PROC mutated_in_arg3 (x TEXT)
 BEGIN
-  DECLARE C CURSOR FOR SELECT "x" AS x;
+  DECLARE C CURSOR FOR
+    SELECT "x" AS x;
   FETCH C INTO x;
 END;
 */
@@ -17322,8 +17425,15 @@ cql_cleanup:
 /*
 CREATE PROC use_cql_blob_get_backed ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT cql_blob_get(k, backed.pk), cql_blob_get(v, backed.flag), cql_blob_get(v, backed.storage), cql_blob_get(v, backed.id), cql_blob_get(v, backed.name), cql_blob_get(v, backed.age)
-    FROM backing;
+  DECLARE C CURSOR FOR
+    SELECT 
+        cql_blob_get(k, backed.pk),
+        cql_blob_get(v, backed.flag),
+        cql_blob_get(v, backed.storage),
+        cql_blob_get(v, backed.id),
+        cql_blob_get(v, backed.name),
+        cql_blob_get(v, backed.age)
+      FROM backing;
 END;
 */
 
@@ -17338,7 +17448,13 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT bgetkey(k, 0), bgetval(v, 1055660242183705531), bgetval(v, -7635294210585028660), bgetval(v, -9155171551243524439), bgetval(v, -6946718245010482247), bgetval(v, -3683705396192132539) "
+    "SELECT  "
+        "bgetkey(k, 0), "
+        "bgetval(v, 1055660242183705531), "
+        "bgetval(v, -7635294210585028660), "
+        "bgetval(v, -9155171551243524439), "
+        "bgetval(v, -6946718245010482247), "
+        "bgetval(v, -3683705396192132539) "
       "FROM backing");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17355,8 +17471,14 @@ cql_cleanup:
 /*
 CREATE PROC use_cql_blob_get_backed2 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT cql_blob_get(k, backed2.pk1), cql_blob_get(k, backed2.pk2), cql_blob_get(v, backed2.id), cql_blob_get(v, backed2.extra), cql_blob_get(v, backed2.name)
-    FROM backing;
+  DECLARE C CURSOR FOR
+    SELECT 
+        cql_blob_get(k, backed2.pk1),
+        cql_blob_get(k, backed2.pk2),
+        cql_blob_get(v, backed2.id),
+        cql_blob_get(v, backed2.extra),
+        cql_blob_get(v, backed2.name)
+      FROM backing;
 END;
 */
 
@@ -17371,7 +17493,12 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed2(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT bgetkey(k, 1), bgetkey(k, 0), bgetval(v, -9155171551243524439), bgetval(v, 4605090824299507084), bgetval(v, -6946718245010482247) "
+    "SELECT  "
+        "bgetkey(k, 1), "
+        "bgetkey(k, 0), "
+        "bgetval(v, -9155171551243524439), "
+        "bgetval(v, 4605090824299507084), "
+        "bgetval(v, -6946718245010482247) "
       "FROM backing");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17389,9 +17516,12 @@ cql_cleanup:
 CREATE PROC insert_into_backed2 ()
 BEGIN
   WITH
-  _vals (pk1, pk2, flag, id, name, extra) AS (VALUES(1, 2, TRUE, 1000, 'hi', 5))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(backed2, V.pk2, backed2.pk2, V.pk1, backed2.pk1), cql_blob_create(backed2, V.flag, backed2.flag, V.id, backed2.id, V.name, backed2.name, V.extra, backed2.extra)
-    FROM _vals AS V;
+    _vals (pk1, pk2, flag, id, name, extra) AS (
+      VALUES(1, 2, TRUE, 1000, 'hi', 5)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(backed2, V.pk2, backed2.pk2, V.pk1, backed2.pk1), cql_blob_create(backed2, V.flag, backed2.flag, V.id, backed2.id, V.name, backed2.name, V.extra, backed2.extra)
+      FROM _vals AS V;
 END;
 */
 
@@ -17406,9 +17536,12 @@ CQL_WARN_UNUSED cql_code insert_into_backed2(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk1, pk2, flag, id, name, extra) AS (VALUES(1, 2, 1, 1000, 'hi', 5)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(3942979045122214775, V.pk2, 1, V.pk1, 1), bcreateval(3942979045122214775, 1055660242183705531, V.flag, 0, -9155171551243524439, V.id, 2, -6946718245010482247, V.name, 4, 4605090824299507084, V.extra, 1) "
-      "FROM _vals AS V");
+      "_vals (pk1, pk2, flag, id, name, extra) AS ( "
+        "VALUES(1, 2, 1, 1000, 'hi', 5) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(3942979045122214775, V.pk2, 1, V.pk1, 1), bcreateval(3942979045122214775, 1055660242183705531, V.flag, 0, -9155171551243524439, V.id, 2, -6946718245010482247, V.name, 4, 4605090824299507084, V.extra, 1) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -17424,12 +17557,12 @@ cql_cleanup:
 CREATE PROC update_backed2 ()
 BEGIN
   WITH
-  backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (CALL _backed2())
+    backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (CALL _backed2())
   UPDATE backing
-  SET k = cql_blob_update(k, 5, backed2.pk1, 7, backed2.pk2)
-    WHERE rowid IN (SELECT rowid
-    FROM backed2
-    WHERE pk1 = 3 AND pk2 = 11);
+    SET k = cql_blob_update(k, 5, backed2.pk1, 7, backed2.pk2)
+      WHERE rowid IN (SELECT rowid
+      FROM backed2
+      WHERE pk1 = 3 AND pk2 = 11);
 END;
 */
 
@@ -17445,16 +17578,23 @@ CQL_WARN_UNUSED cql_code update_backed2(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
-  "SELECT rowid, bgetkey(T.k, 1), bgetkey(T.k, 0), bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, 4605090824299507084) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = 3942979045122214775",
+      "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 1), "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, 4605090824299507084) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = 3942979045122214775",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 1, 5, 0, 7) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed2 "
-      "WHERE pk1 = 3 AND pk2 = 11)"
+      "SET k = bupdatekey(k, 1, 5, 0, 7) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed2 "
+        "WHERE pk1 = 3 AND pk2 = 11)"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17471,7 +17611,7 @@ cql_cleanup:
 CREATE PROC use_generated_fragment ()
 BEGIN
   WITH
-  _backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    _backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM _backed;
 END;
@@ -17595,10 +17735,17 @@ CQL_WARN_UNUSED cql_code use_generated_fragment(sqlite3 *_Nonnull _db_, sqlite3_
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "_backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "_backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM _backed"
@@ -17619,7 +17766,7 @@ cql_cleanup:
 CREATE PROC use_backed_table_directly ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -17743,10 +17890,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly(sqlite3 *_Nonnull _db_, sqlit
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -17766,10 +17920,11 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_with_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
-  SELECT *
-    FROM backed;
+  DECLARE C CURSOR FOR
+    WITH
+      backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    SELECT *
+      FROM backed;
 END;
 */
 
@@ -17786,10 +17941,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_cursor(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_prepare_var(_db_, &C_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -17810,9 +17972,13 @@ cql_cleanup:
 CREATE PROC use_backed_table_directly_in_with_select ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  one (x) AS (SELECT 1 AS x),
-  two (x) AS (SELECT 2 AS x)
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+    one (x) AS (
+      SELECT 1 AS x
+    ),
+    two (x) AS (
+      SELECT 2 AS x
+    )
   SELECT *
     FROM backed;
 END;
@@ -17936,13 +18102,24 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select(sqlite3 *_Nonn
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "one (x) AS (SELECT 1), "
-    "two (x) AS (SELECT 2) "
+      "one (x) AS ( "
+        "SELECT 1 "
+      "), "
+      "two (x) AS ( "
+        "SELECT 2 "
+      ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
   );
@@ -17961,12 +18138,17 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_with_select_and_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  one (x) AS (SELECT 1 AS x),
-  two (x) AS (SELECT 2 AS x)
-  SELECT *
-    FROM backed;
+  DECLARE C CURSOR FOR
+    WITH
+      backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+      one (x) AS (
+        SELECT 1 AS x
+      ),
+      two (x) AS (
+        SELECT 2 AS x
+      )
+    SELECT *
+      FROM backed;
 END;
 */
 
@@ -17983,13 +18165,24 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_select_and_cursor(sqlite3 *_Nonnu
   _rc_ = cql_prepare_var(_db_, &C_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "one (x) AS (SELECT 1), "
-    "two (x) AS (SELECT 2) "
+      "one (x) AS ( "
+        "SELECT 1 "
+      "), "
+      "two (x) AS ( "
+        "SELECT 2 "
+      ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
   );
@@ -18008,8 +18201,8 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_select_expr (OUT x BOOL NOT NULL)
 BEGIN
-  SET x := ( WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+  SET x := (   WITH
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT flag
     FROM backed );
 END;
@@ -18031,10 +18224,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
   _rc_ = cql_prepare_var(_db_, &_temp_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT flag "
       "FROM backed"
@@ -18061,7 +18261,7 @@ CREATE PROC explain_query_plan_backed (OUT x BOOL NOT NULL)
 BEGIN
   EXPLAIN QUERY PLAN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -18082,10 +18282,17 @@ static CQL_WARN_UNUSED cql_code explain_query_plan_backed(sqlite3 *_Nonnull _db_
     3, NULL,
   "EXPLAIN QUERY PLAN "
     "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -18105,8 +18312,8 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_select_expr_value_offsets (OUT x BOOL NOT NULL)
 BEGIN
-  SET x := ( WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+  SET x := (   WITH
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT flag
     FROM backed );
 END;
@@ -18128,10 +18335,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
   _rc_ = cql_prepare_var(_db_, &_temp_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 0), bgetval(T.v, 1), bgetval(T.v, 2), bgetval(T.v, 3), bgetval(T.v, 4), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 0), "
+          "bgetval(T.v, 1), "
+          "bgetval(T.v, 2), "
+          "bgetval(T.v, 3), "
+          "bgetval(T.v, 4), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT flag "
       "FROM backed"
@@ -18156,9 +18370,12 @@ cql_cleanup:
 CREATE PROC insert_backed_values ()
 BEGIN
   WITH
-  _vals (pk, x, y) AS (VALUES(1, "2", 3.14), (4, "5", 6), (7, "8", 9.7))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    _vals (pk, x, y) AS (
+      VALUES(1, "2", 3.14), (4, "5", 6), (7, "8", 9.7)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18173,9 +18390,12 @@ CQL_WARN_UNUSED cql_code insert_backed_values(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk, x, y) AS (VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "_vals (pk, x, y) AS ( "
+        "VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18191,12 +18411,19 @@ cql_cleanup:
 CREATE PROC insert_backed_values_using_with ()
 BEGIN
   WITH
-  U (x, y, z) AS (VALUES(1, "2", 3.14)),
-  V (x, y, z) AS (VALUES(1, "2", 3.14)),
-  _vals (pk, x, y) AS (SELECT *
-    FROM V)
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    U (x, y, z) AS (
+      VALUES(1, "2", 3.14)
+    ),
+    V (x, y, z) AS (
+      VALUES(1, "2", 3.14)
+    ),
+    _vals (pk, x, y) AS (
+      SELECT *
+        FROM V
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18211,12 +18438,19 @@ CQL_WARN_UNUSED cql_code insert_backed_values_using_with(sqlite3 *_Nonnull _db_)
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "U (x, y, z) AS (VALUES(1, '2', 3.14)), "
-    "V (x, y, z) AS (VALUES(1, '2', 3.14)), "
-    "_vals (pk, x, y) AS (SELECT x, y, z "
-      "FROM V) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "U (x, y, z) AS ( "
+        "VALUES(1, '2', 3.14) "
+      "), "
+      "V (x, y, z) AS ( "
+        "VALUES(1, '2', 3.14) "
+      "), "
+      "_vals (pk, x, y) AS ( "
+        "SELECT x, y, z "
+          "FROM V "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18232,9 +18466,12 @@ cql_cleanup:
 CREATE PROC insert_backed_values_using_form ()
 BEGIN
   WITH
-  _vals (pk, x, y) AS (VALUES(1, "2", 3.14))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    _vals (pk, x, y) AS (
+      VALUES(1, "2", 3.14)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18249,9 +18486,12 @@ CQL_WARN_UNUSED cql_code insert_backed_values_using_form(sqlite3 *_Nonnull _db_)
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk, x, y) AS (VALUES(1, '2', 3.14)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "_vals (pk, x, y) AS ( "
+        "VALUES(1, '2', 3.14) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18267,11 +18507,14 @@ cql_cleanup:
 CREATE PROC inserted_backed_from_select ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
-  _vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50
-    FROM small_backed AS B)
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
+    _vals (pk, x, y) AS (
+      SELECT pk + 1000, B.x || 'x', B.y + 50
+        FROM small_backed AS B
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18287,15 +18530,22 @@ CQL_WARN_UNUSED cql_code inserted_backed_from_select(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0) AS pk, bgetval(T.v, 7953209610392031882) AS x, bgetval(T.v, 3032304244189539277) AS y "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0) AS pk, "
+          "bgetval(T.v, 7953209610392031882) AS x, "
+          "bgetval(T.v, 3032304244189539277) AS y "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   "), "
-    "_vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50 "
-      "FROM small_backed AS B) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V"
+      "_vals (pk, x, y) AS ( "
+        "SELECT pk + 1000, B.x || 'x', B.y + 50 "
+          "FROM small_backed AS B "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18312,7 +18562,7 @@ cql_cleanup:
 CREATE PROC delete_from_backed ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed())
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed())
   DELETE FROM backing WHERE rowid IN (SELECT rowid
     FROM small_backed
     WHERE pk = 12345);
@@ -18331,10 +18581,14 @@ CQL_WARN_UNUSED cql_code delete_from_backed(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0), bgetval(T.v, 7953209610392031882), bgetval(T.v, 3032304244189539277) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 7953209610392031882), "
+          "bgetval(T.v, 3032304244189539277) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   ") "
     "DELETE FROM backing WHERE rowid IN (SELECT rowid "
       "FROM small_backed "
@@ -18355,8 +18609,10 @@ cql_cleanup:
 CREATE PROC delete_from_backed_no_where_clause ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
-  v (x) AS (VALUES(1))
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
+    v (x) AS (
+      VALUES(1)
+    )
   DELETE FROM backing WHERE rowid IN (SELECT rowid
     FROM small_backed);
 END;
@@ -18374,12 +18630,18 @@ CQL_WARN_UNUSED cql_code delete_from_backed_no_where_clause(sqlite3 *_Nonnull _d
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0), bgetval(T.v, 7953209610392031882), bgetval(T.v, 3032304244189539277) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 7953209610392031882), "
+          "bgetval(T.v, 3032304244189539277) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   "), "
-    "v (x) AS (VALUES(1)) "
+      "v (x) AS ( "
+        "VALUES(1) "
+      ") "
     "DELETE FROM backing WHERE rowid IN (SELECT rowid "
       "FROM small_backed)"
   );
@@ -18452,12 +18714,12 @@ cql_cleanup:
 CREATE PROC update_backed_set_value ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET v = cql_blob_update(v, 'foo', backed.name)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'one');
+    SET v = cql_blob_update(v, 'foo', backed.name)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'one');
 END;
 */
 
@@ -18473,16 +18735,23 @@ CQL_WARN_UNUSED cql_code update_backed_set_value(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET v = bupdateval(v, -6946718245010482247, 'foo', 4) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'one')"
+      "SET v = bupdateval(v, -6946718245010482247, 'foo', 4) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'one')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18499,13 +18768,15 @@ cql_cleanup:
 CREATE PROC update_backed_with_clause ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  V (x) AS (VALUES(1))
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+    V (x) AS (
+      VALUES(1)
+    )
   UPDATE backing
-  SET v = cql_blob_update(v, 'goo', backed.name)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'with_update');
+    SET v = cql_blob_update(v, 'goo', backed.name)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'with_update');
 END;
 */
 
@@ -18521,17 +18792,26 @@ CQL_WARN_UNUSED cql_code update_backed_with_clause(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "V (x) AS (VALUES(1)) "
+      "V (x) AS ( "
+        "VALUES(1) "
+      ") "
     "UPDATE backing "
-    "SET v = bupdateval(v, -6946718245010482247, 'goo', 4) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'with_update')"
+      "SET v = bupdateval(v, -6946718245010482247, 'goo', 4) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'with_update')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18548,12 +18828,12 @@ cql_cleanup:
 CREATE PROC update_backed_set_key ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET k = cql_blob_update(k, 100, backed.pk)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'two');
+    SET k = cql_blob_update(k, 100, backed.pk)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'two');
 END;
 */
 
@@ -18569,16 +18849,23 @@ CQL_WARN_UNUSED cql_code update_backed_set_key(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 0, 100) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'two')"
+      "SET k = bupdatekey(k, 0, 100) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'two')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18595,15 +18882,14 @@ cql_cleanup:
 CREATE PROC update_backed_set_both ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET k = cql_blob_update(k, 100, backed.pk),
-  v = cql_blob_update(v, 77, backed.age)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'three'
-  ORDER BY age
-  LIMIT 7);
+    SET k = cql_blob_update(k, 100, backed.pk), v = cql_blob_update(v, 77, backed.age)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'three'
+    ORDER BY age
+    LIMIT 7);
 END;
 */
 
@@ -18619,19 +18905,25 @@ CQL_WARN_UNUSED cql_code update_backed_set_both(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 0, 100), "
-    "v = bupdateval(v, -3683705396192132539, 77, 3) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'three' "
-    "ORDER BY age "
-    "LIMIT 7)"
+      "SET k = bupdatekey(k, 0, 100), v = bupdateval(v, -3683705396192132539, 77, 3) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'three' "
+      "ORDER BY age "
+      "LIMIT 7)"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18654,7 +18946,7 @@ BEGIN
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 */
 
@@ -18691,7 +18983,7 @@ CQL_WARN_UNUSED cql_code stmt_in_loop(sqlite3 *_Nonnull _db_) {
   }
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT 1 "
-      "FROM foo)");
+        "FROM foo)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -18715,14 +19007,15 @@ BEGIN
   LET i := 0;
   WHILE i < 10
   BEGIN
-    DECLARE C CURSOR FOR SELECT *
-      FROM foo
-      WHERE id = i;
+    DECLARE C CURSOR FOR
+      SELECT *
+        FROM foo
+        WHERE id = i;
     FETCH C;
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 */
 
@@ -18767,7 +19060,7 @@ CQL_WARN_UNUSED cql_code cursor_in_loop(sqlite3 *_Nonnull _db_) {
   }
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT 1 "
-      "FROM foo)");
+        "FROM foo)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -19095,8 +19388,9 @@ cql_cleanup:
 /*
 CREATE PROC qid_t1 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM `xyz``abc`;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM `xyz``abc`;
   LOOP FETCH C
   BEGIN
     CALL printf("%d %d", C.x, C.`a b`);
@@ -19151,8 +19445,9 @@ cql_cleanup:
 /*
 CREATE PROC qid_t2 ()
 BEGIN
-  DECLARE D CURSOR FOR SELECT `xyz``abc`.*
-    FROM `xyz``abc`;
+  DECLARE D CURSOR FOR
+    SELECT `xyz``abc`.*
+      FROM `xyz``abc`;
   LOOP FETCH D
   BEGIN
     CALL printf("%d %d", D.x, D.`a b`);
@@ -20009,9 +20304,10 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE foo_cursor CURSOR FOR SELECT id, i2
-    FROM foo
-    WHERE id = i0_nullable;
+  DECLARE foo_cursor CURSOR FOR
+    SELECT id, i2
+      FROM foo
+      WHERE id = i0_nullable;
   */
   _rc_ = cql_prepare(_db_, &foo_cursor_stmt,
     "SELECT id, ? "
@@ -20037,7 +20333,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE basic_cursor CURSOR FOR SELECT 1, 2.5;
+  DECLARE basic_cursor CURSOR FOR
+    SELECT 1, 2.5;
   */
   _rc_ = cql_prepare(_db_, &basic_cursor_stmt,
     "SELECT 1, 2.5");
@@ -20079,7 +20376,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE exchange_cursor CURSOR FOR SELECT arg2, arg1;
+  DECLARE exchange_cursor CURSOR FOR
+    SELECT arg2, arg1;
   */
   _rc_ = cql_prepare(_db_, &exchange_cursor_stmt,
     "SELECT ?, ?");
@@ -20706,10 +21004,12 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5);
+  INSERT OR REPLACE INTO bar(id, type)
+    VALUES(1, 5);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5)");
+    "INSERT OR REPLACE INTO bar(id, type) "
+      "VALUES(1, 5)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -20725,11 +21025,11 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   SET b2 := ( SELECT EXISTS (SELECT *
-    FROM bar) );
+      FROM bar) );
   */
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT * "
-      "FROM bar)");
+        "FROM bar)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -20739,8 +21039,9 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE expanded_select CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE expanded_select CURSOR FOR
+    SELECT *
+      FROM bar;
   */
   _rc_ = cql_prepare(_db_, &expanded_select_stmt,
     "SELECT id, name, rate, type, size "
@@ -20750,8 +21051,9 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE table_expanded_select CURSOR FOR SELECT bar.*
-    FROM bar;
+  DECLARE table_expanded_select CURSOR FOR
+    SELECT bar.*
+      FROM bar;
   */
   _rc_ = cql_prepare(_db_, &table_expanded_select_stmt,
     "SELECT bar.id, bar.name, bar.rate, bar.type, bar.size "
@@ -21000,10 +21302,12 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
+  INSERT INTO blob_table(blob_id, b_nullable, b_notnull)
+    VALUES(0, blob_var, blob_var_notnull);
   */
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)");
+    "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) "
+      "VALUES(0, ?, ?)");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
                 CQL_DATA_TYPE_BLOB, blob_var,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
@@ -21055,15 +21359,21 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) VALUES(ifnull(( SELECT a
-    FROM x ), 0));
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    VALUES(ifnull(( SELECT a
+      FROM x ), 0));
   */
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
-    "INSERT INTO foo(id) VALUES(ifnull(( SELECT a "
-      "FROM x ), 0))");
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
+    "INSERT INTO foo(id) "
+      "VALUES(ifnull(( SELECT a "
+        "FROM x ), 0))");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -21082,7 +21392,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE global_cursor CURSOR FOR SELECT 1 AS a, 2 AS b;
+  DECLARE global_cursor CURSOR FOR
+    SELECT 1 AS a, 2 AS b;
   */
   _rc_ = cql_prepare(_db_, &global_cursor_stmt,
     "SELECT 1, 2");
@@ -21202,14 +21513,18 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   WITH
-  some_cte (id) AS (SELECT 1 AS id)
+    some_cte (id) AS (
+      SELECT 1 AS id
+    )
   INSERT INTO bar(id) VALUES(ifnull(( SELECT id
     FROM some_cte ), 0)) @DUMMY_SEED(1337);
   */
   _seed_ = 1337;
   _rc_ = cql_exec(_db_,
     "WITH "
-    "some_cte (id) AS (SELECT 1 AS id) "
+      "some_cte (id) AS ( "
+        "SELECT 1 AS id "
+      ") "
     "INSERT INTO bar(id) VALUES(ifnull(( SELECT id "
       "FROM some_cte ), 0))");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -21219,13 +21534,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   INSERT INTO bar(id) VALUES(1) @DUMMY_SEED(1338)
   ON CONFLICT (id) DO UPDATE
-  SET id = 10;
+    SET id = 10;
   */
   _seed_ = 1338;
   _rc_ = cql_exec(_db_,
     "INSERT INTO bar(id) VALUES(1) "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10");
+      "SET id = 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -21485,19 +21800,23 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO virtual_with_hidden(vy) VALUES(1);
+  INSERT INTO virtual_with_hidden(vy)
+    VALUES(1);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT INTO virtual_with_hidden(vy) VALUES(1)");
+    "INSERT INTO virtual_with_hidden(vy) "
+      "VALUES(1)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2);
+  INSERT INTO virtual_with_hidden(vx, vy)
+    VALUES(1, 2);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2)");
+    "INSERT INTO virtual_with_hidden(vx, vy) "
+      "VALUES(1, 2)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -1565,7 +1565,7 @@ DECLARE PROC plugh (id INTEGER);
 /*
 CREATE PROC complex_return ()
 BEGIN
-  SELECT 
+  SELECT
       TRUE AS _bool,
       2 AS _integer,
       CAST(3 AS LONG_INT) AS _longint,
@@ -1678,7 +1678,7 @@ CQL_WARN_UNUSED cql_code complex_return(sqlite3 *_Nonnull _db_, sqlite3_stmt *_N
   cql_error_prepare();
 
   _rc_ = cql_prepare(_db_, _result_stmt,
-    "SELECT  "
+    "SELECT "
         "1, "
         "2, "
         "CAST(3 AS LONG_INT), "
@@ -8232,7 +8232,7 @@ CQL_WARN_UNUSED cql_code pretty_print_with_quote(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "INSERT INTO bar(id, name) "
-      "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
+      "VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -17426,7 +17426,7 @@ cql_cleanup:
 CREATE PROC use_cql_blob_get_backed ()
 BEGIN
   DECLARE C CURSOR FOR
-    SELECT 
+    SELECT
         cql_blob_get(k, backed.pk),
         cql_blob_get(v, backed.flag),
         cql_blob_get(v, backed.storage),
@@ -17448,7 +17448,7 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT  "
+    "SELECT "
         "bgetkey(k, 0), "
         "bgetval(v, 1055660242183705531), "
         "bgetval(v, -7635294210585028660), "
@@ -17472,7 +17472,7 @@ cql_cleanup:
 CREATE PROC use_cql_blob_get_backed2 ()
 BEGIN
   DECLARE C CURSOR FOR
-    SELECT 
+    SELECT
         cql_blob_get(k, backed2.pk1),
         cql_blob_get(k, backed2.pk2),
         cql_blob_get(v, backed2.id),
@@ -17493,7 +17493,7 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed2(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT  "
+    "SELECT "
         "bgetkey(k, 1), "
         "bgetkey(k, 0), "
         "bgetval(v, -9155171551243524439), "
@@ -17579,7 +17579,7 @@ CQL_WARN_UNUSED cql_code update_backed2(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 1), "
           "bgetkey(T.k, 0), "
@@ -17736,7 +17736,7 @@ CQL_WARN_UNUSED cql_code use_generated_fragment(sqlite3 *_Nonnull _db_, sqlite3_
     3, NULL,
   "WITH "
       "_backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -17891,7 +17891,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly(sqlite3 *_Nonnull _db_, sqlit
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -17942,7 +17942,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_cursor(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18103,7 +18103,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select(sqlite3 *_Nonn
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18166,7 +18166,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_select_and_cursor(sqlite3 *_Nonnu
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18225,7 +18225,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18283,7 +18283,7 @@ static CQL_WARN_UNUSED cql_code explain_query_plan_backed(sqlite3 *_Nonnull _db_
   "EXPLAIN QUERY PLAN "
     "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18336,7 +18336,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 0), "
           "bgetval(T.v, 1), "
@@ -18531,7 +18531,7 @@ CQL_WARN_UNUSED cql_code inserted_backed_from_select(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0) AS pk, "
           "bgetval(T.v, 7953209610392031882) AS x, "
@@ -18582,7 +18582,7 @@ CQL_WARN_UNUSED cql_code delete_from_backed(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0), "
           "bgetval(T.v, 7953209610392031882), "
@@ -18631,7 +18631,7 @@ CQL_WARN_UNUSED cql_code delete_from_backed_no_where_clause(sqlite3 *_Nonnull _d
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0), "
           "bgetval(T.v, 7953209610392031882), "
@@ -18736,7 +18736,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_value(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18793,7 +18793,7 @@ CQL_WARN_UNUSED cql_code update_backed_with_clause(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18850,7 +18850,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_key(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18906,7 +18906,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_both(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -1357,13 +1357,15 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC easy_fetch ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   FETCH C;
   CALL printf("%d %s\n", C.id, C.name);
-  DECLARE C2 CURSOR FOR SELECT *
-    FROM bar
-    WHERE C AND id = C.id;
+  DECLARE C2 CURSOR FOR
+    SELECT *
+      FROM bar
+      WHERE C AND id = C.id;
 END;
 */
 
@@ -1524,7 +1526,8 @@ DECLARE PROC xyzzy (id INTEGER) (A INTEGER NOT NULL);
 /*
 CREATE PROC xyzzy_test ()
 BEGIN
-  DECLARE xyzzy_cursor CURSOR FOR CALL xyzzy(1);
+  DECLARE xyzzy_cursor CURSOR FOR
+    CALL xyzzy(1);
 END;
 */
 
@@ -1562,7 +1565,13 @@ DECLARE PROC plugh (id INTEGER);
 /*
 CREATE PROC complex_return ()
 BEGIN
-  SELECT TRUE AS _bool, 2 AS _integer, CAST(3 AS LONG_INT) AS _longint, 3.0 AS _real, 'xyz' AS _text, CAST(NULL AS BOOL) AS _nullable_bool;
+  SELECT 
+      TRUE AS _bool,
+      2 AS _integer,
+      CAST(3 AS LONG_INT) AS _longint,
+      3.0 AS _real,
+      'xyz' AS _text,
+      CAST(NULL AS BOOL) AS _nullable_bool;
 END;
 */
 
@@ -1669,7 +1678,13 @@ CQL_WARN_UNUSED cql_code complex_return(sqlite3 *_Nonnull _db_, sqlite3_stmt *_N
   cql_error_prepare();
 
   _rc_ = cql_prepare(_db_, _result_stmt,
-    "SELECT 1, 2, CAST(3 AS LONG_INT), 3.0, 'xyz', NULL");
+    "SELECT  "
+        "1, "
+        "2, "
+        "CAST(3 AS LONG_INT), "
+        "3.0, "
+        "'xyz', "
+        "NULL");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -2113,10 +2128,13 @@ cql_cleanup:
 /*
 CREATE PROC with_stmt_using_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
-  SELECT *
-    FROM X;
+  DECLARE C CURSOR FOR
+    WITH
+      X (a, b, c) AS (
+        SELECT 1, 2, 3
+      )
+    SELECT *
+      FROM X;
   FETCH C;
 END;
 */
@@ -2143,7 +2161,9 @@ CQL_WARN_UNUSED cql_code with_stmt_using_cursor(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_prepare(_db_, &C_stmt,
     "WITH "
-    "X (a, b, c) AS (SELECT 1, 2, 3) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2169,7 +2189,9 @@ cql_cleanup:
 CREATE PROC with_stmt ()
 BEGIN
   WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+    )
   SELECT *
     FROM X;
 END;
@@ -2246,7 +2268,9 @@ CQL_WARN_UNUSED cql_code with_stmt(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullab
 
   _rc_ = cql_prepare(_db_, _result_stmt,
     "WITH "
-    "X (a, b, c) AS (SELECT 1, 2, 3) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2265,9 +2289,11 @@ cql_cleanup:
 CREATE PROC with_recursive_stmt ()
 BEGIN
   WITH RECURSIVE
-  X (a, b, c) AS (SELECT 1, 2, 3
-  UNION ALL
-  SELECT 4, 5, 6)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+      UNION ALL
+      SELECT 4, 5, 6
+    )
   SELECT *
     FROM X;
 END;
@@ -2344,9 +2370,11 @@ CQL_WARN_UNUSED cql_code with_recursive_stmt(sqlite3 *_Nonnull _db_, sqlite3_stm
 
   _rc_ = cql_prepare(_db_, _result_stmt,
     "WITH RECURSIVE "
-    "X (a, b, c) AS (SELECT 1, 2, 3 "
-    "UNION ALL "
-    "SELECT 4, 5, 6) "
+      "X (a, b, c) AS ( "
+        "SELECT 1, 2, 3 "
+        "UNION ALL "
+        "SELECT 4, 5, 6 "
+      ") "
     "SELECT a, b, c "
       "FROM X");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -2544,7 +2572,8 @@ cql_cleanup:
 /*
 CREATE PROC outint_nullable (OUT output INTEGER, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -2589,7 +2618,8 @@ cql_cleanup:
 /*
 CREATE PROC outint_notnull (OUT output INTEGER NOT NULL, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -2832,7 +2862,8 @@ void echo_test(void) {
 /*
 CREATE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER)
 BEGIN
-  INSERT INTO bar(id, type) VALUES(id_, type_);
+  INSERT INTO bar(id, type)
+    VALUES(id_, type_);
 END;
 */
 
@@ -2847,7 +2878,8 @@ CQL_WARN_UNUSED cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cq
   sqlite3_stmt *_temp_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO bar(id, type) VALUES(?, ?)");
+    "INSERT INTO bar(id, type) "
+      "VALUES(?, ?)");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_,
                 CQL_DATA_TYPE_INT32, &type_);
@@ -3085,11 +3117,13 @@ cql_cleanup:
 /*
 CREATE PROC misc_dml_proc ()
 BEGIN
-  INSERT INTO foo(id) VALUES(NULL);
-  INSERT INTO foo(id) VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
   UPDATE bar
-  SET name = 'bar'
-    WHERE name = 'baz';
+    SET name = 'bar'
+      WHERE name = 'baz';
   DELETE FROM foo WHERE id = 1;
 END;
 */
@@ -3104,15 +3138,17 @@ CQL_WARN_UNUSED cql_code misc_dml_proc(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) VALUES(NULL)");
+    "INSERT INTO foo(id) "
+      "VALUES(NULL)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) VALUES(NULL)");
+    "INSERT INTO foo(id) "
+      "VALUES(NULL)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
     "UPDATE bar "
-    "SET name = 'bar' "
-      "WHERE name = 'baz'");
+      "SET name = 'bar' "
+        "WHERE name = 'baz'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = cql_exec(_db_,
     "DELETE FROM foo WHERE id = 1");
@@ -3389,8 +3425,9 @@ void voidproc(void) {
 /*
 CREATE PROC out_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
+      FROM bar;
   FETCH C;
   OUT C;
 END;
@@ -3713,7 +3750,7 @@ CREATE PROC thread_theme_info_list (thread_key_ LONG_INT NOT NULL)
 BEGIN
   SELECT *
     FROM (SELECT thread_key
-    FROM threads) AS T;
+        FROM threads) AS T;
 END;
 */
 
@@ -3773,7 +3810,7 @@ CQL_WARN_UNUSED cql_code thread_theme_info_list(sqlite3 *_Nonnull _db_, sqlite3_
   _rc_ = cql_prepare(_db_, _result_stmt,
     "SELECT thread_key "
       "FROM (SELECT thread_key "
-      "FROM threads) AS T");
+          "FROM threads) AS T");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -3930,7 +3967,8 @@ void c_literal(cql_string_ref _Nullable *_Nonnull x) {
 CREATE PROC no_cleanup_label_needed_proc ()
 BEGIN
   BEGIN TRY
-    DECLARE C CURSOR FOR SELECT 1 AS N;
+    DECLARE C CURSOR FOR
+      SELECT 1 AS N;
     FETCH C;
   END TRY;
   BEGIN CATCH
@@ -4686,9 +4724,12 @@ void blob_no_else(void) {
 CREATE PROC with_inserter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) SELECT *
-    FROM x;
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    SELECT *
+      FROM x;
 END;
 */
 
@@ -4703,9 +4744,12 @@ CQL_WARN_UNUSED cql_code with_inserter(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
-    "INSERT INTO foo(id) SELECT a "
-      "FROM x");
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
+    "INSERT INTO foo(id) "
+      "SELECT a "
+        "FROM x");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -4873,7 +4917,8 @@ void fetch_to_cursor_from_cursor(fetch_to_cursor_from_cursor_row *_Nonnull _resu
 /*
 CREATE PROC loop_statement_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.A);
@@ -4925,7 +4970,8 @@ cql_cleanup:
 /*
 CREATE PROC loop_statement_not_auto_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   DECLARE A_ INTEGER NOT NULL;
   LOOP FETCH C INTO A_
   BEGIN
@@ -5009,7 +5055,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -5066,7 +5113,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -5125,7 +5173,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     DECLARE box OBJECT<C CURSOR>;
     SET box FROM CURSOR C;
     DECLARE D CURSOR FOR box;
@@ -5259,7 +5308,8 @@ void out_union_helper_fetch_results(out_union_helper_result_set_ref _Nullable *_
 /*
 CREATE PROC out_union_dml_helper ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   OUT UNION C;
 END;
@@ -5348,7 +5398,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL out_union_helper();
+    DECLARE C CURSOR FOR
+      CALL out_union_helper();
     FETCH C;
   END;
 END;
@@ -5986,7 +6037,8 @@ cql_cleanup:
 @ATTRIBUTE(cql:identity=(id))
 CREATE PROC out_cursor_identity ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 2 AS data;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 2 AS data;
   FETCH C;
   OUT C;
 END;
@@ -6183,7 +6235,9 @@ cql_cleanup:
 CREATE PROC with_deleter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   DELETE FROM foo WHERE id IN (SELECT *
     FROM x);
 END;
@@ -6200,7 +6254,9 @@ CQL_WARN_UNUSED cql_code with_deleter(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
     "DELETE FROM foo WHERE id IN (SELECT a "
       "FROM x)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -6218,11 +6274,13 @@ cql_cleanup:
 CREATE PROC with_updater ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   UPDATE bar
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 */
 
@@ -6237,11 +6295,13 @@ CQL_WARN_UNUSED cql_code with_updater(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
     "UPDATE bar "
-    "SET name = 'xyzzy' "
-      "WHERE id IN (SELECT a "
-      "FROM x)");
+      "SET name = 'xyzzy' "
+        "WHERE id IN (SELECT a "
+        "FROM x)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6530,12 +6590,13 @@ cql_cleanup:
 /*
 CREATE PROC settings_info ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
-    FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
-    FROM unread_pending_threads AS P
-  UNION ALL
-  SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
-    FROM switch_account_badges AS S) AS A;
+  DECLARE C CURSOR FOR
+    SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
+      FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
+          FROM unread_pending_threads AS P
+        UNION ALL
+        SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
+          FROM switch_account_badges AS S) AS A;
 END;
 */
 
@@ -6552,10 +6613,10 @@ CQL_WARN_UNUSED cql_code settings_info(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_prepare(_db_, &C_stmt,
     "SELECT SUM(A.unread_pending_thread_count), SUM(A.switch_account_badge_count) "
       "FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count "
-      "FROM unread_pending_threads AS P "
-    "UNION ALL "
-    "SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count "
-      "FROM switch_account_badges AS S) AS A");
+          "FROM unread_pending_threads AS P "
+        "UNION ALL "
+        "SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count "
+          "FROM switch_account_badges AS S) AS A");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6750,8 +6811,10 @@ cql_cleanup:
 CREATE PROC use_with_select ()
 BEGIN
   DECLARE x INTEGER;
-  SET x := ( WITH
-  threads2 (count) AS (SELECT 1 AS foo)
+  SET x := (   WITH
+    threads2 (count) AS (
+      SELECT 1 AS foo
+    )
   SELECT COUNT(*)
     FROM threads2 );
 END;
@@ -6771,7 +6834,9 @@ CQL_WARN_UNUSED cql_code use_with_select(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "WITH "
-    "threads2 (count) AS (SELECT 1) "
+      "threads2 (count) AS ( "
+        "SELECT 1 "
+      ") "
     "SELECT COUNT(*) "
       "FROM threads2");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -6794,8 +6859,9 @@ cql_cleanup:
 /*
 CREATE PROC rowset_object_reader (rowset OBJECT<rowset>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM ReadFromRowset(rowset);
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM ReadFromRowset(rowset);
 END;
 */
 
@@ -6829,12 +6895,13 @@ cql_cleanup:
 /*
 CREATE PROC upsert_do_something ()
 BEGIN
-  INSERT INTO foo(id) SELECT id
-    FROM bar
-    WHERE 1
+  INSERT INTO foo(id)
+    SELECT id
+      FROM bar
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 */
 
@@ -6848,12 +6915,13 @@ CQL_WARN_UNUSED cql_code upsert_do_something(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO foo(id) SELECT id "
-      "FROM bar "
-      "WHERE 1 "
+    "INSERT INTO foo(id) "
+      "SELECT id "
+        "FROM bar "
+        "WHERE 1 "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10 "
-      "WHERE id <> 10");
+      "SET id = 10 "
+        "WHERE id <> 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6869,13 +6937,16 @@ cql_cleanup:
 CREATE PROC with_upsert_form ()
 BEGIN
   WITH
-  names (id) AS (VALUES(1), (5), (3), (12))
-  INSERT INTO foo(id) SELECT id
-    FROM names
-    WHERE 1
+    names (id) AS (
+      VALUES(1), (5), (3), (12)
+    )
+  INSERT INTO foo(id)
+    SELECT id
+      FROM names
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 */
 
@@ -6890,13 +6961,16 @@ CQL_WARN_UNUSED cql_code with_upsert_form(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "names (id) AS (VALUES(1), (5), (3), (12)) "
-    "INSERT INTO foo(id) SELECT id "
-      "FROM names "
-      "WHERE 1 "
+      "names (id) AS ( "
+        "VALUES(1), (5), (3), (12) "
+      ") "
+    "INSERT INTO foo(id) "
+      "SELECT id "
+        "FROM names "
+        "WHERE 1 "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10 "
-      "WHERE id <> 10");
+      "SET id = 10 "
+        "WHERE id <> 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -6911,7 +6985,8 @@ cql_cleanup:
 /*
 CREATE PROC upsert_do_nothing (id_ INTEGER NOT NULL)
 BEGIN
-  INSERT INTO foo(id) VALUES(id_)
+  INSERT INTO foo(id)
+    VALUES(id_)
   ON CONFLICT DO NOTHING;
 END;
 */
@@ -6927,7 +7002,8 @@ CQL_WARN_UNUSED cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_
   sqlite3_stmt *_temp_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO foo(id) VALUES(?) "
+    "INSERT INTO foo(id) "
+      "VALUES(?) "
     "ON CONFLICT DO NOTHING");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_);
@@ -7171,7 +7247,8 @@ void out_union_two_fetch_results(out_union_two_result_set_ref _Nullable *_Nonnul
 /*
 CREATE PROC out_union_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_two();
+  DECLARE c CURSOR FOR
+    CALL out_union_two();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -7230,7 +7307,8 @@ CQL_WARN_UNUSED cql_code out_union_reader(sqlite3 *_Nonnull _db_) {
 /*
 CREATE PROC out_union_from_select ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x, '2' AS y;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x, '2' AS y;
   FETCH C;
   OUT UNION C;
   OUT UNION C;
@@ -7335,7 +7413,8 @@ cql_cleanup:
 /*
 CREATE PROC out_union_dml_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_from_select();
+  DECLARE c CURSOR FOR
+    CALL out_union_from_select();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -7473,7 +7552,8 @@ void out_union_values_fetch_results(out_union_values_result_set_ref _Nullable *_
 /*
 CREATE PROC read_out_union_values (a INTEGER NOT NULL, b INTEGER NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_values(a, b);
+  DECLARE C CURSOR FOR
+    CALL out_union_values(a, b);
   FETCH C;
 END;
 */
@@ -7521,8 +7601,9 @@ CQL_WARN_UNUSED cql_code read_out_union_values(sqlite3 *_Nonnull _db_, cql_int32
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml ()
 BEGIN
-  DECLARE x CURSOR FOR SELECT *
-    FROM radioactive;
+  DECLARE x CURSOR FOR
+    SELECT *
+      FROM radioactive;
   FETCH x;
   OUT UNION x;
 END;
@@ -7630,7 +7711,8 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml_for_call ()
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_dml();
+  DECLARE C CURSOR FOR
+    CALL out_union_dml();
   FETCH C;
 END;
 */
@@ -8009,7 +8091,8 @@ BEGIN
   WHILE 1
   BEGIN
   END;
-  DECLARE c CURSOR FOR SELECT 1 AS x;
+  DECLARE c CURSOR FOR
+    SELECT 1 AS x;
   LOOP FETCH c
   BEGIN
   END;
@@ -8133,7 +8216,8 @@ CQL_WARN_UNUSED cql_code tail_catch(sqlite3 *_Nonnull _db_) {
 /*
 CREATE PROC pretty_print_with_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "it's high noon\r\n\f\b\t\v");
+  INSERT INTO bar(id, name)
+    VALUES(1, "it's high noon\r\n\f\b\t\v");
 END;
 */
 
@@ -8147,7 +8231,8 @@ CQL_WARN_UNUSED cql_code pretty_print_with_quote(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO bar(id, name) VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
+    "INSERT INTO bar(id, name) "
+      "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -8162,7 +8247,8 @@ cql_cleanup:
 /*
 CREATE PROC hex_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "\x01\x02\xa1\x1bg");
+  INSERT INTO bar(id, name)
+    VALUES(1, "\x01\x02\xa1\x1bg");
 END;
 */
 
@@ -8176,7 +8262,8 @@ CQL_WARN_UNUSED cql_code hex_quote(sqlite3 *_Nonnull _db_) {
   cql_error_prepare();
 
   _rc_ = cql_exec(_db_,
-    "INSERT INTO bar(id, name) VALUES(1, '\x01\x02\xa1\x1bg')");
+    "INSERT INTO bar(id, name) "
+      "VALUES(1, '\x01\x02\xa1\x1bg')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -9016,7 +9103,8 @@ cql_cleanup:
 /*
 CREATE PROC early_out_rc_cleared (OUT x INTEGER)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   IF C THEN
     RETURN;
@@ -9701,8 +9789,9 @@ cql_cleanup:
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC vault_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT name
-    FROM vault_mixed_sensitive;
+  DECLARE C CURSOR FOR
+    SELECT name
+      FROM vault_mixed_sensitive;
   FETCH c;
 END;
 */
@@ -10093,8 +10182,9 @@ cql_cleanup:
 /*
 CREATE PROC try_boxing (OUT result OBJECT<bar CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET result FROM CURSOR C;
 END;
 */
@@ -13119,7 +13209,8 @@ void c_proc_with_alt_prefix(cql_nullable_int32 *_Nonnull x) {
 /*
 CREATE PROC use_private_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL private_out_union();
+  DECLARE C CURSOR FOR
+    CALL private_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13235,7 +13326,8 @@ void no_getters_out_union_fetch_results(no_getters_out_union_result_set_ref _Nul
 /*
 CREATE PROC use_no_getters_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL no_getters_out_union();
+  DECLARE C CURSOR FOR
+    CALL no_getters_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13351,7 +13443,8 @@ void suppress_results_out_union_fetch_results(suppress_results_out_union_result_
 /*
 CREATE PROC use_suppress_results_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL suppress_results_out_union();
+  DECLARE C CURSOR FOR
+    CALL suppress_results_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -13595,8 +13688,9 @@ void various_lets(void) {
 /*
 CREATE PROC try_catch_rc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 'foo' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT 'foo' AS extra2
+      FROM bar;
   BEGIN TRY
     FETCH C;
   END TRY;
@@ -14423,8 +14517,9 @@ cql_bool false_test = 0;
 /*
 CREATE PROC BigFormat ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM big_data;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM big_data;
   LOOP FETCH C
   BEGIN
     LET s := cql_cursor_format(C);
@@ -15374,7 +15469,7 @@ END;
 CREATE PROC foo ()
 BEGIN
   WITH
-  shared_frag (shared_something) AS (CALL shared_frag())
+    shared_frag (shared_something) AS (CALL shared_frag())
   SELECT *
     FROM shared_frag;
 END;
@@ -15436,7 +15531,7 @@ CQL_WARN_UNUSED cql_code foo(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_N
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "shared_frag (shared_something) AS (",
+      "shared_frag (shared_something) AS (",
   "SELECT 1234",
   ") "
     "SELECT shared_something "
@@ -15474,8 +15569,10 @@ END;
 CREATE PROC shared_conditional_user (x INTEGER NOT NULL)
 BEGIN
   WITH
-  some_cte (id) AS (SELECT x),
-  shared_conditional (x) AS (CALL shared_conditional(1))
+    some_cte (id) AS (
+      SELECT x
+    ),
+    shared_conditional (x) AS (CALL shared_conditional(1))
   SELECT bar.*
     FROM bar
     INNER JOIN some_cte ON x = 5;
@@ -15616,8 +15713,10 @@ CQL_WARN_UNUSED cql_code shared_conditional_user(sqlite3 *_Nonnull _db_, sqlite3
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     5, _preds_1,
   "WITH "
-    "some_cte (id) AS (SELECT ?), "
-    "shared_conditional (x) AS (",
+      "some_cte (id) AS ( "
+        "SELECT ? "
+      "), "
+      "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
@@ -15653,7 +15752,7 @@ CREATE PROC nested_shared_proc (x_ INTEGER NOT NULL)
 BEGIN
   IF x_ <= 5 THEN
     WITH
-    shared_conditional (x) AS (CALL shared_conditional(1))
+      shared_conditional (x) AS (CALL shared_conditional(1))
     SELECT *
       FROM shared_conditional
       WHERE x_ = 5;
@@ -15669,7 +15768,7 @@ END;
 CREATE PROC nested_shared_stuff ()
 BEGIN
   WITH
-  nested_shared_proc (x) AS (CALL nested_shared_proc(1))
+    nested_shared_proc (x) AS (CALL nested_shared_proc(1))
   SELECT *
     FROM nested_shared_proc;
 END;
@@ -15767,16 +15866,16 @@ CQL_WARN_UNUSED cql_code nested_shared_stuff(sqlite3 *_Nonnull _db_, sqlite3_stm
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     8, _preds_1,
   "WITH "
-    "nested_shared_proc (x) AS (",
-  "WITH "
-    "shared_conditional (x) AS (",
+      "nested_shared_proc (x) AS (",
+  "  WITH "
+        "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
   ") "
-    "SELECT x "
-      "FROM shared_conditional "
-      "WHERE ? = 5",
+      "SELECT x "
+        "FROM shared_conditional "
+        "WHERE ? = 5",
   "SELECT ?",
   ") "
     "SELECT x "
@@ -15907,15 +16006,15 @@ CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form(sqlite3 *_Nonnull _d
   "SELECT x "
       "FROM (",
   "(",
-  "WITH "
-    "shared_conditional (x) AS (",
+  "  WITH "
+        "shared_conditional (x) AS (",
   "SELECT ?",
   "SELECT ? + ?",
   "SELECT ? + ? + ?",
   ") "
-    "SELECT x "
-      "FROM shared_conditional "
-      "WHERE ? = 5",
+      "SELECT x "
+        "FROM shared_conditional "
+        "WHERE ? = 5",
   "SELECT ? AS x",
   ")",
   ")"
@@ -15999,7 +16098,7 @@ END;
 CREATE PROC shared_frag_else_nothing_test ()
 BEGIN
   WITH
-  shared_frag_else_nothing (id1, text1) AS (CALL shared_frag_else_nothing(5))
+    shared_frag_else_nothing (id1, text1) AS (CALL shared_frag_else_nothing(5))
   SELECT *
     FROM foo;
 END;
@@ -16078,7 +16177,7 @@ CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test(sqlite3 *_Nonnull _db_, s
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     4, _preds_1,
   "WITH "
-    "shared_frag_else_nothing (id1, text1) AS (",
+      "shared_frag_else_nothing (id1, text1) AS (",
   "SELECT ?, 'x'",
   "SELECT 0,0 WHERE 0",
   ") "
@@ -16246,7 +16345,8 @@ void slash_star_and_star_slash(void) {
 /*
 CREATE PROC blob_serialization_test ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'foo' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'foo' AS name;
   FETCH C;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
@@ -16570,7 +16670,8 @@ DECLARE PROC some_redeclared_out_proc () OUT (x INTEGER) USING TRANSACTION;
 /*
 CREATE PROC some_redeclared_out_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT c;
 END;
@@ -16675,7 +16776,8 @@ DECLARE PROC some_redeclared_out_union_proc () OUT UNION (x INTEGER) USING TRANS
 /*
 CREATE PROC some_redeclared_out_union_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT UNION c;
 END;
@@ -16908,7 +17010,8 @@ void mutated_in_arg2(cql_string_ref _Nullable _in__x) {
 /*
 CREATE PROC mutated_in_arg3 (x TEXT)
 BEGIN
-  DECLARE C CURSOR FOR SELECT "x" AS x;
+  DECLARE C CURSOR FOR
+    SELECT "x" AS x;
   FETCH C INTO x;
 END;
 */
@@ -17322,8 +17425,15 @@ cql_cleanup:
 /*
 CREATE PROC use_cql_blob_get_backed ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT cql_blob_get(k, backed.pk), cql_blob_get(v, backed.flag), cql_blob_get(v, backed.storage), cql_blob_get(v, backed.id), cql_blob_get(v, backed.name), cql_blob_get(v, backed.age)
-    FROM backing;
+  DECLARE C CURSOR FOR
+    SELECT 
+        cql_blob_get(k, backed.pk),
+        cql_blob_get(v, backed.flag),
+        cql_blob_get(v, backed.storage),
+        cql_blob_get(v, backed.id),
+        cql_blob_get(v, backed.name),
+        cql_blob_get(v, backed.age)
+      FROM backing;
 END;
 */
 
@@ -17338,7 +17448,13 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT bgetkey(k, 0), bgetval(v, 1055660242183705531), bgetval(v, -7635294210585028660), bgetval(v, -9155171551243524439), bgetval(v, -6946718245010482247), bgetval(v, -3683705396192132539) "
+    "SELECT  "
+        "bgetkey(k, 0), "
+        "bgetval(v, 1055660242183705531), "
+        "bgetval(v, -7635294210585028660), "
+        "bgetval(v, -9155171551243524439), "
+        "bgetval(v, -6946718245010482247), "
+        "bgetval(v, -3683705396192132539) "
       "FROM backing");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17355,8 +17471,14 @@ cql_cleanup:
 /*
 CREATE PROC use_cql_blob_get_backed2 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT cql_blob_get(k, backed2.pk1), cql_blob_get(k, backed2.pk2), cql_blob_get(v, backed2.id), cql_blob_get(v, backed2.extra), cql_blob_get(v, backed2.name)
-    FROM backing;
+  DECLARE C CURSOR FOR
+    SELECT 
+        cql_blob_get(k, backed2.pk1),
+        cql_blob_get(k, backed2.pk2),
+        cql_blob_get(v, backed2.id),
+        cql_blob_get(v, backed2.extra),
+        cql_blob_get(v, backed2.name)
+      FROM backing;
 END;
 */
 
@@ -17371,7 +17493,12 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed2(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT bgetkey(k, 1), bgetkey(k, 0), bgetval(v, -9155171551243524439), bgetval(v, 4605090824299507084), bgetval(v, -6946718245010482247) "
+    "SELECT  "
+        "bgetkey(k, 1), "
+        "bgetkey(k, 0), "
+        "bgetval(v, -9155171551243524439), "
+        "bgetval(v, 4605090824299507084), "
+        "bgetval(v, -6946718245010482247) "
       "FROM backing");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17389,9 +17516,12 @@ cql_cleanup:
 CREATE PROC insert_into_backed2 ()
 BEGIN
   WITH
-  _vals (pk1, pk2, flag, id, name, extra) AS (VALUES(1, 2, TRUE, 1000, 'hi', 5))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(backed2, V.pk2, backed2.pk2, V.pk1, backed2.pk1), cql_blob_create(backed2, V.flag, backed2.flag, V.id, backed2.id, V.name, backed2.name, V.extra, backed2.extra)
-    FROM _vals AS V;
+    _vals (pk1, pk2, flag, id, name, extra) AS (
+      VALUES(1, 2, TRUE, 1000, 'hi', 5)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(backed2, V.pk2, backed2.pk2, V.pk1, backed2.pk1), cql_blob_create(backed2, V.flag, backed2.flag, V.id, backed2.id, V.name, backed2.name, V.extra, backed2.extra)
+      FROM _vals AS V;
 END;
 */
 
@@ -17406,9 +17536,12 @@ CQL_WARN_UNUSED cql_code insert_into_backed2(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk1, pk2, flag, id, name, extra) AS (VALUES(1, 2, 1, 1000, 'hi', 5)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(3942979045122214775, V.pk2, 1, V.pk1, 1), bcreateval(3942979045122214775, 1055660242183705531, V.flag, 0, -9155171551243524439, V.id, 2, -6946718245010482247, V.name, 4, 4605090824299507084, V.extra, 1) "
-      "FROM _vals AS V");
+      "_vals (pk1, pk2, flag, id, name, extra) AS ( "
+        "VALUES(1, 2, 1, 1000, 'hi', 5) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(3942979045122214775, V.pk2, 1, V.pk1, 1), bcreateval(3942979045122214775, 1055660242183705531, V.flag, 0, -9155171551243524439, V.id, 2, -6946718245010482247, V.name, 4, 4605090824299507084, V.extra, 1) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -17424,12 +17557,12 @@ cql_cleanup:
 CREATE PROC update_backed2 ()
 BEGIN
   WITH
-  backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (CALL _backed2())
+    backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (CALL _backed2())
   UPDATE backing
-  SET k = cql_blob_update(k, 5, backed2.pk1, 7, backed2.pk2)
-    WHERE rowid IN (SELECT rowid
-    FROM backed2
-    WHERE pk1 = 3 AND pk2 = 11);
+    SET k = cql_blob_update(k, 5, backed2.pk1, 7, backed2.pk2)
+      WHERE rowid IN (SELECT rowid
+      FROM backed2
+      WHERE pk1 = 3 AND pk2 = 11);
 END;
 */
 
@@ -17445,16 +17578,23 @@ CQL_WARN_UNUSED cql_code update_backed2(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
-  "SELECT rowid, bgetkey(T.k, 1), bgetkey(T.k, 0), bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, 4605090824299507084) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = 3942979045122214775",
+      "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 1), "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, 4605090824299507084) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = 3942979045122214775",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 1, 5, 0, 7) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed2 "
-      "WHERE pk1 = 3 AND pk2 = 11)"
+      "SET k = bupdatekey(k, 1, 5, 0, 7) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed2 "
+        "WHERE pk1 = 3 AND pk2 = 11)"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -17471,7 +17611,7 @@ cql_cleanup:
 CREATE PROC use_generated_fragment ()
 BEGIN
   WITH
-  _backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    _backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM _backed;
 END;
@@ -17595,10 +17735,17 @@ CQL_WARN_UNUSED cql_code use_generated_fragment(sqlite3 *_Nonnull _db_, sqlite3_
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "_backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "_backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM _backed"
@@ -17619,7 +17766,7 @@ cql_cleanup:
 CREATE PROC use_backed_table_directly ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -17743,10 +17890,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly(sqlite3 *_Nonnull _db_, sqlit
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -17766,10 +17920,11 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_with_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
-  SELECT *
-    FROM backed;
+  DECLARE C CURSOR FOR
+    WITH
+      backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    SELECT *
+      FROM backed;
 END;
 */
 
@@ -17786,10 +17941,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_cursor(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_prepare_var(_db_, &C_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -17810,9 +17972,13 @@ cql_cleanup:
 CREATE PROC use_backed_table_directly_in_with_select ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  one (x) AS (SELECT 1 AS x),
-  two (x) AS (SELECT 2 AS x)
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+    one (x) AS (
+      SELECT 1 AS x
+    ),
+    two (x) AS (
+      SELECT 2 AS x
+    )
   SELECT *
     FROM backed;
 END;
@@ -17936,13 +18102,24 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select(sqlite3 *_Nonn
   _rc_ = cql_prepare_var(_db_, _result_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "one (x) AS (SELECT 1), "
-    "two (x) AS (SELECT 2) "
+      "one (x) AS ( "
+        "SELECT 1 "
+      "), "
+      "two (x) AS ( "
+        "SELECT 2 "
+      ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
   );
@@ -17961,12 +18138,17 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_with_select_and_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  one (x) AS (SELECT 1 AS x),
-  two (x) AS (SELECT 2 AS x)
-  SELECT *
-    FROM backed;
+  DECLARE C CURSOR FOR
+    WITH
+      backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+      one (x) AS (
+        SELECT 1 AS x
+      ),
+      two (x) AS (
+        SELECT 2 AS x
+      )
+    SELECT *
+      FROM backed;
 END;
 */
 
@@ -17983,13 +18165,24 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_select_and_cursor(sqlite3 *_Nonnu
   _rc_ = cql_prepare_var(_db_, &C_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "one (x) AS (SELECT 1), "
-    "two (x) AS (SELECT 2) "
+      "one (x) AS ( "
+        "SELECT 1 "
+      "), "
+      "two (x) AS ( "
+        "SELECT 2 "
+      ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
   );
@@ -18008,8 +18201,8 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_select_expr (OUT x BOOL NOT NULL)
 BEGIN
-  SET x := ( WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+  SET x := (   WITH
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT flag
     FROM backed );
 END;
@@ -18031,10 +18224,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
   _rc_ = cql_prepare_var(_db_, &_temp_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT flag "
       "FROM backed"
@@ -18061,7 +18261,7 @@ CREATE PROC explain_query_plan_backed (OUT x BOOL NOT NULL)
 BEGIN
   EXPLAIN QUERY PLAN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -18082,10 +18282,17 @@ static CQL_WARN_UNUSED cql_code explain_query_plan_backed(sqlite3 *_Nonnull _db_
     3, NULL,
   "EXPLAIN QUERY PLAN "
     "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT rowid, flag, id, name, age, storage, pk "
       "FROM backed"
@@ -18105,8 +18312,8 @@ cql_cleanup:
 /*
 CREATE PROC use_backed_table_select_expr_value_offsets (OUT x BOOL NOT NULL)
 BEGIN
-  SET x := ( WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+  SET x := (   WITH
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   SELECT flag
     FROM backed );
 END;
@@ -18128,10 +18335,17 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
   _rc_ = cql_prepare_var(_db_, &_temp_stmt,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 0), bgetval(T.v, 1), bgetval(T.v, 2), bgetval(T.v, 3), bgetval(T.v, 4), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 0), "
+          "bgetval(T.v, 1), "
+          "bgetval(T.v, 2), "
+          "bgetval(T.v, 3), "
+          "bgetval(T.v, 4), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "SELECT flag "
       "FROM backed"
@@ -18156,9 +18370,12 @@ cql_cleanup:
 CREATE PROC insert_backed_values ()
 BEGIN
   WITH
-  _vals (pk, x, y) AS (VALUES(1, "2", 3.14), (4, "5", 6), (7, "8", 9.7))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    _vals (pk, x, y) AS (
+      VALUES(1, "2", 3.14), (4, "5", 6), (7, "8", 9.7)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18173,9 +18390,12 @@ CQL_WARN_UNUSED cql_code insert_backed_values(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk, x, y) AS (VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "_vals (pk, x, y) AS ( "
+        "VALUES(1, '2', 3.14), (4, '5', 6), (7, '8', 9.7) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18191,12 +18411,19 @@ cql_cleanup:
 CREATE PROC insert_backed_values_using_with ()
 BEGIN
   WITH
-  U (x, y, z) AS (VALUES(1, "2", 3.14)),
-  V (x, y, z) AS (VALUES(1, "2", 3.14)),
-  _vals (pk, x, y) AS (SELECT *
-    FROM V)
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    U (x, y, z) AS (
+      VALUES(1, "2", 3.14)
+    ),
+    V (x, y, z) AS (
+      VALUES(1, "2", 3.14)
+    ),
+    _vals (pk, x, y) AS (
+      SELECT *
+        FROM V
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18211,12 +18438,19 @@ CQL_WARN_UNUSED cql_code insert_backed_values_using_with(sqlite3 *_Nonnull _db_)
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "U (x, y, z) AS (VALUES(1, '2', 3.14)), "
-    "V (x, y, z) AS (VALUES(1, '2', 3.14)), "
-    "_vals (pk, x, y) AS (SELECT x, y, z "
-      "FROM V) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "U (x, y, z) AS ( "
+        "VALUES(1, '2', 3.14) "
+      "), "
+      "V (x, y, z) AS ( "
+        "VALUES(1, '2', 3.14) "
+      "), "
+      "_vals (pk, x, y) AS ( "
+        "SELECT x, y, z "
+          "FROM V "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18232,9 +18466,12 @@ cql_cleanup:
 CREATE PROC insert_backed_values_using_form ()
 BEGIN
   WITH
-  _vals (pk, x, y) AS (VALUES(1, "2", 3.14))
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    _vals (pk, x, y) AS (
+      VALUES(1, "2", 3.14)
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18249,9 +18486,12 @@ CQL_WARN_UNUSED cql_code insert_backed_values_using_form(sqlite3 *_Nonnull _db_)
 
   _rc_ = cql_exec(_db_,
     "WITH "
-    "_vals (pk, x, y) AS (VALUES(1, '2', 3.14)) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V");
+      "_vals (pk, x, y) AS ( "
+        "VALUES(1, '2', 3.14) "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -18267,11 +18507,14 @@ cql_cleanup:
 CREATE PROC inserted_backed_from_select ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
-  _vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50
-    FROM small_backed AS B)
-  INSERT INTO backing(k, v) SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
-    FROM _vals AS V;
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
+    _vals (pk, x, y) AS (
+      SELECT pk + 1000, B.x || 'x', B.y + 50
+        FROM small_backed AS B
+    )
+  INSERT INTO backing(k, v)
+    SELECT cql_blob_create(small_backed, V.pk, small_backed.pk), cql_blob_create(small_backed, V.x, small_backed.x, V.y, small_backed.y)
+      FROM _vals AS V;
 END;
 */
 
@@ -18287,15 +18530,22 @@ CQL_WARN_UNUSED cql_code inserted_backed_from_select(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0) AS pk, bgetval(T.v, 7953209610392031882) AS x, bgetval(T.v, 3032304244189539277) AS y "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0) AS pk, "
+          "bgetval(T.v, 7953209610392031882) AS x, "
+          "bgetval(T.v, 3032304244189539277) AS y "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   "), "
-    "_vals (pk, x, y) AS (SELECT pk + 1000, B.x || 'x', B.y + 50 "
-      "FROM small_backed AS B) "
-    "INSERT INTO backing(k, v) SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
-      "FROM _vals AS V"
+      "_vals (pk, x, y) AS ( "
+        "SELECT pk + 1000, B.x || 'x', B.y + 50 "
+          "FROM small_backed AS B "
+      ") "
+    "INSERT INTO backing(k, v) "
+      "SELECT bcreatekey(-4190907309554122430, V.pk, 1), bcreateval(-4190907309554122430, 7953209610392031882, V.x, 4, 3032304244189539277, V.y, 3) "
+        "FROM _vals AS V"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18312,7 +18562,7 @@ cql_cleanup:
 CREATE PROC delete_from_backed ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed())
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed())
   DELETE FROM backing WHERE rowid IN (SELECT rowid
     FROM small_backed
     WHERE pk = 12345);
@@ -18331,10 +18581,14 @@ CQL_WARN_UNUSED cql_code delete_from_backed(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0), bgetval(T.v, 7953209610392031882), bgetval(T.v, 3032304244189539277) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 7953209610392031882), "
+          "bgetval(T.v, 3032304244189539277) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   ") "
     "DELETE FROM backing WHERE rowid IN (SELECT rowid "
       "FROM small_backed "
@@ -18355,8 +18609,10 @@ cql_cleanup:
 CREATE PROC delete_from_backed_no_where_clause ()
 BEGIN
   WITH
-  small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
-  v (x) AS (VALUES(1))
+    small_backed (rowid, pk, x, y) AS (CALL _small_backed()),
+    v (x) AS (
+      VALUES(1)
+    )
   DELETE FROM backing WHERE rowid IN (SELECT rowid
     FROM small_backed);
 END;
@@ -18374,12 +18630,18 @@ CQL_WARN_UNUSED cql_code delete_from_backed_no_where_clause(sqlite3 *_Nonnull _d
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "small_backed (rowid, pk, x, y) AS (",
-  "SELECT rowid, bgetkey(T.k, 0), bgetval(T.v, 7953209610392031882), bgetval(T.v, 3032304244189539277) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -4190907309554122430",
+      "small_backed (rowid, pk, x, y) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetkey(T.k, 0), "
+          "bgetval(T.v, 7953209610392031882), "
+          "bgetval(T.v, 3032304244189539277) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -4190907309554122430",
   "), "
-    "v (x) AS (VALUES(1)) "
+      "v (x) AS ( "
+        "VALUES(1) "
+      ") "
     "DELETE FROM backing WHERE rowid IN (SELECT rowid "
       "FROM small_backed)"
   );
@@ -18452,12 +18714,12 @@ cql_cleanup:
 CREATE PROC update_backed_set_value ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET v = cql_blob_update(v, 'foo', backed.name)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'one');
+    SET v = cql_blob_update(v, 'foo', backed.name)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'one');
 END;
 */
 
@@ -18473,16 +18735,23 @@ CQL_WARN_UNUSED cql_code update_backed_set_value(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET v = bupdateval(v, -6946718245010482247, 'foo', 4) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'one')"
+      "SET v = bupdateval(v, -6946718245010482247, 'foo', 4) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'one')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18499,13 +18768,15 @@ cql_cleanup:
 CREATE PROC update_backed_with_clause ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
-  V (x) AS (VALUES(1))
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed()),
+    V (x) AS (
+      VALUES(1)
+    )
   UPDATE backing
-  SET v = cql_blob_update(v, 'goo', backed.name)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'with_update');
+    SET v = cql_blob_update(v, 'goo', backed.name)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'with_update');
 END;
 */
 
@@ -18521,17 +18792,26 @@ CQL_WARN_UNUSED cql_code update_backed_with_clause(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   "), "
-    "V (x) AS (VALUES(1)) "
+      "V (x) AS ( "
+        "VALUES(1) "
+      ") "
     "UPDATE backing "
-    "SET v = bupdateval(v, -6946718245010482247, 'goo', 4) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'with_update')"
+      "SET v = bupdateval(v, -6946718245010482247, 'goo', 4) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'with_update')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18548,12 +18828,12 @@ cql_cleanup:
 CREATE PROC update_backed_set_key ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET k = cql_blob_update(k, 100, backed.pk)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'two');
+    SET k = cql_blob_update(k, 100, backed.pk)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'two');
 END;
 */
 
@@ -18569,16 +18849,23 @@ CQL_WARN_UNUSED cql_code update_backed_set_key(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 0, 100) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'two')"
+      "SET k = bupdatekey(k, 0, 100) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'two')"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18595,15 +18882,14 @@ cql_cleanup:
 CREATE PROC update_backed_set_both ()
 BEGIN
   WITH
-  backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
+    backed (rowid, flag, id, name, age, storage, pk) AS (CALL _backed())
   UPDATE backing
-  SET k = cql_blob_update(k, 100, backed.pk),
-  v = cql_blob_update(v, 77, backed.age)
-    WHERE rowid IN (SELECT rowid
-    FROM backed
-    WHERE name = 'three'
-  ORDER BY age
-  LIMIT 7);
+    SET k = cql_blob_update(k, 100, backed.pk), v = cql_blob_update(v, 77, backed.age)
+      WHERE rowid IN (SELECT rowid
+      FROM backed
+      WHERE name = 'three'
+    ORDER BY age
+    LIMIT 7);
 END;
 */
 
@@ -18619,19 +18905,25 @@ CQL_WARN_UNUSED cql_code update_backed_set_both(sqlite3 *_Nonnull _db_) {
   _rc_ = cql_exec_var(_db_,
     3, NULL,
   "WITH "
-    "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT rowid, bgetval(T.v, 1055660242183705531), bgetval(T.v, -9155171551243524439), bgetval(T.v, -6946718245010482247), bgetval(T.v, -3683705396192132539), bgetval(T.v, -7635294210585028660), bgetkey(T.k, 0) "
-      "FROM backing AS T "
-      "WHERE bgetkey_type(T.k) = -5417664364642960231",
+      "backed (rowid, flag, id, name, age, storage, pk) AS (",
+  "SELECT  "
+          "rowid, "
+          "bgetval(T.v, 1055660242183705531), "
+          "bgetval(T.v, -9155171551243524439), "
+          "bgetval(T.v, -6946718245010482247), "
+          "bgetval(T.v, -3683705396192132539), "
+          "bgetval(T.v, -7635294210585028660), "
+          "bgetkey(T.k, 0) "
+        "FROM backing AS T "
+        "WHERE bgetkey_type(T.k) = -5417664364642960231",
   ") "
     "UPDATE backing "
-    "SET k = bupdatekey(k, 0, 100), "
-    "v = bupdateval(v, -3683705396192132539, 77, 3) "
-      "WHERE rowid IN (SELECT rowid "
-      "FROM backed "
-      "WHERE name = 'three' "
-    "ORDER BY age "
-    "LIMIT 7)"
+      "SET k = bupdatekey(k, 0, 100), v = bupdateval(v, -3683705396192132539, 77, 3) "
+        "WHERE rowid IN (SELECT rowid "
+        "FROM backed "
+        "WHERE name = 'three' "
+      "ORDER BY age "
+      "LIMIT 7)"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
@@ -18654,7 +18946,7 @@ BEGIN
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 */
 
@@ -18691,7 +18983,7 @@ CQL_WARN_UNUSED cql_code stmt_in_loop(sqlite3 *_Nonnull _db_) {
   }
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT 1 "
-      "FROM foo)");
+        "FROM foo)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -18715,14 +19007,15 @@ BEGIN
   LET i := 0;
   WHILE i < 10
   BEGIN
-    DECLARE C CURSOR FOR SELECT *
-      FROM foo
-      WHERE id = i;
+    DECLARE C CURSOR FOR
+      SELECT *
+        FROM foo
+        WHERE id = i;
     FETCH C;
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 */
 
@@ -18767,7 +19060,7 @@ CQL_WARN_UNUSED cql_code cursor_in_loop(sqlite3 *_Nonnull _db_) {
   }
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT 1 "
-      "FROM foo)");
+        "FROM foo)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -19095,8 +19388,9 @@ cql_cleanup:
 /*
 CREATE PROC qid_t1 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM `xyz``abc`;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM `xyz``abc`;
   LOOP FETCH C
   BEGIN
     CALL printf("%d %d", C.x, C.`a b`);
@@ -19151,8 +19445,9 @@ cql_cleanup:
 /*
 CREATE PROC qid_t2 ()
 BEGIN
-  DECLARE D CURSOR FOR SELECT `xyz``abc`.*
-    FROM `xyz``abc`;
+  DECLARE D CURSOR FOR
+    SELECT `xyz``abc`.*
+      FROM `xyz``abc`;
   LOOP FETCH D
   BEGIN
     CALL printf("%d %d", D.x, D.`a b`);
@@ -20009,9 +20304,10 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE foo_cursor CURSOR FOR SELECT id, i2
-    FROM foo
-    WHERE id = i0_nullable;
+  DECLARE foo_cursor CURSOR FOR
+    SELECT id, i2
+      FROM foo
+      WHERE id = i0_nullable;
   */
   _rc_ = cql_prepare(_db_, &foo_cursor_stmt,
     "SELECT id, ? "
@@ -20037,7 +20333,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE basic_cursor CURSOR FOR SELECT 1, 2.5;
+  DECLARE basic_cursor CURSOR FOR
+    SELECT 1, 2.5;
   */
   _rc_ = cql_prepare(_db_, &basic_cursor_stmt,
     "SELECT 1, 2.5");
@@ -20079,7 +20376,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE exchange_cursor CURSOR FOR SELECT arg2, arg1;
+  DECLARE exchange_cursor CURSOR FOR
+    SELECT arg2, arg1;
   */
   _rc_ = cql_prepare(_db_, &exchange_cursor_stmt,
     "SELECT ?, ?");
@@ -20706,10 +21004,12 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5);
+  INSERT OR REPLACE INTO bar(id, type)
+    VALUES(1, 5);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5)");
+    "INSERT OR REPLACE INTO bar(id, type) "
+      "VALUES(1, 5)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -20725,11 +21025,11 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   SET b2 := ( SELECT EXISTS (SELECT *
-    FROM bar) );
+      FROM bar) );
   */
   _rc_ = cql_prepare(_db_, &_temp_stmt,
     "SELECT EXISTS (SELECT * "
-      "FROM bar)");
+        "FROM bar)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = sqlite3_step(_temp_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
@@ -20739,8 +21039,9 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE expanded_select CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE expanded_select CURSOR FOR
+    SELECT *
+      FROM bar;
   */
   _rc_ = cql_prepare(_db_, &expanded_select_stmt,
     "SELECT id, name, rate, type, size "
@@ -20750,8 +21051,9 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE table_expanded_select CURSOR FOR SELECT bar.*
-    FROM bar;
+  DECLARE table_expanded_select CURSOR FOR
+    SELECT bar.*
+      FROM bar;
   */
   _rc_ = cql_prepare(_db_, &table_expanded_select_stmt,
     "SELECT bar.id, bar.name, bar.rate, bar.type, bar.size "
@@ -21000,10 +21302,12 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
+  INSERT INTO blob_table(blob_id, b_nullable, b_notnull)
+    VALUES(0, blob_var, blob_var_notnull);
   */
   _rc_ = cql_prepare(_db_, &_temp_stmt,
-    "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)");
+    "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) "
+      "VALUES(0, ?, ?)");
   cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
                 CQL_DATA_TYPE_BLOB, blob_var,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
@@ -21055,15 +21359,21 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) VALUES(ifnull(( SELECT a
-    FROM x ), 0));
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    VALUES(ifnull(( SELECT a
+      FROM x ), 0));
   */
   _rc_ = cql_exec(_db_,
     "WITH "
-    "x (a) AS (SELECT 111) "
-    "INSERT INTO foo(id) VALUES(ifnull(( SELECT a "
-      "FROM x ), 0))");
+      "x (a) AS ( "
+        "SELECT 111 "
+      ") "
+    "INSERT INTO foo(id) "
+      "VALUES(ifnull(( SELECT a "
+        "FROM x ), 0))");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -21082,7 +21392,8 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  DECLARE global_cursor CURSOR FOR SELECT 1 AS a, 2 AS b;
+  DECLARE global_cursor CURSOR FOR
+    SELECT 1 AS a, 2 AS b;
   */
   _rc_ = cql_prepare(_db_, &global_cursor_stmt,
     "SELECT 1, 2");
@@ -21202,14 +21513,18 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
 
   /*
   WITH
-  some_cte (id) AS (SELECT 1 AS id)
+    some_cte (id) AS (
+      SELECT 1 AS id
+    )
   INSERT INTO bar(id) VALUES(ifnull(( SELECT id
     FROM some_cte ), 0)) @DUMMY_SEED(1337);
   */
   _seed_ = 1337;
   _rc_ = cql_exec(_db_,
     "WITH "
-    "some_cte (id) AS (SELECT 1 AS id) "
+      "some_cte (id) AS ( "
+        "SELECT 1 AS id "
+      ") "
     "INSERT INTO bar(id) VALUES(ifnull(( SELECT id "
       "FROM some_cte ), 0))");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
@@ -21219,13 +21534,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   INSERT INTO bar(id) VALUES(1) @DUMMY_SEED(1338)
   ON CONFLICT (id) DO UPDATE
-  SET id = 10;
+    SET id = 10;
   */
   _seed_ = 1338;
   _rc_ = cql_exec(_db_,
     "INSERT INTO bar(id) VALUES(1) "
     "ON CONFLICT (id) DO UPDATE "
-    "SET id = 10");
+      "SET id = 10");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
@@ -21485,19 +21800,23 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO virtual_with_hidden(vy) VALUES(1);
+  INSERT INTO virtual_with_hidden(vy)
+    VALUES(1);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT INTO virtual_with_hidden(vy) VALUES(1)");
+    "INSERT INTO virtual_with_hidden(vy) "
+      "VALUES(1)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX
 
   /*
-  INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2);
+  INSERT INTO virtual_with_hidden(vx, vy)
+    VALUES(1, 2);
   */
   _rc_ = cql_exec(_db_,
-    "INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2)");
+    "INSERT INTO virtual_with_hidden(vx, vy) "
+      "VALUES(1, 2)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
   // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -1565,7 +1565,7 @@ DECLARE PROC plugh (id INTEGER);
 /*
 CREATE PROC complex_return ()
 BEGIN
-  SELECT 
+  SELECT
       TRUE AS _bool,
       2 AS _integer,
       CAST(3 AS LONG_INT) AS _longint,
@@ -1678,7 +1678,7 @@ CQL_WARN_UNUSED cql_code complex_return(sqlite3 *_Nonnull _db_, sqlite3_stmt *_N
   cql_error_prepare();
 
   _rc_ = cql_prepare(_db_, _result_stmt,
-    "SELECT  "
+    "SELECT "
         "1, "
         "2, "
         "CAST(3 AS LONG_INT), "
@@ -8232,7 +8232,7 @@ CQL_WARN_UNUSED cql_code pretty_print_with_quote(sqlite3 *_Nonnull _db_) {
 
   _rc_ = cql_exec(_db_,
     "INSERT INTO bar(id, name) "
-      "VALUES(1, 'it''s high noon\r\n  \f\b\t\v')");
+      "VALUES(1, 'it''s high noon\r\n\f\b\t\v')");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
   _rc_ = SQLITE_OK;
 
@@ -17426,7 +17426,7 @@ cql_cleanup:
 CREATE PROC use_cql_blob_get_backed ()
 BEGIN
   DECLARE C CURSOR FOR
-    SELECT 
+    SELECT
         cql_blob_get(k, backed.pk),
         cql_blob_get(v, backed.flag),
         cql_blob_get(v, backed.storage),
@@ -17448,7 +17448,7 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT  "
+    "SELECT "
         "bgetkey(k, 0), "
         "bgetval(v, 1055660242183705531), "
         "bgetval(v, -7635294210585028660), "
@@ -17472,7 +17472,7 @@ cql_cleanup:
 CREATE PROC use_cql_blob_get_backed2 ()
 BEGIN
   DECLARE C CURSOR FOR
-    SELECT 
+    SELECT
         cql_blob_get(k, backed2.pk1),
         cql_blob_get(k, backed2.pk2),
         cql_blob_get(v, backed2.id),
@@ -17493,7 +17493,7 @@ CQL_WARN_UNUSED cql_code use_cql_blob_get_backed2(sqlite3 *_Nonnull _db_) {
   sqlite3_stmt *C_stmt = NULL;
 
   _rc_ = cql_prepare(_db_, &C_stmt,
-    "SELECT  "
+    "SELECT "
         "bgetkey(k, 1), "
         "bgetkey(k, 0), "
         "bgetval(v, -9155171551243524439), "
@@ -17579,7 +17579,7 @@ CQL_WARN_UNUSED cql_code update_backed2(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed2 (rowid, pk1, pk2, flag, id, name, extra) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 1), "
           "bgetkey(T.k, 0), "
@@ -17736,7 +17736,7 @@ CQL_WARN_UNUSED cql_code use_generated_fragment(sqlite3 *_Nonnull _db_, sqlite3_
     3, NULL,
   "WITH "
       "_backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -17891,7 +17891,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly(sqlite3 *_Nonnull _db_, sqlit
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -17942,7 +17942,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_cursor(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18103,7 +18103,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select(sqlite3 *_Nonn
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18166,7 +18166,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_with_select_and_cursor(sqlite3 *_Nonnu
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18225,7 +18225,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18283,7 +18283,7 @@ static CQL_WARN_UNUSED cql_code explain_query_plan_backed(sqlite3 *_Nonnull _db_
   "EXPLAIN QUERY PLAN "
     "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18336,7 +18336,7 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 0), "
           "bgetval(T.v, 1), "
@@ -18531,7 +18531,7 @@ CQL_WARN_UNUSED cql_code inserted_backed_from_select(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0) AS pk, "
           "bgetval(T.v, 7953209610392031882) AS x, "
@@ -18582,7 +18582,7 @@ CQL_WARN_UNUSED cql_code delete_from_backed(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0), "
           "bgetval(T.v, 7953209610392031882), "
@@ -18631,7 +18631,7 @@ CQL_WARN_UNUSED cql_code delete_from_backed_no_where_clause(sqlite3 *_Nonnull _d
     3, NULL,
   "WITH "
       "small_backed (rowid, pk, x, y) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetkey(T.k, 0), "
           "bgetval(T.v, 7953209610392031882), "
@@ -18736,7 +18736,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_value(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18793,7 +18793,7 @@ CQL_WARN_UNUSED cql_code update_backed_with_clause(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18850,7 +18850,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_key(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "
@@ -18906,7 +18906,7 @@ CQL_WARN_UNUSED cql_code update_backed_set_both(sqlite3 *_Nonnull _db_) {
     3, NULL,
   "WITH "
       "backed (rowid, flag, id, name, age, storage, pk) AS (",
-  "SELECT  "
+  "SELECT "
           "rowid, "
           "bgetval(T.v, 1055660242183705531), "
           "bgetval(T.v, -9155171551243524439), "

--- a/sources/test/cg_test_json_schema.out.ref
+++ b/sources/test/cg_test_json_schema.out.ref
@@ -3251,16 +3251,17 @@
       WHEN old.id > 1 AND new.id < 3
     BEGIN
     UPDATE Foo
-    SET id = 7
-      WHERE name > old.name AND name < new.name;
+      SET id = 7
+        WHERE name > old.name AND name < new.name;
 
-    INSERT INTO Foo(id, name) VALUES(7, 'goo');
+    INSERT INTO Foo(id, name)
+      VALUES(7, 'goo');
     END
 
     ,
     {
       "name" : "trigger3",
-      "CRC" : "6621399856062205043",
+      "CRC" : "-1599636186644474341",
       "target" : "MyView",
       "isTemp" : 0,
       "ifNotExists" : 0,
@@ -3766,13 +3767,17 @@
     CREATE PROC with_select_proc ()
     BEGIN
     WITH
-    nums (i) AS (SELECT 0
-    UNION ALL
-    SELECT i + 1
-      FROM nums
-    LIMIT 1),
-    vals (v) AS (SELECT i
-      FROM nums)
+      nums (i) AS (
+        SELECT 0
+        UNION ALL
+        SELECT i + 1
+          FROM nums
+        LIMIT 1
+      ),
+      vals (v) AS (
+        SELECT i
+          FROM nums
+      )
     SELECT *
       FROM vals;
     END
@@ -3791,7 +3796,7 @@
           "isNotNull" : 1
         }
       ],
-      "statement" : "WITH nums (i) AS (SELECT 0 UNION ALL SELECT i + 1 FROM nums LIMIT 1), vals (v) AS (SELECT i FROM nums) SELECT v FROM vals",
+      "statement" : "WITH nums (i) AS ( SELECT 0 UNION ALL SELECT i + 1 FROM nums LIMIT 1 ), vals (v) AS ( SELECT i FROM nums ) SELECT v FROM vals",
       "statementArgs" : [  ]
     },
 
@@ -4001,7 +4006,9 @@
     CREATE PROC uses_deleted_view_alias ()
     BEGIN
     WITH
-    deleted_view (x, y) AS (SELECT 1 AS x, 2 AS y)
+      deleted_view (x, y) AS (
+        SELECT 1 AS x, 2 AS y
+      )
     SELECT *
       FROM deleted_view;
     END
@@ -4025,7 +4032,7 @@
           "isNotNull" : 1
         }
       ],
-      "statement" : "WITH deleted_view (x, y) AS (SELECT 1 AS x, 2 AS y) SELECT x, y FROM deleted_view",
+      "statement" : "WITH deleted_view (x, y) AS ( SELECT 1 AS x, 2 AS y ) SELECT x, y FROM deleted_view",
       "statementArgs" : [  ]
     },
 
@@ -4116,7 +4123,8 @@
 
     CREATE PROC insert_proc (id_ INTEGER NOT NULL, name_ TEXT)
     BEGIN
-    INSERT OR REPLACE INTO Foo(id, name) VALUES(id_, name_);
+    INSERT OR REPLACE INTO Foo(id, name)
+      VALUES(id_, name_);
     END
 
     {
@@ -4200,7 +4208,8 @@
 
     CREATE PROC insert_with_select ()
     BEGIN
-    INSERT INTO T3(id) SELECT 1;
+    INSERT INTO T3(id)
+      SELECT 1;
     END
 
     {
@@ -4222,9 +4231,10 @@
 
     CREATE PROC insert_compound ()
     BEGIN
-    INSERT INTO T3(id) VALUES(1)
-    UNION ALL
-    SELECT 1 AS column1;
+    INSERT INTO T3(id)
+      VALUES(1)
+      UNION ALL
+      SELECT 1 AS column1;
     END
 
     {
@@ -4246,7 +4256,8 @@
 
     CREATE PROC insert_multi_value ()
     BEGIN
-    INSERT INTO T3(id) VALUES(1), (2), (3);
+    INSERT INTO T3(id)
+      VALUES(1), (2), (3);
     END
 
     {
@@ -4268,10 +4279,11 @@
 
     CREATE PROC upsert_proc ()
     BEGIN
-    INSERT INTO T3(id) VALUES(1)
+    INSERT INTO T3(id)
+      VALUES(1)
     ON CONFLICT DO UPDATE
-    SET id = 1
-      WHERE id = 9;
+      SET id = 1
+        WHERE id = 9;
     END
 
     {
@@ -4294,13 +4306,16 @@
     CREATE PROC with_upsert_proc ()
     BEGIN
     WITH
-    data (id) AS (VALUES(1), (2), (3))
-    INSERT INTO T3(id) SELECT id
-      FROM data
-      WHERE 1
+      data (id) AS (
+        VALUES(1), (2), (3)
+      )
+    INSERT INTO T3(id)
+      SELECT id
+        FROM data
+        WHERE 1
     ON CONFLICT DO UPDATE
-    SET id = 1
-      WHERE id = 9;
+      SET id = 1
+        WHERE id = 9;
     END
 
     {
@@ -4312,7 +4327,7 @@
       "insertTables" : [ "T3" ],
       "usesTables" : [ "T3" ],
       "table" : "T3",
-      "statement" : "WITH data (id) AS (VALUES(1), (2), (3)) INSERT INTO T3(id) SELECT id FROM data WHERE 1 ON CONFLICT DO UPDATE SET id = 1 WHERE id = 9",
+      "statement" : "WITH data (id) AS ( VALUES(1), (2), (3) ) INSERT INTO T3(id) SELECT id FROM data WHERE 1 ON CONFLICT DO UPDATE SET id = 1 WHERE id = 9",
       "statementArgs" : [  ],
       "statementType" : "INSERT",
       "columns" : [ "id" ]
@@ -4323,9 +4338,12 @@
     CREATE PROC with_insert_proc (x INTEGER NOT NULL)
     BEGIN
     WITH
-    data (id) AS (VALUES(1), (2), (x))
-    INSERT INTO T3(id) SELECT *
-      FROM data;
+      data (id) AS (
+        VALUES(1), (2), (x)
+      )
+    INSERT INTO T3(id)
+      SELECT *
+        FROM data;
     END
 
     {
@@ -4343,7 +4361,7 @@
       "insertTables" : [ "T3" ],
       "usesTables" : [ "T3" ],
       "table" : "T3",
-      "statement" : "WITH data (id) AS (VALUES(1), (2), (?)) INSERT INTO T3(id) SELECT id FROM data",
+      "statement" : "WITH data (id) AS ( VALUES(1), (2), (?) ) INSERT INTO T3(id) SELECT id FROM data",
       "statementArgs" : [ "x" ],
       "statementType" : "INSERT",
       "columns" : [ "id" ]
@@ -4356,10 +4374,10 @@
     CREATE PROC update_proc (id_ INTEGER NOT NULL, name_ TEXT)
     BEGIN
     UPDATE foO
-    SET name = name_
-      WHERE id = id_
-    ORDER BY name
-    LIMIT 1;
+      SET name = name_
+        WHERE id = id_
+      ORDER BY name
+      LIMIT 1;
     END
 
     {
@@ -4392,11 +4410,13 @@
     CREATE PROC update_with_proc (id_ INTEGER NOT NULL, name_ TEXT)
     BEGIN
     WITH
-    names (n) AS (VALUES("this"), ("that"))
+      names (n) AS (
+        VALUES("this"), ("that")
+      )
     UPDATE foO
-    SET name = name_
-      WHERE name IN (SELECT *
-      FROM names);
+      SET name = name_
+        WHERE name IN (SELECT *
+        FROM names);
     END
 
     {
@@ -4420,7 +4440,7 @@
       "updateTables" : [ "Foo" ],
       "usesTables" : [ "Foo" ],
       "table" : "Foo",
-      "statement" : "WITH names (n) AS (VALUES('this'), ('that')) UPDATE foO SET name = ? WHERE name IN (SELECT n FROM names)",
+      "statement" : "WITH names (n) AS ( VALUES('this'), ('that') ) UPDATE foO SET name = ? WHERE name IN (SELECT n FROM names)",
       "statementArgs" : [ "name_" ]
     }
   ],
@@ -4457,7 +4477,9 @@
     CREATE PROC delete_with_values (name_ TEXT)
     BEGIN
     WITH
-    names (n) AS (VALUES("this"), ("that"))
+      names (n) AS (
+        VALUES("this"), ("that")
+      )
     DELETE FROM foO WHERE name IN (SELECT *
       FROM names);
     END
@@ -4477,7 +4499,7 @@
       "deleteTables" : [ "Foo" ],
       "usesTables" : [ "Foo" ],
       "table" : "Foo",
-      "statement" : "WITH names (n) AS (VALUES('this'), ('that')) DELETE FROM foO WHERE name IN (SELECT n FROM names)",
+      "statement" : "WITH names (n) AS ( VALUES('this'), ('that') ) DELETE FROM foO WHERE name IN (SELECT n FROM names)",
       "statementArgs" : [  ]
     }
   ],
@@ -4855,7 +4877,8 @@
     BEGIN
     END;
 
-    DECLARE c CURSOR FOR SELECT 1 AS x;
+    DECLARE c CURSOR FOR
+      SELECT 1 AS x;
 
     LOOP FETCH c
     BEGIN
@@ -4940,7 +4963,7 @@
     CREATE PROC shared_frag_user ()
     BEGIN
     WITH
-    shared (id) AS (CALL shared_frag_proc() USING T1 AS source, T2 AS control)
+      shared (id) AS (CALL shared_frag_proc() USING T1 AS source, T2 AS control)
     SELECT *
       FROM shared
     UNION ALL

--- a/sources/test/cg_test_json_schema.sql
+++ b/sources/test/cg_test_json_schema.sql
@@ -489,7 +489,7 @@ end;
 -- TEST: an update statement and with clause
 -- + "name" : "update_with_proc",
 -- + "table" : "Foo",
--- + "statement" : "WITH names (n) AS (VALUES('this'), ('that')) UPDATE foO SET name = ? WHERE name IN (SELECT n FROM names)",
+-- + "statement" : "WITH names (n) AS ( VALUES('this'), ('that') ) UPDATE foO SET name = ? WHERE name IN (SELECT n FROM names)",
 -- + "statementArgs" : [ "name_" ]
 create proc update_with_proc(id_ integer not null, name_ text)
 begin
@@ -791,7 +791,7 @@ end;
 -- + ],
 -- + "name" : "with_upsert_proc",
 -- + "usesTables" : [ "T3" ],
--- + "statement" : "WITH data (id) AS (VALUES(1), (2), (3)) INSERT INTO T3(id) SELECT id FROM data WHERE 1 ON CONFLICT DO UPDATE SET id = 1 WHERE id = 9",
+-- + "statement" : "WITH data (id) AS ( VALUES(1), (2), (3) ) INSERT INTO T3(id) SELECT id FROM data WHERE 1 ON CONFLICT DO UPDATE SET id = 1 WHERE id = 9",
 -- + "statementArgs" : [  ],
 -- + "statementType" : "INSERT",
 create proc with_upsert_proc()
@@ -808,7 +808,7 @@ end;
 -- + "insertTables" : [ "T3" ],
 -- + "usesTables" : [ "T3" ],
 -- + "table" : "T3",
--- + "statement" : "WITH data (id) AS (VALUES(1), (2), (?)) INSERT INTO T3(id) SELECT id FROM data",
+-- + "statement" : "WITH data (id) AS ( VALUES(1), (2), (?) ) INSERT INTO T3(id) SELECT id FROM data",
 -- + "statementArgs" : [ "x" ],
 -- + "statementType" : "INSERT",
 -- + "columns" : [ "id" ]
@@ -1066,7 +1066,7 @@ end;
 -- +         "name" : "v",
 -- +         "type" : "integer",
 -- +         "isNotNull" : 1
--- +   "statement" : "WITH nums (i) AS (SELECT 0 UNION ALL SELECT i + 1 FROM nums LIMIT 1), vals (v) AS (SELECT i FROM nums) SELECT v FROM vals",
+-- +   "statement" : "WITH nums (i) AS ( SELECT 0 UNION ALL SELECT i + 1 FROM nums LIMIT 1 ), vals (v) AS ( SELECT i FROM nums ) SELECT v FROM vals",
 -- +   "statementArgs" : [  ]
 create procedure with_select_proc()
 begin

--- a/sources/test/cg_test_lua.lua.ref
+++ b/sources/test/cg_test_lua.lua.ref
@@ -448,13 +448,15 @@ end
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC easy_fetch ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   FETCH C;
   CALL printf("%d %s\n", C.id, C.name);
-  DECLARE C2 CURSOR FOR SELECT *
-    FROM bar
-    WHERE C AND id = C.id;
+  DECLARE C2 CURSOR FOR
+    SELECT *
+      FROM bar
+      WHERE C AND id = C.id;
 END;
 --]]
 
@@ -566,7 +568,8 @@ DECLARE PROC xyzzy (id INTEGER) (A INTEGER NOT NULL);
 --[[
 CREATE PROC xyzzy_test ()
 BEGIN
-  DECLARE xyzzy_cursor CURSOR FOR CALL xyzzy(1);
+  DECLARE xyzzy_cursor CURSOR FOR
+    CALL xyzzy(1);
 END;
 --]]
 
@@ -598,7 +601,13 @@ DECLARE PROC plugh (id INTEGER);
 --[[
 CREATE PROC complex_return ()
 BEGIN
-  SELECT TRUE AS _bool, 2 AS _integer, CAST(3 AS LONG_INT) AS _longint, 3.0 AS _real, 'xyz' AS _text, CAST(NULL AS BOOL) AS _nullable_bool;
+  SELECT
+      TRUE AS _bool,
+      2 AS _integer,
+      CAST(3 AS LONG_INT) AS _longint,
+      3.0 AS _real,
+      'xyz' AS _text,
+      CAST(NULL AS BOOL) AS _nullable_bool;
 END;
 --]]
 
@@ -849,10 +858,13 @@ end
 --[[
 CREATE PROC with_stmt_using_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
-  SELECT *
-    FROM X;
+  DECLARE C CURSOR FOR
+    WITH
+      X (a, b, c) AS (
+        SELECT 1, 2, 3
+      )
+    SELECT *
+      FROM X;
   FETCH C;
 END;
 --]]
@@ -865,7 +877,7 @@ function with_stmt_using_cursor(_db_)
   local C_types_ = "III"
 
   _rc_, C_stmt = cql_prepare(_db_, 
-    "WITH X (a, b, c) AS (SELECT 1, 2, 3) SELECT a, b, c FROM X")
+    "WITH X (a, b, c) AS ( SELECT 1, 2, 3 ) SELECT a, b, c FROM X")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   -- step and fetch
   _rc_ = cql_multifetch(C_stmt, C, C_types_, C_fields_)
@@ -884,7 +896,9 @@ end
 CREATE PROC with_stmt ()
 BEGIN
   WITH
-  X (a, b, c) AS (SELECT 1, 2, 3)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+    )
   SELECT *
     FROM X;
 END;
@@ -894,7 +908,7 @@ function with_stmt(_db_)
   local _rc_ = CQL_OK
   local _result_stmt = nil
   _rc_, _result_stmt = cql_prepare(_db_, 
-    "WITH X (a, b, c) AS (SELECT 1, 2, 3) SELECT a, b, c FROM X")
+    "WITH X (a, b, c) AS ( SELECT 1, 2, 3 ) SELECT a, b, c FROM X")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = CQL_OK
 
@@ -923,9 +937,11 @@ end
 CREATE PROC with_recursive_stmt ()
 BEGIN
   WITH RECURSIVE
-  X (a, b, c) AS (SELECT 1, 2, 3
-  UNION ALL
-  SELECT 4, 5, 6)
+    X (a, b, c) AS (
+      SELECT 1, 2, 3
+      UNION ALL
+      SELECT 4, 5, 6
+    )
   SELECT *
     FROM X;
 END;
@@ -935,7 +951,7 @@ function with_recursive_stmt(_db_)
   local _rc_ = CQL_OK
   local _result_stmt = nil
   _rc_, _result_stmt = cql_prepare(_db_, 
-    "WITH RECURSIVE X (a, b, c) AS (SELECT 1, 2, 3 UNION ALL SELECT 4, 5, 6) SELECT a, b, c FROM X")
+    "WITH RECURSIVE X (a, b, c) AS ( SELECT 1, 2, 3 UNION ALL SELECT 4, 5, 6 ) SELECT a, b, c FROM X")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = CQL_OK
 
@@ -1035,7 +1051,8 @@ end
 --[[
 CREATE PROC outint_nullable (OUT output INTEGER, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -1071,7 +1088,8 @@ end
 --[[
 CREATE PROC outint_notnull (OUT output INTEGER NOT NULL, OUT result BOOL NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1;
+  DECLARE C CURSOR FOR
+    SELECT 1;
   FETCH C INTO output;
   SET result := C;
 END;
@@ -1238,7 +1256,8 @@ end
 --[[
 CREATE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER)
 BEGIN
-  INSERT INTO bar(id, type) VALUES(id_, type_);
+  INSERT INTO bar(id, type)
+    VALUES(id_, type_);
 END;
 --]]
 
@@ -1375,11 +1394,13 @@ end
 --[[
 CREATE PROC misc_dml_proc ()
 BEGIN
-  INSERT INTO foo(id) VALUES(NULL);
-  INSERT INTO foo(id) VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
+  INSERT INTO foo(id)
+    VALUES(NULL);
   UPDATE bar
-  SET name = 'bar'
-    WHERE name = 'baz';
+    SET name = 'bar'
+      WHERE name = 'baz';
   DELETE FROM foo WHERE id = 1;
 END;
 --]]
@@ -1571,8 +1592,9 @@ end
 --[[
 CREATE PROC out_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT bar.*, 'xyzzy' AS extra1, 'plugh' AS extra2
+      FROM bar;
   FETCH C;
   OUT C;
 END;
@@ -1712,7 +1734,7 @@ CREATE PROC thread_theme_info_list (thread_key_ LONG_INT NOT NULL)
 BEGIN
   SELECT *
     FROM (SELECT thread_key
-    FROM threads) AS T;
+        FROM threads) AS T;
 END;
 --]]
 
@@ -1829,7 +1851,8 @@ end
 CREATE PROC no_cleanup_label_needed_proc ()
 BEGIN
   BEGIN TRY
-    DECLARE C CURSOR FOR SELECT 1 AS N;
+    DECLARE C CURSOR FOR
+      SELECT 1 AS N;
     FETCH C;
   END TRY;
   BEGIN CATCH
@@ -2201,16 +2224,19 @@ end
 CREATE PROC with_inserter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) SELECT *
-    FROM x;
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    SELECT *
+      FROM x;
 END;
 --]]
 
 function with_inserter(_db_)
   local _rc_ = CQL_OK
   _rc_ = cql_exec(_db_,
-    "WITH x (a) AS (SELECT 111) INSERT INTO foo(id) SELECT a FROM x")
+    "WITH x (a) AS ( SELECT 111 ) INSERT INTO foo(id) SELECT a FROM x")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = CQL_OK
 
@@ -2303,7 +2329,8 @@ end
 --[[
 CREATE PROC loop_statement_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.A);
@@ -2342,7 +2369,8 @@ end
 --[[
 CREATE PROC loop_statement_not_auto_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A;
   DECLARE A_ INTEGER NOT NULL;
   LOOP FETCH C INTO A_
   BEGIN
@@ -2412,7 +2440,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -2456,7 +2485,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     FETCH C;
   END;
 END;
@@ -2500,7 +2530,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL simple_select();
+    DECLARE C CURSOR FOR
+      CALL simple_select();
     DECLARE box OBJECT<C CURSOR>;
     SET box FROM CURSOR C;
     DECLARE D CURSOR FOR box;
@@ -2573,7 +2604,8 @@ end
 --[[
 CREATE PROC out_union_dml_helper ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   OUT UNION C;
 END;
@@ -2614,7 +2646,8 @@ BEGIN
   WHILE i < 5
   BEGIN
     SET i := i + 1;
-    DECLARE C CURSOR FOR CALL out_union_helper();
+    DECLARE C CURSOR FOR
+      CALL out_union_helper();
     FETCH C;
   END;
 END;
@@ -2961,7 +2994,8 @@ end
 @ATTRIBUTE(cql:identity=(id))
 CREATE PROC out_cursor_identity ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 2 AS data;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 2 AS data;
   FETCH C;
   OUT C;
 END;
@@ -3046,7 +3080,9 @@ end
 CREATE PROC with_deleter ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   DELETE FROM foo WHERE id IN (SELECT *
     FROM x);
 END;
@@ -3055,7 +3091,7 @@ END;
 function with_deleter(_db_)
   local _rc_ = CQL_OK
   _rc_ = cql_exec(_db_,
-    "WITH x (a) AS (SELECT 111) DELETE FROM foo WHERE id IN (SELECT a FROM x)")
+    "WITH x (a) AS ( SELECT 111 ) DELETE FROM foo WHERE id IN (SELECT a FROM x)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = CQL_OK
 
@@ -3069,18 +3105,20 @@ end
 CREATE PROC with_updater ()
 BEGIN
   WITH
-  x (a) AS (SELECT 111)
+    x (a) AS (
+      SELECT 111
+    )
   UPDATE bar
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 --]]
 
 function with_updater(_db_)
   local _rc_ = CQL_OK
   _rc_ = cql_exec(_db_,
-    "WITH x (a) AS (SELECT 111) UPDATE bar SET name = 'xyzzy' WHERE id IN (SELECT a FROM x)")
+    "WITH x (a) AS ( SELECT 111 ) UPDATE bar SET name = 'xyzzy' WHERE id IN (SELECT a FROM x)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = CQL_OK
 
@@ -3223,12 +3261,13 @@ end
 --[[
 CREATE PROC settings_info ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
-    FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
-    FROM unread_pending_threads AS P
-  UNION ALL
-  SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
-    FROM switch_account_badges AS S) AS A;
+  DECLARE C CURSOR FOR
+    SELECT SUM(A.unread_pending_thread_count) AS unread_pending_thread_count, SUM(A.switch_account_badge_count) AS switch_account_badge_count
+      FROM (SELECT P.unread_pending_thread_count AS unread_pending_thread_count, 0 AS switch_account_badge_count
+          FROM unread_pending_threads AS P
+        UNION ALL
+        SELECT 0 AS unread_pending_thread_count, S.badge_count AS switch_account_badge_count
+          FROM switch_account_badges AS S) AS A;
 END;
 --]]
 
@@ -3335,8 +3374,10 @@ end
 CREATE PROC use_with_select ()
 BEGIN
   DECLARE x INTEGER;
-  SET x := ( WITH
-  threads2 (count) AS (SELECT 1 AS foo)
+  SET x := (   WITH
+    threads2 (count) AS (
+      SELECT 1 AS foo
+    )
   SELECT COUNT(*)
     FROM threads2 );
 END;
@@ -3349,7 +3390,7 @@ function use_with_select(_db_)
   local _temp_stmt = nil
 
   _rc_, _temp_stmt = cql_prepare(_db_, 
-    "WITH threads2 (count) AS (SELECT 1) SELECT COUNT(*) FROM threads2")
+    "WITH threads2 (count) AS ( SELECT 1 ) SELECT COUNT(*) FROM threads2")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = cql_step(_temp_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
@@ -3370,8 +3411,9 @@ end
 --[[
 CREATE PROC rowset_object_reader (rowset OBJECT<rowset>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM ReadFromRowset(rowset);
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM ReadFromRowset(rowset);
 END;
 --]]
 
@@ -3400,12 +3442,13 @@ end
 --[[
 CREATE PROC upsert_do_something ()
 BEGIN
-  INSERT INTO foo(id) SELECT id
-    FROM bar
-    WHERE 1
+  INSERT INTO foo(id)
+    SELECT id
+      FROM bar
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 --]]
 
@@ -3426,20 +3469,23 @@ end
 CREATE PROC with_upsert_form ()
 BEGIN
   WITH
-  names (id) AS (VALUES(1), (5), (3), (12))
-  INSERT INTO foo(id) SELECT id
-    FROM names
-    WHERE 1
+    names (id) AS (
+      VALUES(1), (5), (3), (12)
+    )
+  INSERT INTO foo(id)
+    SELECT id
+      FROM names
+      WHERE 1
   ON CONFLICT (id) DO UPDATE
-  SET id = 10
-    WHERE id <> 10;
+    SET id = 10
+      WHERE id <> 10;
 END;
 --]]
 
 function with_upsert_form(_db_)
   local _rc_ = CQL_OK
   _rc_ = cql_exec(_db_,
-    "WITH names (id) AS (VALUES(1), (5), (3), (12)) INSERT INTO foo(id) SELECT id FROM names WHERE 1 ON CONFLICT (id) DO UPDATE SET id = 10 WHERE id <> 10")
+    "WITH names (id) AS ( VALUES(1), (5), (3), (12) ) INSERT INTO foo(id) SELECT id FROM names WHERE 1 ON CONFLICT (id) DO UPDATE SET id = 10 WHERE id <> 10")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   _rc_ = CQL_OK
 
@@ -3452,7 +3498,8 @@ end
 --[[
 CREATE PROC upsert_do_nothing (id_ INTEGER NOT NULL)
 BEGIN
-  INSERT INTO foo(id) VALUES(id_)
+  INSERT INTO foo(id)
+    VALUES(id_)
   ON CONFLICT DO NOTHING;
 END;
 --]]
@@ -3600,7 +3647,8 @@ end
 --[[
 CREATE PROC out_union_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_two();
+  DECLARE c CURSOR FOR
+    CALL out_union_two();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -3641,7 +3689,8 @@ end
 --[[
 CREATE PROC out_union_from_select ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x, '2' AS y;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x, '2' AS y;
   FETCH C;
   OUT UNION C;
   OUT UNION C;
@@ -3681,7 +3730,8 @@ end
 --[[
 CREATE PROC out_union_dml_reader ()
 BEGIN
-  DECLARE c CURSOR FOR CALL out_union_from_select();
+  DECLARE c CURSOR FOR
+    CALL out_union_from_select();
   LOOP FETCH C
   BEGIN
     CALL printf("%d %s\n", C.x, C.y);
@@ -3754,7 +3804,8 @@ end
 --[[
 CREATE PROC read_out_union_values (a INTEGER NOT NULL, b INTEGER NOT NULL)
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_values(a, b);
+  DECLARE C CURSOR FOR
+    CALL out_union_values(a, b);
   FETCH C;
 END;
 --]]
@@ -3791,8 +3842,9 @@ end
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml ()
 BEGIN
-  DECLARE x CURSOR FOR SELECT *
-    FROM radioactive;
+  DECLARE x CURSOR FOR
+    SELECT *
+      FROM radioactive;
   FETCH x;
   OUT UNION x;
 END;
@@ -3829,7 +3881,8 @@ end
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC out_union_dml_for_call ()
 BEGIN
-  DECLARE C CURSOR FOR CALL out_union_dml();
+  DECLARE C CURSOR FOR
+    CALL out_union_dml();
   FETCH C;
 END;
 --]]
@@ -4070,7 +4123,8 @@ BEGIN
   WHILE 1
   BEGIN
   END;
-  DECLARE c CURSOR FOR SELECT 1 AS x;
+  DECLARE c CURSOR FOR
+    SELECT 1 AS x;
   LOOP FETCH c
   BEGIN
   END;
@@ -4176,7 +4230,8 @@ end
 --[[
 CREATE PROC pretty_print_with_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "it's high noon\r\n\f\b\t\v");
+  INSERT INTO bar(id, name)
+    VALUES(1, "it's high noon\r\n\f\b\t\v");
 END;
 --]]
 
@@ -4196,7 +4251,8 @@ end
 --[[
 CREATE PROC hex_quote ()
 BEGIN
-  INSERT INTO bar(id, name) VALUES(1, "\x01\x02\xa1\x1bg");
+  INSERT INTO bar(id, name)
+    VALUES(1, "\x01\x02\xa1\x1bg");
 END;
 --]]
 
@@ -4447,7 +4503,8 @@ end
 --[[
 CREATE PROC early_out_rc_cleared (OUT x INTEGER)
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   FETCH C;
   IF C THEN
     RETURN;
@@ -4720,8 +4777,9 @@ end
 @ATTRIBUTE(cql:vault_sensitive)
 CREATE PROC vault_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT name
-    FROM vault_mixed_sensitive;
+  DECLARE C CURSOR FOR
+    SELECT name
+      FROM vault_mixed_sensitive;
   FETCH c;
 END;
 --]]
@@ -4866,8 +4924,9 @@ end
 --[[
 CREATE PROC try_boxing (OUT result OBJECT<bar CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET result FROM CURSOR C;
 END;
 --]]
@@ -6376,7 +6435,8 @@ end
 --[[
 CREATE PROC use_private_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL private_out_union();
+  DECLARE C CURSOR FOR
+    CALL private_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -6444,7 +6504,8 @@ end
 --[[
 CREATE PROC use_no_getters_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL no_getters_out_union();
+  DECLARE C CURSOR FOR
+    CALL no_getters_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -6512,7 +6573,8 @@ end
 --[[
 CREATE PROC use_suppress_results_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL suppress_results_out_union();
+  DECLARE C CURSOR FOR
+    CALL suppress_results_out_union();
   LOOP FETCH C
   BEGIN
     CALL printf("%d\n", C.a_field);
@@ -6703,8 +6765,9 @@ end
 --[[
 CREATE PROC try_catch_rc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 'foo' AS extra2
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT 'foo' AS extra2
+      FROM bar;
   BEGIN TRY
     FETCH C;
   END TRY;
@@ -7180,8 +7243,9 @@ local false_test = false
 --[[
 CREATE PROC BigFormat ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM big_data;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM big_data;
   LOOP FETCH C
   BEGIN
     LET s := cql_cursor_format(C);
@@ -7522,7 +7586,7 @@ end
 CREATE PROC foo ()
 BEGIN
   WITH
-  shared_frag (shared_something) AS (CALL shared_frag())
+    shared_frag (shared_something) AS (CALL shared_frag())
   SELECT *
     FROM shared_frag;
 END;
@@ -7567,8 +7631,10 @@ end
 CREATE PROC shared_conditional_user (x INTEGER NOT NULL)
 BEGIN
   WITH
-  some_cte (id) AS (SELECT x),
-  shared_conditional (x) AS (CALL shared_conditional(1))
+    some_cte (id) AS (
+      SELECT x
+    ),
+    shared_conditional (x) AS (CALL shared_conditional(1))
   SELECT bar.*
     FROM bar
     INNER JOIN some_cte ON x = 5;
@@ -7609,7 +7675,7 @@ function shared_conditional_user(_db_, x)
   _rc_, _result_stmt = cql_prepare_var(_db_, 
     5, _preds_1,
     {
-    "WITH some_cte (id) AS (SELECT ?), shared_conditional (x) AS (",
+    "WITH some_cte (id) AS ( SELECT ? ), shared_conditional (x) AS (",
     "SELECT ?",
     "SELECT ? + ?",
     "SELECT ? + ? + ?",
@@ -7646,7 +7712,7 @@ end
 CREATE PROC nested_shared_stuff ()
 BEGIN
   WITH
-  nested_shared_proc (x) AS (CALL nested_shared_proc(1))
+    nested_shared_proc (x) AS (CALL nested_shared_proc(1))
   SELECT *
     FROM nested_shared_proc;
 END;
@@ -7693,7 +7759,7 @@ function nested_shared_stuff(_db_)
     8, _preds_1,
     {
     "WITH nested_shared_proc (x) AS (",
-    "WITH shared_conditional (x) AS (",
+    "  WITH shared_conditional (x) AS (",
     "SELECT ?",
     "SELECT ? + ?",
     "SELECT ? + ? + ?",
@@ -7780,7 +7846,7 @@ function use_nested_select_shared_frag_form(_db_)
     {
     "SELECT x FROM (",
     "(",
-    "WITH shared_conditional (x) AS (",
+    "  WITH shared_conditional (x) AS (",
     "SELECT ?",
     "SELECT ? + ?",
     "SELECT ? + ? + ?",
@@ -7867,7 +7933,8 @@ end
 --[[
 CREATE PROC blob_serialization_test ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'foo' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'foo' AS name;
   FETCH C;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
@@ -8024,7 +8091,8 @@ DECLARE PROC some_redeclared_out_proc () OUT (x INTEGER) USING TRANSACTION;
 --[[
 CREATE PROC some_redeclared_out_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT c;
 END;
@@ -8082,7 +8150,8 @@ DECLARE PROC some_redeclared_out_union_proc () OUT UNION (x INTEGER) USING TRANS
 --[[
 CREATE PROC some_redeclared_out_union_proc ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS x;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS x;
   FETCH c;
   OUT UNION c;
 END;
@@ -8198,7 +8267,8 @@ end
 --[[
 CREATE PROC mutated_in_arg3 (x TEXT)
 BEGIN
-  DECLARE C CURSOR FOR SELECT "x" AS x;
+  DECLARE C CURSOR FOR
+    SELECT "x" AS x;
   FETCH C INTO x;
 END;
 --]]
@@ -8377,7 +8447,7 @@ CREATE PROC explain_equery_plan_backed (OUT x BOOL NOT NULL)
 BEGIN
   EXPLAIN QUERY PLAN
   WITH
-  backed (rowid, pk, flag, id, name, age, storage) AS (CALL _backed())
+    backed (rowid, pk, flag, id, name, age, storage) AS (CALL _backed())
   SELECT *
     FROM backed;
 END;
@@ -8416,7 +8486,7 @@ BEGIN
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 --]]
 
@@ -8469,14 +8539,15 @@ BEGIN
   LET i := 0;
   WHILE i < 10
   BEGIN
-    DECLARE C CURSOR FOR SELECT *
-      FROM foo
-      WHERE id = i;
+    DECLARE C CURSOR FOR
+      SELECT *
+        FROM foo
+        WHERE id = i;
     FETCH C;
     SET i := i + 1;
   END;
   LET x := ( SELECT EXISTS (SELECT 1
-    FROM foo) );
+      FROM foo) );
 END;
 --]]
 
@@ -9170,9 +9241,10 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  DECLARE foo_cursor CURSOR FOR SELECT id, i2
-    FROM foo
-    WHERE id = i0_nullable;
+  DECLARE foo_cursor CURSOR FOR
+    SELECT id, i2
+      FROM foo
+      WHERE id = i0_nullable;
   --]]
   _rc_, foo_cursor_stmt = cql_prepare(_db_, 
     "SELECT id, ? FROM foo WHERE id = ?")
@@ -9194,7 +9266,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  DECLARE basic_cursor CURSOR FOR SELECT 1, 2.5;
+  DECLARE basic_cursor CURSOR FOR
+    SELECT 1, 2.5;
   --]]
   _rc_, basic_cursor_stmt = cql_prepare(_db_, 
     "SELECT 1, 2.5")
@@ -9237,7 +9310,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  DECLARE exchange_cursor CURSOR FOR SELECT arg2, arg1;
+  DECLARE exchange_cursor CURSOR FOR
+    SELECT arg2, arg1;
   --]]
   _rc_, exchange_cursor_stmt = cql_prepare(_db_, 
     "SELECT ?, ?")
@@ -9763,7 +9837,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5);
+  INSERT OR REPLACE INTO bar(id, type)
+    VALUES(1, 5);
   --]]
   _rc_ = cql_exec(_db_,
     "INSERT OR REPLACE INTO bar(id, type) VALUES(1, 5)")
@@ -9782,7 +9857,7 @@ function cql_startup(_db_)
 
   --[[
   SET b2 := ( SELECT EXISTS (SELECT *
-    FROM bar) );
+      FROM bar) );
   --]]
   _rc_, _temp_stmt = cql_prepare(_db_, 
     "SELECT EXISTS (SELECT * FROM bar)")
@@ -9796,8 +9871,9 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  DECLARE expanded_select CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE expanded_select CURSOR FOR
+    SELECT *
+      FROM bar;
   --]]
   _rc_, expanded_select_stmt = cql_prepare(_db_, 
     "SELECT id, name, rate, type, size FROM bar")
@@ -9806,8 +9882,9 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  DECLARE table_expanded_select CURSOR FOR SELECT bar.*
-    FROM bar;
+  DECLARE table_expanded_select CURSOR FOR
+    SELECT bar.*
+      FROM bar;
   --]]
   _rc_, table_expanded_select_stmt = cql_prepare(_db_, 
     "SELECT bar.id, bar.name, bar.rate, bar.type, bar.size FROM bar")
@@ -10052,7 +10129,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
+  INSERT INTO blob_table(blob_id, b_nullable, b_notnull)
+    VALUES(0, blob_var, blob_var_notnull);
   --]]
   _rc_, _temp_stmt = cql_prepare(_db_, 
     "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)")
@@ -10107,12 +10185,15 @@ function cql_startup(_db_)
 
   --[[
   WITH
-  x (a) AS (SELECT 111)
-  INSERT INTO foo(id) VALUES(ifnull(( SELECT a
-    FROM x ), 0));
+    x (a) AS (
+      SELECT 111
+    )
+  INSERT INTO foo(id)
+    VALUES(ifnull(( SELECT a
+      FROM x ), 0));
   --]]
   _rc_ = cql_exec(_db_,
-    "WITH x (a) AS (SELECT 111) INSERT INTO foo(id) VALUES(ifnull(( SELECT a FROM x ), 0))")
+    "WITH x (a) AS ( SELECT 111 ) INSERT INTO foo(id) VALUES(ifnull(( SELECT a FROM x ), 0))")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
 
   -- The statement ending at line XXXX
@@ -10132,7 +10213,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  DECLARE global_cursor CURSOR FOR SELECT 1 AS a, 2 AS b;
+  DECLARE global_cursor CURSOR FOR
+    SELECT 1 AS a, 2 AS b;
   --]]
   _rc_, global_cursor_stmt = cql_prepare(_db_, 
     "SELECT 1, 2")
@@ -10253,13 +10335,15 @@ function cql_startup(_db_)
 
   --[[
   WITH
-  some_cte (id) AS (SELECT 1 AS id)
+    some_cte (id) AS (
+      SELECT 1 AS id
+    )
   INSERT INTO bar(id) VALUES(ifnull(( SELECT id
     FROM some_cte ), 0)) @DUMMY_SEED(1337);
   --]]
   _seed_ = 1337
   _rc_ = cql_exec(_db_,
-    "WITH some_cte (id) AS (SELECT 1 AS id) INSERT INTO bar(id) VALUES(ifnull(( SELECT id FROM some_cte ), 0))")
+    "WITH some_cte (id) AS ( SELECT 1 AS id ) INSERT INTO bar(id) VALUES(ifnull(( SELECT id FROM some_cte ), 0))")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
 
   -- The statement ending at line XXXX
@@ -10267,7 +10351,7 @@ function cql_startup(_db_)
   --[[
   INSERT INTO bar(id) VALUES(1) @DUMMY_SEED(1338)
   ON CONFLICT (id) DO UPDATE
-  SET id = 10;
+    SET id = 10;
   --]]
   _seed_ = 1338
   _rc_ = cql_exec(_db_,
@@ -10560,7 +10644,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  INSERT INTO virtual_with_hidden(vy) VALUES(1);
+  INSERT INTO virtual_with_hidden(vy)
+    VALUES(1);
   --]]
   _rc_ = cql_exec(_db_,
     "INSERT INTO virtual_with_hidden(vy) VALUES(1)")
@@ -10569,7 +10654,8 @@ function cql_startup(_db_)
   -- The statement ending at line XXXX
 
   --[[
-  INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2);
+  INSERT INTO virtual_with_hidden(vx, vy)
+    VALUES(1, 2);
   --]]
   _rc_ = cql_exec(_db_,
     "INSERT INTO virtual_with_hidden(vx, vy) VALUES(1, 2)")

--- a/sources/test/cg_test_lua.sql
+++ b/sources/test/cg_test_lua.sql
@@ -868,7 +868,7 @@ end;
 -- TEST: create a simple with statement
 -- + local C_fields_ = { "a", "b", "c" }
 -- + local C_types_ = "III"
--- + "WITH X (a, b, c) AS (SELECT 1, 2, 3) SELECT a, b, c FROM X")
+-- + "WITH X (a, b, c) AS ( SELECT 1, 2, 3 ) SELECT a, b, c FROM X")
 -- +  _rc_ = cql_multifetch(C_stmt, C, C_types_, C_fields_)
 -- - fetch_results
 create proc with_stmt_using_cursor()
@@ -880,7 +880,7 @@ begin
 end;
 
 -- TEST: with statement top level
--- + "WITH X (a, b, c) AS (SELECT 1, 2, 3) SELECT a, b, c FROM X")
+-- + "WITH X (a, b, c) AS ( SELECT 1, 2, 3 ) SELECT a, b, c FROM X")
 -- + _rc_, result_set = cql_fetch_all_rows(stmt, "III", { "a", "b", "c" })
 create proc with_stmt()
 begin
@@ -888,7 +888,7 @@ begin
 end;
 
 -- TEST: with recursive statement top level
--- + "WITH RECURSIVE X (a, b, c) AS (SELECT 1, 2, 3 UNION ALL SELECT 4, 5, 6) SELECT a, b, c FROM X"
+-- + "WITH RECURSIVE X (a, b, c) AS ( SELECT 1, 2, 3 UNION ALL SELECT 4, 5, 6 ) SELECT a, b, c FROM X"
 -- + _rc_, result_set = cql_fetch_all_rows(stmt, "III", { "a", "b", "c" })
 create proc with_recursive_stmt()
 begin
@@ -1390,7 +1390,8 @@ declare blob_var_notnull blob not null;
 set blob_var_notnull := blob_notnull_func();
 
 -- TEST: bind a nullable blob and a not null blob
--- + INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
+-- + INSERT INTO blob_table(blob_id, b_nullable, b_notnull)
+-- +   VALUES(0, blob_var, blob_var_notnull);
 -- + "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)"
 -- + _rc_ = cql_multibind(_db_, _temp_stmt, "bB", blob_var, blob_var_notnull)
 insert into blob_table(blob_id, b_nullable, b_notnull) values(0, blob_var, blob_var_notnull);
@@ -1730,12 +1731,12 @@ end;
 
 -- TEST: use with-insert form
 -- +  _rc_ = cql_exec(_db_,
--- + "WITH x (a) AS (SELECT 111) INSERT INTO foo(id) VALUES(ifnull(( SELECT a FROM x ), 0))"
+-- + "WITH x (a) AS ( SELECT 111 ) INSERT INTO foo(id) VALUES(ifnull(( SELECT a FROM x ), 0))"
 with x(a) as (select 111)
 insert into foo values ( ifnull((select a from x), 0));
 
 -- TEST: use insert from select (put this in a proc to force the schema utils to walk it)
--- + "WITH x (a) AS (SELECT 111) INSERT INTO foo(id) SELECT a FROM x")
+-- + "WITH x (a) AS ( SELECT 111 ) INSERT INTO foo(id) SELECT a FROM x")
 create proc with_inserter()
 begin
   with x(a) as (select 111)
@@ -2200,7 +2201,7 @@ begin
 end;
 
 -- TEST: with delete form
--- +  "WITH x (a) AS (SELECT 111) DELETE FROM foo WHERE id IN (SELECT a FROM x)")
+-- +  "WITH x (a) AS ( SELECT 111 ) DELETE FROM foo WHERE id IN (SELECT a FROM x)")
 create proc with_deleter()
 begin
   with x(a) as (select 111)
@@ -2208,7 +2209,7 @@ begin
 end;
 
 -- TEST: with update form
--- +  "WITH x (a) AS (SELECT 111) UPDATE bar SET name = 'xyzzy' WHERE id IN (SELECT a FROM x)"
+-- +  "WITH x (a) AS ( SELECT 111 ) UPDATE bar SET name = 'xyzzy' WHERE id IN (SELECT a FROM x)"
 create proc with_updater()
 begin
   with x(a) as (select 111)
@@ -2331,7 +2332,7 @@ BEGIN
 END;
 
 -- TEST: try to use a WITH_SELECT form in a select expression
--- + "WITH threads2 (count) AS (SELECT 1) SELECT COUNT(*) FROM threads2"
+-- + "WITH threads2 (count) AS ( SELECT 1 ) SELECT COUNT(*) FROM threads2"
 -- + _tmp_int_0 = cql_get_value(_temp_stmt, 0)
 -- + x = _tmp_int_0
 create proc use_with_select()
@@ -2363,7 +2364,7 @@ END;
 
 -- TEST: codegen with upsert statement form
 -- + function with_upsert_form(_db_)
--- + "WITH names (id) AS (VALUES(1), (5), (3), (12)) INSERT INTO foo(id)
+-- + "WITH names (id) AS ( VALUES(1), (5), (3), (12) ) INSERT INTO foo(id)
 -- + SELECT id FROM names WHERE 1 ON CONFLICT (id) DO UPDATE SET id = 10 WHERE id <> 10"
 create proc with_upsert_form()
 BEGIN
@@ -2381,7 +2382,7 @@ END;
 
 -- TEST: codegen with-insert with a seed
 -- + _seed_ = 1337
--- + "WITH some_cte (id) AS (SELECT 1 AS id) INSERT INTO bar(id) VALUES(ifnull(( SELECT id FROM some_cte ), 0))"
+-- + "WITH some_cte (id) AS ( SELECT 1 AS id ) INSERT INTO bar(id) VALUES(ifnull(( SELECT id FROM some_cte ), 0))"
 with some_cte(id) as (select 1 id)
 insert into bar(id)
 values (ifnull((select id from some_cte), 0))
@@ -4599,7 +4600,7 @@ end;
 -- + 5, _preds_1,
 --
 -- root fragment 0 always present
--- + "WITH some_cte (id) AS (SELECT ?), shared_conditional (x) AS (",
+-- + "WITH some_cte (id) AS ( SELECT ? ), shared_conditional (x) AS (",
 --
 -- option 1 fragment 1
 -- + "SELECT ?",
@@ -4726,7 +4727,7 @@ end;
 -- +  "(",
 --
 -- fragment 2 present if x <= 5
--- +  "WITH shared_conditional (x) AS (",
+-- + "  WITH shared_conditional (x) AS (",
 --
 -- fragment 3 present if x == 1
 -- first variable binding v[0] = pred[3]

--- a/sources/test/cg_test_query_plan.out.ref
+++ b/sources/test/cg_test_query_plan.out.ref
@@ -210,14 +210,13 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "UPDATE `table one`\\nSET id = 1,\\nname = '1'\\n  WHERE name IN (SELECT T.NAME\\n  FROM t3 AS T)";
+  SET stmt := "UPDATE `table one`\\n  SET id = 1, name = '1'\\n    WHERE name IN (SELECT T.NAME\\n    FROM t3 AS T)";
   INSERT INTO sql_temp(id, sql) VALUES(3, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   UPDATE `table one`
-  SET id = 1,
-  name = '1'
-    WHERE name IN (SELECT T.NAME
-    FROM t3 AS T);
+    SET id = 1, name = '1'
+      WHERE name IN (SELECT T.NAME
+      FROM t3 AS T);
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(3, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -230,17 +229,18 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nsome_cte (id, name) AS (SELECT T.*\\n  FROM t2 AS T)\\nUPDATE `table one`\\nSET id = 1,\\nname = '1'\\n  WHERE name IN (SELECT name\\n  FROM some_cte)";
+  SET stmt := "WITH\\n  some_cte (id, name) AS (\\n    SELECT T.*\\n      FROM t2 AS T\\n  )\\nUPDATE `table one`\\n  SET id = 1, name = '1'\\n    WHERE name IN (SELECT name\\n    FROM some_cte)";
   INSERT INTO sql_temp(id, sql) VALUES(4, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  some_cte (id, name) AS (SELECT T.*
-    FROM t2 AS T)
+    some_cte (id, name) AS (
+      SELECT T.*
+        FROM t2 AS T
+    )
   UPDATE `table one`
-  SET id = 1,
-  name = '1'
-    WHERE name IN (SELECT name
-    FROM some_cte);
+    SET id = 1, name = '1'
+      WHERE name IN (SELECT name
+      FROM some_cte);
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(4, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -271,13 +271,15 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nsome_cte (name) AS (SELECT foo.name\\n  FROM t2 AS foo\\n  INNER JOIN t3 USING (id))\\nDELETE FROM `table one` WHERE name NOT IN (SELECT *\\n  FROM some_cte)";
+  SET stmt := "WITH\\n  some_cte (name) AS (\\n    SELECT foo.name\\n      FROM t2 AS foo\\n      INNER JOIN t3 USING (id)\\n  )\\nDELETE FROM `table one` WHERE name NOT IN (SELECT *\\n  FROM some_cte)";
   INSERT INTO sql_temp(id, sql) VALUES(6, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  some_cte (name) AS (SELECT foo.name
-    FROM t2 AS foo
-    INNER JOIN t3 USING (id))
+    some_cte (name) AS (
+      SELECT foo.name
+        FROM t2 AS foo
+        INNER JOIN t3 USING (id)
+    )
   DELETE FROM `table one` WHERE name NOT IN (SELECT *
     FROM some_cte);
   LOOP FETCH C
@@ -292,14 +294,15 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "INSERT INTO `table one`(id, name) SELECT foo.*\\n  FROM t2 AS foo\\nUNION ALL\\nSELECT bar.*\\n  FROM t3 AS bar";
+  SET stmt := "INSERT INTO `table one`(id, name)\\n  SELECT foo.*\\n    FROM t2 AS foo\\n  UNION ALL\\n  SELECT bar.*\\n    FROM t3 AS bar";
   INSERT INTO sql_temp(id, sql) VALUES(7, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
-  INSERT INTO `table one`(id, name) SELECT foo.*
-    FROM t2 AS foo
-  UNION ALL
-  SELECT bar.*
-    FROM t3 AS bar;
+  INSERT INTO `table one`(id, name)
+    SELECT foo.*
+      FROM t2 AS foo
+    UNION ALL
+    SELECT bar.*
+      FROM t3 AS bar;
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(7, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -312,14 +315,17 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nsome_cte (id, name) AS (SELECT T.*\\n  FROM t2 AS T)\\nINSERT INTO `table one`(id, name) SELECT *\\n  FROM some_cte";
+  SET stmt := "WITH\\n  some_cte (id, name) AS (\\n    SELECT T.*\\n      FROM t2 AS T\\n  )\\nINSERT INTO `table one`(id, name)\\n  SELECT *\\n    FROM some_cte";
   INSERT INTO sql_temp(id, sql) VALUES(8, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  some_cte (id, name) AS (SELECT T.*
-    FROM t2 AS T)
-  INSERT INTO `table one`(id, name) SELECT *
-    FROM some_cte;
+    some_cte (id, name) AS (
+      SELECT T.*
+        FROM t2 AS T
+    )
+  INSERT INTO `table one`(id, name)
+    SELECT *
+      FROM some_cte;
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(8, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -348,12 +354,13 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "INSERT INTO `table one`(id, name) VALUES(1, 'Irene')\\nON CONFLICT (id) DO UPDATE\\nSET name = excluded.name || 'replace' || ' \\u00e2\\u0080\\u00a2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
+  SET stmt := "INSERT INTO `table one`(id, name)\\n  VALUES(1, 'Irene')\\nON CONFLICT (id) DO UPDATE\\n  SET name = excluded.name || 'replace' || ' \\u00e2\\u0080\\u00a2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
   INSERT INTO sql_temp(id, sql) VALUES(10, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
-  INSERT INTO `table one`(id, name) VALUES(1, 'Irene')
+  INSERT INTO `table one`(id, name)
+    VALUES(1, 'Irene')
   ON CONFLICT (id) DO UPDATE
-  SET name = excluded.name || 'replace' || ' • ' || '\x01\x02\xA1\x1b\x00\xg' || 'it''s high noon\r\n\f\b\t\v' || "it's" || name;
+    SET name = excluded.name || 'replace' || ' • ' || '\x01\x02\xA1\x1b\x00\xg' || 'it''s high noon\r\n\f\b\t\v' || "it's" || name;
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(10, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -366,16 +373,19 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nsome_cte (id, name) AS (SELECT 1, 'Irene')\\nINSERT INTO `table one`(id, name) SELECT *\\n  FROM some_cte\\n  WHERE id = 1\\nON CONFLICT (id) DO UPDATE\\nSET name = excluded.name || 'replace' || ' \\u00e2\\u0080\\u00a2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
+  SET stmt := "WITH\\n  some_cte (id, name) AS (\\n    SELECT 1, 'Irene'\\n  )\\nINSERT INTO `table one`(id, name)\\n  SELECT *\\n    FROM some_cte\\n    WHERE id = 1\\nON CONFLICT (id) DO UPDATE\\n  SET name = excluded.name || 'replace' || ' \\u00e2\\u0080\\u00a2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
   INSERT INTO sql_temp(id, sql) VALUES(11, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  some_cte (id, name) AS (SELECT 1, 'Irene')
-  INSERT INTO `table one`(id, name) SELECT *
-    FROM some_cte
-    WHERE id = 1
+    some_cte (id, name) AS (
+      SELECT 1, 'Irene'
+    )
+  INSERT INTO `table one`(id, name)
+    SELECT *
+      FROM some_cte
+      WHERE id = 1
   ON CONFLICT (id) DO UPDATE
-  SET name = excluded.name || 'replace' || ' • ' || '\x01\x02\xA1\x1b\x00\xg' || 'it''s high noon\r\n\f\b\t\v' || "it's" || name;
+    SET name = excluded.name || 'replace' || ' • ' || '\x01\x02\xA1\x1b\x00\xg' || 'it''s high noon\r\n\f\b\t\v' || "it's" || name;
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(11, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -452,13 +462,15 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nsome_cte (name) AS (SELECT t2.name\\n  FROM t2\\n  INNER JOIN t3 USING (id))\\nSELECT *\\n  FROM some_cte";
+  SET stmt := "WITH\\n  some_cte (name) AS (\\n    SELECT t2.name\\n      FROM t2\\n      INNER JOIN t3 USING (id)\\n  )\\nSELECT *\\n  FROM some_cte";
   INSERT INTO sql_temp(id, sql) VALUES(16, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  some_cte (name) AS (SELECT t2.name
-    FROM t2
-    INNER JOIN t3 USING (id))
+    some_cte (name) AS (
+      SELECT t2.name
+        FROM t2
+        INNER JOIN t3 USING (id)
+    )
   SELECT *
     FROM some_cte;
   LOOP FETCH C
@@ -508,12 +520,12 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "SELECT 1 AS n\\n  FROM foo_,\\n_foo";
+  SET stmt := "SELECT 1 AS n\\n  FROM foo_,\\n  _foo";
   INSERT INTO sql_temp(id, sql) VALUES(19, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   SELECT 1 AS n
     FROM foo_,
-  _foo;
+    _foo;
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(19, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -540,11 +552,13 @@ END;
 CREATE PROC split_commas (str TEXT)
 BEGIN
 WITH
-splitter (tok, rest) AS (SELECT "", IFNULL(str || ",", "")
-UNION ALL
-SELECT substr(rest, 1, instr(rest, ",") - 1), substr(rest, instr(rest, ",") + 1)
-  FROM splitter
-  WHERE rest <> "")
+  splitter (tok, rest) AS (
+    SELECT "", IFNULL(str || ",", "")
+    UNION ALL
+    SELECT substr(rest, 1, instr(rest, ",") - 1), substr(rest, instr(rest, ",") + 1)
+      FROM splitter
+      WHERE rest <> ""
+  )
 SELECT tok
   FROM splitter
   WHERE tok <> "";
@@ -554,7 +568,7 @@ END;
 CREATE PROC ids_from_string (str TEXT)
 BEGIN
 WITH
-toks (tok) AS (CALL split_commas(str))
+  toks (tok) AS (CALL split_commas(str))
 SELECT CAST(tok AS LONG_INT) AS id
   FROM toks;
 END;
@@ -565,12 +579,12 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nI (id) AS (CALL ids_from_string('1')),\\nE (id) AS (CALL ids_from_string('1'))\\nSELECT C.*\\n  FROM C\\n  WHERE C.id IN (SELECT *\\n  FROM I) AND C.id NOT IN (SELECT *\\n  FROM E)";
+  SET stmt := "WITH\\n  I (id) AS (CALL ids_from_string('1')),\\n  E (id) AS (CALL ids_from_string('1'))\\nSELECT C.*\\n  FROM C\\n  WHERE C.id IN (SELECT *\\n  FROM I) AND C.id NOT IN (SELECT *\\n  FROM E)";
   INSERT INTO sql_temp(id, sql) VALUES(21, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  I (id) AS (CALL ids_from_string('1')),
-  E (id) AS (CALL ids_from_string('1'))
+    I (id) AS (CALL ids_from_string('1')),
+    E (id) AS (CALL ids_from_string('1'))
   SELECT C.*
     FROM C
     WHERE C.id IN (SELECT *
@@ -606,7 +620,9 @@ END;
 CREATE PROC frag_with_select ()
 BEGIN
 WITH
-cte (a) AS (SELECT 1 AS a)
+  cte (a) AS (
+    SELECT 1 AS a
+  )
 SELECT *
   FROM cte;
 END;
@@ -630,11 +646,11 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nfrag (val) AS (CALL frag(1))\\nSELECT *\\n  FROM frag";
+  SET stmt := "WITH\\n  frag (val) AS (CALL frag(1))\\nSELECT *\\n  FROM frag";
   INSERT INTO sql_temp(id, sql) VALUES(22, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  frag (val) AS (CALL frag(1))
+    frag (val) AS (CALL frag(1))
   SELECT *
     FROM frag;
   LOOP FETCH C
@@ -649,11 +665,11 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nfrag (val) AS (CALL frag(1))\\nSELECT *\\n  FROM frag";
+  SET stmt := "WITH\\n  frag (val) AS (CALL frag(1))\\nSELECT *\\n  FROM frag";
   INSERT INTO sql_temp(id, sql) VALUES(23, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  frag (val) AS (CALL frag(1))
+    frag (val) AS (CALL frag(1))
   SELECT *
     FROM frag;
   LOOP FETCH C
@@ -668,12 +684,20 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "SELECT one.id, one.t, one.b, one.r, two.id AS id_, two.t AS t_, two.b AS b_, two.r AS r_\\n  FROM select_virtual_table AS one,\\nselect_virtual_table AS two";
+  SET stmt := "SELECT \\n    one.id,\\n    one.t,\\n    one.b,\\n    one.r,\\n    two.id AS id_,\\n    two.t AS t_,\\n    two.b AS b_,\\n    two.r AS r_\\n  FROM select_virtual_table AS one,\\nselect_virtual_table   AS two";
   INSERT INTO sql_temp(id, sql) VALUES(24, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
-  SELECT one.id, one.t, one.b, one.r, two.id AS id_, two.t AS t_, two.b AS b_, two.r AS r_
+  SELECT 
+      one.id,
+      one.t,
+      one.b,
+      one.r,
+      two.id AS id_,
+      two.t AS t_,
+      two.b AS b_,
+      two.r AS r_
     FROM select_virtual_table AS one,
-  select_virtual_table AS two;
+  select_virtual_table   AS two;
   LOOP FETCH C
   BEGIN
     INSERT INTO plan_temp(sql_id, iselectid, iorder, ifrom, zdetail) VALUES(24, C.iselectid, C.iorder, C.ifrom, C.zdetail);
@@ -686,11 +710,11 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nbacked (rowid, id, name) AS (CALL _backed())\\nSELECT *\\n  FROM backed\\n  WHERE name = 'x'";
+  SET stmt := "WITH\\n  backed (rowid, id, name) AS (CALL _backed())\\nSELECT *\\n  FROM backed\\n  WHERE name = 'x'";
   INSERT INTO sql_temp(id, sql) VALUES(25, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  backed (rowid, id, name) AS (CALL _backed())
+    backed (rowid, id, name) AS (CALL _backed())
   SELECT *
     FROM backed
     WHERE name = 'x';
@@ -860,7 +884,7 @@ END;
 CREATE PROC qp_take_blob (foo BLOB)
 BEGIN
 WITH
-qp_take_inner_blob (inner_a) AS (CALL qp_take_inner_blob(LOCALS.foo))
+  qp_take_inner_blob (inner_a) AS (CALL qp_take_inner_blob(LOCALS.foo))
 SELECT *
   FROM qp_take_inner_blob;
 END;
@@ -871,11 +895,11 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nqp_take_blob (inner_a) AS (CALL qp_take_blob(nullable(query_plan_trivial_blob)))\\nSELECT *\\n  FROM qp_take_blob";
+  SET stmt := "WITH\\n  qp_take_blob (inner_a) AS (CALL qp_take_blob(nullable(query_plan_trivial_blob)))\\nSELECT *\\n  FROM qp_take_blob";
   INSERT INTO sql_temp(id, sql) VALUES(34, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  qp_take_blob (inner_a) AS (CALL qp_take_blob(nullable(query_plan_trivial_blob)))
+    qp_take_blob (inner_a) AS (CALL qp_take_blob(nullable(query_plan_trivial_blob)))
   SELECT *
     FROM qp_take_blob;
   LOOP FETCH C
@@ -890,11 +914,11 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "WITH\\nqp_take_inner_blob (inner_a) AS (CALL qp_take_inner_blob(nullable(query_plan_trivial_blob)))\\nSELECT *\\n  FROM qp_take_inner_blob";
+  SET stmt := "WITH\\n  qp_take_inner_blob (inner_a) AS (CALL qp_take_inner_blob(nullable(query_plan_trivial_blob)))\\nSELECT *\\n  FROM qp_take_inner_blob";
   INSERT INTO sql_temp(id, sql) VALUES(35, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
   WITH
-  qp_take_inner_blob (inner_a) AS (CALL qp_take_inner_blob(nullable(query_plan_trivial_blob)))
+    qp_take_inner_blob (inner_a) AS (CALL qp_take_inner_blob(nullable(query_plan_trivial_blob)))
   SELECT *
     FROM qp_take_inner_blob;
   LOOP FETCH C

--- a/sources/test/cg_test_query_plan.out.ref
+++ b/sources/test/cg_test_query_plan.out.ref
@@ -684,10 +684,10 @@ BEGIN
   LET query_plan_trivial_blob := trivial_blob();
 
   DECLARE stmt TEXT NOT NULL;
-  SET stmt := "SELECT \\n    one.id,\\n    one.t,\\n    one.b,\\n    one.r,\\n    two.id AS id_,\\n    two.t AS t_,\\n    two.b AS b_,\\n    two.r AS r_\\n  FROM select_virtual_table AS one,\\nselect_virtual_table   AS two";
+  SET stmt := "SELECT\\n    one.id,\\n    one.t,\\n    one.b,\\n    one.r,\\n    two.id AS id_,\\n    two.t AS t_,\\n    two.b AS b_,\\n    two.r AS r_\\n  FROM select_virtual_table AS one,\\nselect_virtual_table   AS two";
   INSERT INTO sql_temp(id, sql) VALUES(24, stmt);
   DECLARE C CURSOR FOR EXPLAIN QUERY PLAN
-  SELECT 
+  SELECT
       one.id,
       one.t,
       one.b,

--- a/sources/test/cg_test_query_plan.sql
+++ b/sources/test/cg_test_query_plan.sql
@@ -57,7 +57,7 @@
 -- + CREATE INDEX backing_index ON backing (bgetkey_type(k));
 -- + @attribute(cql:backed_by=backing)
 -- + CREATE TABLE backed(
--- + SET stmt := "WITH\\nbacked (rowid, id, name) AS (CALL _backed())\\nSELECT *\\n  FROM backed\\n  WHERE name = 'x'";
+-- + SET stmt := "WITH\\n  backed (rowid, id, name) AS (CALL _backed())\\nSELECT *\\n  FROM backed\\n  WHERE name = 'x'";
 -- + SELECT CAST(1L AS INTEGER);
 -- + SELECT CAST(1.0 AS INTEGER);
 -- + SELECT CAST(1 AS REAL);

--- a/sources/test/cg_test_test_helpers.out.ref
+++ b/sources/test/cg_test_test_helpers.out.ref
@@ -2767,8 +2767,9 @@ BEGIN
   CREATE TRIGGER IF NOT EXISTS trig
     AFTER INSERT ON trig_test_t1
   BEGIN
-  INSERT OR IGNORE INTO trig_test_tx(ak) SELECT pk
-    FROM trig_test_t3;
+  INSERT OR IGNORE INTO trig_test_tx(ak)
+    SELECT pk
+      FROM trig_test_t3;
   END;
 END;
 

--- a/sources/test/macro_test.out.ref
+++ b/sources/test/macro_test.out.ref
@@ -242,7 +242,7 @@ The statement ending at line XXXX
 @MACRO(QUERY_PARTS) qp!()
 BEGIN
   first_table AS T1
-    INNER JOIN second_table AS T2 ON T1.x = T2.y
+  INNER JOIN second_table AS T2 ON T1.x = T2.y
 END;
 
   {query_parts_macro_def}
@@ -274,8 +274,9 @@ END;
 The statement ending at line XXXX
 
 SELECT *
-  FROM (first_table AS T1
-  INNER JOIN second_table AS T2 ON T1.x = T2.y)
+  FROM (
+    first_table AS T1
+    INNER JOIN second_table AS T2 ON T1.x = T2.y)
   INNER JOIN second_table;
 
   {select_stmt}
@@ -325,8 +326,9 @@ SELECT *
 The statement ending at line XXXX
 
 SELECT *
-  FROM (first_table AS T1
-  INNER JOIN second_table AS T2 ON T1.x = T2.y) AS T1;
+  FROM (
+    first_table AS T1
+    INNER JOIN second_table AS T2 ON T1.x = T2.y) AS T1;
 
   {select_stmt}
   | {select_core_list}
@@ -413,8 +415,9 @@ END;
 The statement ending at line XXXX
 
 SELECT x
-  FROM (first_table AS T1
-  INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
+  FROM (
+    first_table AS T1
+    INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
 
   {select_stmt}
   | {select_core_list}
@@ -460,8 +463,9 @@ SELECT x
 The statement ending at line XXXX
 
 SELECT x
-  FROM (first_table AS T1
-  INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
+  FROM (
+    first_table AS T1
+    INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
 
   {select_stmt}
   | {select_core_list}
@@ -508,8 +512,12 @@ The statement ending at line XXXX
 
 @MACRO(CTE_TABLES) cte!()
 BEGIN
-  foo (*) AS (SELECT 1 AS x, 2 AS y),
-  bar (*) AS (SELECT 3 AS u, 4 AS v)
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v
+  )
 END;
 
   {cte_tables_macro_def}
@@ -571,10 +579,18 @@ END;
 The statement ending at line XXXX
 
 WITH
-vv (*) AS (SELECT 1 AS x, 2 AS y),
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v),
-uu (*) AS (SELECT 1 AS x, 2 AS y)
+  vv (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v
+  ),
+  uu (*) AS (
+    SELECT 1 AS x, 2 AS y
+  )
 SELECT *
   FROM foo;
 
@@ -704,9 +720,15 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v),
-uu (*) AS (SELECT 1 AS x, 2 AS y)
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v
+  ),
+  uu (*) AS (
+    SELECT 1 AS x, 2 AS y
+  )
 SELECT *
   FROM foo;
 
@@ -810,8 +832,12 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v)
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v
+  )
 SELECT *
   FROM foo;
 
@@ -889,9 +915,15 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-vv (*) AS (SELECT 1 AS x, 2 AS y),
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v)
+  vv (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y
+  ),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v
+  )
 SELECT *
   FROM foo;
 
@@ -997,7 +1029,7 @@ The statement ending at line XXXX
 @MACRO(STMT_LIST) query!(u! CTE_TABLES)
 BEGIN
   WITH
-  u!
+    u!
   SELECT *
     FROM foo;
 END;
@@ -1035,7 +1067,9 @@ END;
 The statement ending at line XXXX
 
 WITH
-foo (*) AS (SELECT 100 AS x, 200 AS y)
+  foo (*) AS (
+    SELECT 100 AS x, 200 AS y
+  )
 SELECT *
   FROM foo;
 
@@ -1504,20 +1538,22 @@ LET zz := "(SELECT 1 AS x, 2 AS y) AS T";
 
 The statement ending at line XXXX
 
-SET zz := "T1\n  INNER JOIN T2 ON T1.id = T2.id";
+SET zz := "T1\nINNER JOIN T2 ON T1.id = T2.id";
 
   {assign}
   | {name zz}
   | {strlit 'T1
-  INNER JOIN T2 ON T1.id = T2.id'}
+INNER JOIN T2 ON T1.id = T2.id'}
 
 The statement ending at line XXXX
 
-SET zz := "x (*) AS (SELECT 1 AS x, 2 AS y)\n";
+SET zz := "x (*) AS (\n  SELECT 1 AS x, 2 AS y\n)\n";
 
   {assign}
   | {name zz}
-  | {strlit 'x (*) AS (SELECT 1 AS x, 2 AS y)
+  | {strlit 'x (*) AS (
+  SELECT 1 AS x, 2 AS y
+)
 '}
 
 The statement ending at line XXXX
@@ -1565,7 +1601,7 @@ The statement ending at line XXXX
 
 @MACRO(STMT_LIST) mondo1!(a! EXPR, b! QUERY_PARTS, c! SELECT_CORE, d! SELECT_EXPR, e! CTE_TABLES, f! STMT_LIST)
 BEGIN
-  SET zz := @TEXT(a!, b!, c!, d!, e!, f!);
+  SET zz := @TEXT(a!, "___", b!, "___", c!, "___", d!, "___", e!, "___", f!);
 END;
 
   {stmt_list_macro_def}
@@ -1603,20 +1639,30 @@ END;
           | {expr_macro_arg_ref}
           | | {name a!}
           | {text_args}
-            | {query_parts_macro_arg_ref}
-            | | {name b!}
+            | {strlit '___'}
             | {text_args}
-              | {select_core_macro_arg_ref}
-              | | {name c!}
+              | {query_parts_macro_arg_ref}
+              | | {name b!}
               | {text_args}
-                | {select_expr_macro_arg_ref}
-                | | {name d!}
+                | {strlit '___'}
                 | {text_args}
-                  | {cte_tables_macro_arg_ref}
-                  | | {name e!}
+                  | {select_core_macro_arg_ref}
+                  | | {name c!}
                   | {text_args}
-                    | {stmt_list_macro_arg_ref}
-                      | {name f!}
+                    | {strlit '___'}
+                    | {text_args}
+                      | {select_expr_macro_arg_ref}
+                      | | {name d!}
+                      | {text_args}
+                        | {strlit '___'}
+                        | {text_args}
+                          | {cte_tables_macro_arg_ref}
+                          | | {name e!}
+                          | {text_args}
+                            | {strlit '___'}
+                            | {text_args}
+                              | {stmt_list_macro_arg_ref}
+                                | {name f!}
 
 The statement ending at line XXXX
 
@@ -1691,18 +1737,20 @@ END;
 
 The statement ending at line XXXX
 
-SET zz := "1 + 2x\n  INNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS first_tablef (*) AS (SELECT 99\n  FROM second_table)\nLET qq := 201;\n";
+SET zz := "1 + 2___x\nINNER JOIN y___SELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar___20 AS first_table___f (*) AS (\n  SELECT 99\n    FROM second_table\n)\n___LET qq := 201;\n";
 
   {assign}
   | {name zz}
-  | {strlit '1 + 2x
-  INNER JOIN ySELECT 1
+  | {strlit '1 + 2___x
+INNER JOIN y___SELECT 1
   FROM foo
 UNION
 SELECT 2
-  FROM bar20 AS first_tablef (*) AS (SELECT 99
-  FROM second_table)
-LET qq := 201;
+  FROM bar___20 AS first_table___f (*) AS (
+  SELECT 99
+    FROM second_table
+)
+___LET qq := 201;
 '}
 
 The statement ending at line XXXX

--- a/sources/test/macro_test.sql
+++ b/sources/test/macro_test.sql
@@ -104,7 +104,7 @@ create table second_table(
 -- + @MACRO(QUERY_PARTS) qp!()
 -- + BEGIN
 -- +   first_table AS T1
--- +     INNER JOIN second_table AS T2 ON T1.x = T2.y
+-- +   INNER JOIN second_table AS T2 ON T1.x = T2.y
 -- + END;
 @macro(query_parts) qp!()
 begin
@@ -114,15 +114,17 @@ end;
 -- TEST: make a select statement...
 -- use macro in a join clause
 -- + SELECT *
--- + FROM (first_table AS T1
--- + INNER JOIN second_table AS T2 ON T1.x = T2.y)
--- + INNER JOIN second_table;
+-- +   FROM (
+-- +     first_table AS T1
+-- +     INNER JOIN second_table AS T2 ON T1.x = T2.y)
+-- +   INNER JOIN second_table;
 select * from qp!() inner join second_table;
 
 -- TEST: use macro as a table
 -- + SELECT *
--- + FROM (first_table AS T1
--- + INNER JOIN second_table AS T2 ON T1.x = T2.y) AS T1;
+-- +   FROM (
+-- +     first_table AS T1
+-- +     INNER JOIN second_table AS T2 ON T1.x = T2.y) AS T1;
 select * from qp!() as T1;
 
 -- TEST: statement macro that assembles query parts
@@ -138,23 +140,28 @@ end;
 
 -- TEST: expand a full select statement with nested macros as args
 -- + SELECT x
--- + FROM (first_table AS T1
--- + INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
+-- +   FROM (
+-- +     first_table AS T1
+-- +     INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
 sel!(x, from( qp!() ));
 
 -- TEST: expand a full select statement with nested macros as args
 -- arg typing is optional for variables, it can be inferred
 -- + SELECT x
--- + FROM (first_table AS T1
--- + INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
+-- +   FROM (
+-- +     first_table AS T1
+-- +     INNER JOIN second_table AS T2 ON T1.x = T2.y) AS Q;
 sel!(x, qp!());
-
 
 -- TEST: cte tables macro
 -- + @MACRO(CTE_TABLES) cte!()
 -- + BEGIN
--- +   foo (*) AS (SELECT 1 AS x, 2 AS y),
--- +   bar (*) AS (SELECT 3 AS u, 4 AS v)
+-- +   foo (*) AS (
+-- +     SELECT 1 AS x, 2 AS y
+-- +   ),
+-- +   bar (*) AS (
+-- +     SELECT 3 AS u, 4 AS v
+-- +   )
 -- + END;
 @macro(cte_tables) cte!()
 begin
@@ -164,10 +171,18 @@ end;
 
 -- TEST use cte tables
 -- + WITH
--- + vv (*) AS (SELECT 1 AS x, 2 AS y),
--- + foo (*) AS (SELECT 1 AS x, 2 AS y),
--- + bar (*) AS (SELECT 3 AS u, 4 AS v),
--- + uu (*) AS (SELECT 1 AS x, 2 AS y)
+-- +   vv (*) AS (
+-- +     SELECT 1 AS x, 2 AS y
+-- +   ),
+-- +   foo (*) AS (
+-- +     SELECT 1 AS x, 2 AS y
+-- +   ),
+-- +   bar (*) AS (
+-- +     SELECT 3 AS u, 4 AS v
+-- +   ),
+-- +   uu (*) AS (
+-- +     SELECT 1 AS x, 2 AS y
+-- +   )
 -- + SELECT *
 -- +   FROM foo;
 with
@@ -178,9 +193,15 @@ select * from foo;
 
 -- TEST: cte tables at the front of the list
 -- + WITH
--- + foo (*) AS (SELECT 1 AS x, 2 AS y),
--- + bar (*) AS (SELECT 3 AS u, 4 AS v),
--- + uu (*) AS (SELECT 1 AS x, 2 AS y)
+-- +   foo (*) AS (
+-- +     SELECT 1 AS x, 2 AS y
+-- +   ),
+-- +   bar (*) AS (
+-- +     SELECT 3 AS u, 4 AS v
+-- +   ),
+-- +   uu (*) AS (
+-- +     SELECT 1 AS x, 2 AS y
+-- +   )
 -- + SELECT *
 -- +   FROM foo;
 with
@@ -190,8 +211,12 @@ select * from foo;
 
 -- TEST: cte tables macro as the only element
 -- + WITH
--- + foo (*) AS (SELECT 1 AS x, 2 AS y),
--- + bar (*) AS (SELECT 3 AS u, 4 AS v)
+-- +  foo (*) AS (
+-- +    SELECT 1 AS x, 2 AS y
+-- +  ),
+-- +  bar (*) AS (
+-- +    SELECT 3 AS u, 4 AS v
+-- +  )
 -- + SELECT *
 -- +   FROM foo;
 with
@@ -200,11 +225,17 @@ select * from foo;
 
 -- TEST: cte tables macro at the end of the list
 -- + WITH
--- + vv (*) AS (SELECT 1 AS x, 2 AS y),
--- + foo (*) AS (SELECT 1 AS x, 2 AS y),
--- + bar (*) AS (SELECT 3 AS u, 4 AS v)
--- + SELECT *
--- +   FROM foo;
+-- +  vv (*) AS (
+-- +    SELECT 1 AS x, 2 AS y
+-- +  ),
+-- +  foo (*) AS (
+-- +    SELECT 1 AS x, 2 AS y
+-- +  ),
+-- +  bar (*) AS (
+-- +    SELECT 3 AS u, 4 AS v
+-- +  )
+-- +SELECT *
+-- +  FROM foo;
 with
 vv(*) as (select 1 x, 2 y),
 cte!()
@@ -225,7 +256,9 @@ end;
 
 -- TEST: use cte tables as a macro arg
 -- + WITH
--- + foo (*) AS (SELECT 100 AS x, 200 AS y)
+-- + foo (*) AS (
+-- +   SELECT 100 AS x, 200 AS y
+-- + )
 -- + SELECT *
 -- +   FROM foo;
 query!(with( foo(*) as (select 100 x, 200 y)));
@@ -373,11 +406,11 @@ let z := macro2!(x, y);
 let zz := macro3!(from( (select 1 x, 2 y) as T));
 
 -- TEST: query parts as text (join)
--- + SET zz := "T1\n  INNER JOIN T2 ON T1.id = T2.id";
+-- + SET zz := "T1\nINNER JOIN T2 ON T1.id = T2.id";
 set zz := macro3!(from( T1 join T2 on T1.id = T2.id));
 
 -- TEST: cte tables as text
--- + SET zz := "x (*) AS (SELECT 1 AS x, 2 AS y)\n"
+-- + SET zz := "x (*) AS (\n  SELECT 1 AS x, 2 AS y\n)\n";
 set zz := macro4!(WITH( x(*) as (select 1 x, 2 y) ));
 
 -- TEST: select core list as text
@@ -403,11 +436,11 @@ let @ID(@TEXT("u", "v")) := 5;
 -- TEST: macro with all the arg types and forwarded with the simple syntax (convert to text)
 -- + @MACRO(STMT_LIST) mondo1!(a! EXPR, b! QUERY_PARTS, c! SELECT_CORE, d! SELECT_EXPR, e! CTE_TABLES, f! STMT_LIST)
 -- + BEGIN
--- +   SET zz := @TEXT(a!, b!, c!, d!, e!, f!);
+-- +   SET zz := @TEXT(a!, "___", b!, "___", c!, "___", d!, "___", e!, "___", f!);
 -- + END;
 @macro(stmt_list) mondo1!(a! expr, b! query_parts, c! select_core, d! select_expr, e! cte_tables, f! stmt_list)
 begin
-  set zz := @text(a!, b!, c!, d!, e!, f!);
+  set zz := @text(a!, "___", b!, "___", c!, "___", d!, "___", e!, "___", f!);
 end;
 
 -- TEST: macro with all the arg types and forwarded with the simple syntax
@@ -426,10 +459,15 @@ begin
 end;
 
 -- TEST: make a big chunk of text
--- + SET zz := "1 + 2x\n  INNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS first_tablef (*) AS (SELECT 99\n  FROM second_table)\nLET qq := 201;\n";
-mondo2!(1+2, from(x join y), all(select 1 from foo union select 2 from bar), select(20 first_table), 
-  with(f(*) as (select 99 from second_table)), begin let qq := 201; end);
-
+-- SET zz := "1 + 2___x\nINNER JOIN y___SELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar___20 AS first_table___f (*) AS (\n  SELECT 99\n    FROM second_table\n)\n___LET qq := 201;\n";
+mondo2!(
+  1+2,
+  from(x join y),
+  all(select 1 from foo union select 2 from bar), 
+  select(20 first_table), 
+  with(f(*) as (select 99 from second_table)), 
+  begin let qq := 201; end
+);
 
 -- TEST: tricky case to make sure that the selection is properly wrapped as an expression
 -- + @MACRO(EXPR) a_selection!()

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -785,10 +785,11 @@ test/sem_test.sql:XXXX:1: error: in create_trigger_stmt : CREATE TRIGGER trigger
   WHEN old.b > 1 AND new.b < 3
 BEGIN
 UPDATE bar
-SET id = 7
-  WHERE rate > old.b AND rate < new.b;
+  SET id = 7
+    WHERE rate > old.b AND rate < new.b;
 
-INSERT INTO bar(id, name, rate) VALUES(7, 'goo', 17L);
+INSERT INTO bar(id, name, rate)
+  VALUES(7, 'goo', 17L);
 END
 test/sem_test.sql:XXXX:1: error: in create_trigger_stmt : CREATE TRIGGER trigger3
   INSTEAD OF UPDATE ON ViewShape

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -15726,7 +15726,7 @@ The statement ending at line XXXX
 
 SELECT 1 AS x, 2 AS x, 3 AS y
 UNION ALL
-SELECT 
+SELECT
     0 AS u,
     1 AS x,
     2 AS x,
@@ -21350,7 +21350,7 @@ The statement ending at line XXXX
 
 WITH
   some_cte (x, y, z, u) AS (
-    SELECT 
+    SELECT
         1 AS x,
         2 AS y,
         3.0 AS z,
@@ -22999,7 +22999,7 @@ SELECT 0 AS _first, T.*, 3 AS _last
 
 The statement ending at line XXXX
 
-SELECT 
+SELECT
     0 AS _first,
     T.*,
     S.*,
@@ -33643,7 +33643,7 @@ The statement ending at line XXXX
 
 CREATE PROC get_sensitive ()
 BEGIN
-  SELECT 
+  SELECT
       1 AS safe,
       info + 1 AS sensitive_1,
       name AS sensitive_2,
@@ -45013,7 +45013,7 @@ SELECT id,
 
 The statement ending at line XXXX
 
-SELECT 
+SELECT
   lag(cost, 1, id) OVER ()
   FROM with_kind;
 
@@ -45481,7 +45481,7 @@ SELECT id,
 
 The statement ending at line XXXX
 
-SELECT 
+SELECT
   first_value(id) OVER () AS first
   FROM with_kind;
 
@@ -45515,7 +45515,7 @@ SELECT
 
 The statement ending at line XXXX
 
-SELECT 
+SELECT
   last_value(id) OVER () AS last
   FROM with_kind;
 
@@ -45549,7 +45549,7 @@ SELECT
 
 The statement ending at line XXXX
 
-SELECT 
+SELECT
   nth_value(id, 5) OVER () AS nth
   FROM with_kind;
 
@@ -49782,7 +49782,7 @@ The statement ending at line XXXX
 
 CREATE PROC exotic_literals ()
 BEGIN
-  SELECT 
+  SELECT
       2147483647 AS a,
       2147483648L AS b,
       3.4e11 AS c,
@@ -52255,7 +52255,7 @@ The statement ending at line XXXX
 CREATE PROC print_call_cql_cursor_format ()
 BEGIN
   DECLARE c1 CURSOR FOR
-    SELECT 
+    SELECT
         TRUE AS a,
         1 AS b,
         99L AS c,
@@ -65064,7 +65064,7 @@ The statement ending at line XXXX
 
 CREATE PROC improvements_correctly_handle_nested_selects ()
 BEGIN
-  SELECT 
+  SELECT
       ( SELECT xn ),
       ( SELECT yn
         FROM tnull ),
@@ -75229,7 +75229,7 @@ test/sem_test.sql:XXXX:1: error: in select_expr_list_con : CQL0053: select colum
 
 The statement ending at line XXXX
 
-SELECT 
+SELECT
     1 AS y,
     T.id,
     T.t,
@@ -89805,4 +89805,13 @@ END;
         | {select_orderby}
           | {select_limit}
             | {select_offset}
+
+The statement ending at line XXXX
+
+DECLARE foobar2 REAL;
+
+  {declare_vars_type}: real
+  | {name_list}: foobar2: real variable
+  | | {name foobar2}: foobar2: real variable
+  | {type_real}: real
 

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -387,7 +387,7 @@ The statement ending at line XXXX
 
 SELECT name
   FROM foo,
-bar;
+  bar;
 
   {select_stmt}: select: { name: text }
   | {select_core_list}: select: { name: text }
@@ -414,8 +414,8 @@ The statement ending at line XXXX
 
 SELECT name
   FROM foo AS T1,
-bar AS T1,
-bar AS T1;
+  bar AS T1,
+  bar AS T1;
 
 test/sem_test.sql:XXXX:1: error: in table_or_subquery_list : CQL0016: duplicate table name in join 'T1'
 
@@ -453,7 +453,7 @@ The statement ending at line XXXX
 
 SELECT id
   FROM foo,
-bar;
+  bar;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0065: identifier is ambiguous 'id'
 
@@ -482,7 +482,7 @@ The statement ending at line XXXX
 
 SELECT not_found
   FROM foo,
-bar;
+  bar;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'not_found'
 
@@ -1629,7 +1629,7 @@ The statement ending at line XXXX
 
 SELECT *
   FROM foo,
-bar;
+  bar;
 
   {select_stmt}: select: { id: integer notnull, id: integer notnull, name: text, rate: longint }
   | {select_core_list}: select: { id: integer notnull, id: integer notnull, name: text, rate: longint }
@@ -1699,8 +1699,9 @@ test/sem_test.sql:XXXX:1: error: in star : CQL0052: select * cannot be used with
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) SELECT *
-  FROM (SELECT 1);
+INSERT INTO foo(id)
+  SELECT *
+    FROM (SELECT 1);
 
 test/sem_test.sql:XXXX:1: error: in star : CQL0055: all columns in the select must have a name
 
@@ -1744,8 +1745,9 @@ test/sem_test.sql:XXXX:1: error: in star : CQL0055: all columns in the select mu
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) SELECT T.*
-  FROM (SELECT 1) AS T;
+INSERT INTO foo(id)
+  SELECT T.*
+    FROM (SELECT 1) AS T;
 
 test/sem_test.sql:XXXX:1: error: in table_star : CQL0055: all columns in the select must have a name
 
@@ -3694,8 +3696,9 @@ SELECT ( SELECT 1 ) || ( SELECT 2 );
 The statement ending at line XXXX
 
 SELECT *
-  FROM (foo,
-bar);
+  FROM (
+    foo,
+    bar);
 
   {select_stmt}: select: { id: integer notnull, id: integer notnull, name: text, rate: longint }
   | {select_core_list}: select: { id: integer notnull, id: integer notnull, name: text, rate: longint }
@@ -3722,8 +3725,9 @@ bar);
 The statement ending at line XXXX
 
 SELECT *
-  FROM (foo,
-foo);
+  FROM (
+    foo,
+    foo);
 
 test/sem_test.sql:XXXX:1: error: in table_or_subquery_list : CQL0016: duplicate table name in join 'foo'
 
@@ -6878,7 +6882,8 @@ SELECT Y;
 
 The statement ending at line XXXX
 
-DECLARE my_cursor CURSOR FOR SELECT 1 AS one, 2 AS two;
+DECLARE my_cursor CURSOR FOR
+  SELECT 1 AS one, 2 AS two;
 
   {declare_cursor}: my_cursor: select: { one: integer notnull, two: integer notnull } variable dml_proc
   | {name my_cursor}: my_cursor: select: { one: integer notnull, two: integer notnull } variable dml_proc shape_storage serialize fetch_into
@@ -6906,8 +6911,9 @@ DECLARE my_cursor CURSOR FOR SELECT 1 AS one, 2 AS two;
 
 The statement ending at line XXXX
 
-DECLARE kind_cursor CURSOR FOR SELECT *
-  FROM with_kind;
+DECLARE kind_cursor CURSOR FOR
+  SELECT *
+    FROM with_kind;
 
   {declare_cursor}: kind_cursor: select: { id: integer<some_key>, cost: real<dollars>, value: real<dollars> } variable dml_proc
   | {name kind_cursor}: kind_cursor: select: { id: integer<some_key>, cost: real<dollars>, value: real<dollars> } variable dml_proc
@@ -7087,7 +7093,8 @@ test/sem_test.sql:XXXX:1: error: in shape_exprs : CQL0495: no columns were selec
 
 The statement ending at line XXXX
 
-DECLARE my_cursor CURSOR FOR SELECT 1;
+DECLARE my_cursor CURSOR FOR
+  SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in declare_cursor : CQL0197: duplicate variable name in the same scope 'my_cursor'
 
@@ -7123,7 +7130,8 @@ test/sem_test.sql:XXXX:1: error: in declare_cursor_like_typed_names : CQL0197: d
 
 The statement ending at line XXXX
 
-DECLARE my_cursor CURSOR FOR SELECT NOT 'x';
+DECLARE my_cursor CURSOR FOR
+  SELECT NOT 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -7586,7 +7594,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'missing_colum
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
+INSERT INTO bar(id, name, rate)
+  VALUES(1, 'bazzle', 3);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -7617,7 +7626,8 @@ INSERT INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
 
 The statement ending at line XXXX
 
-REPLACE INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
+REPLACE INTO bar(id, name, rate)
+  VALUES(1, 'bazzle', 3);
 
   {insert_stmt}: ok
   | {insert_replace}
@@ -7648,7 +7658,8 @@ REPLACE INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
 
 The statement ending at line XXXX
 
-INSERT OR FAIL INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
+INSERT OR FAIL INTO bar(id, name, rate)
+  VALUES(1, 'bazzle', 3);
 
   {insert_stmt}: ok
   | {insert_or_fail}
@@ -7679,7 +7690,8 @@ INSERT OR FAIL INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
 
 The statement ending at line XXXX
 
-INSERT OR ROLLBACK INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
+INSERT OR ROLLBACK INTO bar(id, name, rate)
+  VALUES(1, 'bazzle', 3);
 
   {insert_stmt}: ok
   | {insert_or_rollback}
@@ -7710,7 +7722,8 @@ INSERT OR ROLLBACK INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
 
 The statement ending at line XXXX
 
-INSERT OR ABORT INTO bar(id, name, rate) VALUES(1, 'bazzle', 3);
+INSERT OR ABORT INTO bar(id, name, rate)
+  VALUES(1, 'bazzle', 3);
 
   {insert_stmt}: ok
   | {insert_or_abort}
@@ -7763,7 +7776,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0315: mandatory column with no defa
 
 The statement ending at line XXXX
 
-INSERT INTO bogus_table VALUES(1);
+INSERT INTO bogus_table
+  VALUES(1);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement does not exist 'bogus_table'
 
@@ -7785,7 +7799,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement doe
 
 The statement ending at line XXXX
 
-INSERT INTO MyView VALUES(1);
+INSERT INTO MyView
+  VALUES(1);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0161: cannot insert into a view 'MyView'
 
@@ -7807,7 +7822,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0161: cannot insert into a view 'My
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) VALUES(id, 'bazzle', 3);
+INSERT INTO bar(id, name, rate)
+  VALUES(id, 'bazzle', 3);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'id'
 
@@ -7840,7 +7856,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'id'
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(NULL);
+INSERT INTO foo(id)
+  VALUES(NULL);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -7863,7 +7880,8 @@ INSERT INTO foo(id) VALUES(NULL);
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) VALUES('string is wrong', 'string', 1);
+INSERT INTO bar(id, name, rate)
+  VALUES('string is wrong', 'string', 1);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'id'
 
@@ -7896,7 +7914,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in express
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) VALUES(1, 2, 3);
+INSERT INTO bar(id, name, rate)
+  VALUES(1, 2, 3);
 
 test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in expression 'name'
 
@@ -7929,7 +7948,8 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in express
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(NULL, 2);
+INSERT INTO foo(id)
+  VALUES(NULL, 2);
 
 test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0157: count of columns differs from count of values
 
@@ -7956,7 +7976,8 @@ test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0157: count of columns diff
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES();
+INSERT INTO foo(id)
+  VALUES();
 
 test/sem_test.sql:XXXX:1: error: in values : CQL0336: select statement with VALUES clause requires a non empty list of values
 
@@ -7979,7 +8000,8 @@ test/sem_test.sql:XXXX:1: error: in values : CQL0336: select statement with VALU
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) VALUES(NULL, 'string', 1);
+INSERT INTO bar(id, name, rate)
+  VALUES(NULL, 'string', 1);
 
 test/sem_test.sql:XXXX:1: error: in null : CQL0013: cannot assign/copy possibly null expression to not null target 'id'
 
@@ -8104,7 +8126,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 
 The statement ending at line XXXX
 
-DECLARE fetch_cursor CURSOR FOR SELECT 1, 'foo', NULL;
+DECLARE fetch_cursor CURSOR FOR
+  SELECT 1, 'foo', NULL;
 
   {declare_cursor}: fetch_cursor: select: { _anon: integer notnull, _anon: text notnull, _anon: null } variable dml_proc
   | {name fetch_cursor}: fetch_cursor: select: { _anon: integer notnull, _anon: text notnull, _anon: null } variable dml_proc fetch_into
@@ -8494,8 +8517,8 @@ SET X := my_cursor;
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 1
-  WHERE id = 2;
+  SET id = 1
+    WHERE id = 2;
 
   {update_stmt}: foo: { id: integer notnull primary_key autoinc }
   | {name foo}: foo: { id: integer notnull primary_key autoinc }
@@ -8515,7 +8538,7 @@ SET id = 1
 The statement ending at line XXXX
 
 UPDATE with_kind
-SET cost = price_d;
+  SET cost = price_d;
 
   {update_stmt}: with_kind: { id: integer<some_key>, cost: real<dollars>, value: real<dollars> }
   | {name with_kind}: with_kind: { id: integer<some_key>, cost: real<dollars>, value: real<dollars> }
@@ -8531,7 +8554,7 @@ SET cost = price_d;
 The statement ending at line XXXX
 
 UPDATE with_kind
-SET cost = price_e;
+  SET cost = price_e;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0070: expressions of different kinds can't be mixed: 'dollars' vs. 'euros'
 
@@ -8549,7 +8572,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0070: expressions of different kind
 The statement ending at line XXXX
 
 UPDATE myView
-SET id = 1;
+  SET id = 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0155: cannot update a view 'myView'
 
@@ -8567,8 +8590,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0155: cannot update a view 'myView'
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 1
-  WHERE NOT 'x';
+  SET id = 1
+    WHERE NOT 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -8589,8 +8612,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 1
-LIMIT 'x';
+  SET id = 1
+  LIMIT 'x';
 
 test/sem_test.sql:XXXX:1: error: in opt_limit : CQL0015: expected numeric expression 'LIMIT'
 
@@ -8610,9 +8633,9 @@ test/sem_test.sql:XXXX:1: error: in opt_limit : CQL0015: expected numeric expres
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 1
-ORDER BY NOT 'x'
-LIMIT 2;
+  SET id = 1
+  ORDER BY NOT 'x'
+  LIMIT 2;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -8637,7 +8660,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 UPDATE foo
-SET non_existent_column = 1;
+  SET non_existent_column = 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'non_existent_column'
 
@@ -8655,7 +8678,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'non_existent_
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 'x';
+  SET id = 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'id'
 
@@ -8673,8 +8696,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in express
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 1L
-  WHERE id = 2;
+  SET id = 1L
+    WHERE id = 2;
 
 test/sem_test.sql:XXXX:1: error: in num : CQL0242: lossy conversion from type 'LONG_INT' in 1L
 
@@ -8696,7 +8719,7 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0242: lossy conversion from type 'L
 The statement ending at line XXXX
 
 UPDATE bar
-SET name = 2;
+  SET name = 2;
 
 test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in expression 'name'
 
@@ -8714,7 +8737,7 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in express
 The statement ending at line XXXX
 
 UPDATE bar
-SET id = NULL;
+  SET id = NULL;
 
 test/sem_test.sql:XXXX:1: error: in null : CQL0013: cannot assign/copy possibly null expression to not null target 'id'
 
@@ -8732,7 +8755,7 @@ test/sem_test.sql:XXXX:1: error: in null : CQL0013: cannot assign/copy possibly 
 The statement ending at line XXXX
 
 UPDATE bar
-SET X = 1;
+  SET X = 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'X'
 
@@ -8750,7 +8773,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'X'
 The statement ending at line XXXX
 
 UPDATE bar
-SET rate = NULL;
+  SET rate = NULL;
 
   {update_stmt}: bar: { id: integer notnull, name: text, rate: longint }
   | {name bar}: bar: { id: integer notnull, name: text, rate: longint }
@@ -8766,7 +8789,7 @@ SET rate = NULL;
 The statement ending at line XXXX
 
 UPDATE bar
-SET id = NOT 'x';
+  SET id = NOT 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -8955,7 +8978,8 @@ The statement ending at line XXXX
 CREATE PROC throw_before_out ()
 BEGIN
   BEGIN TRY
-    DECLARE C CURSOR FOR SELECT 1 AS x;
+    DECLARE C CURSOR FOR
+      SELECT 1 AS x;
     FETCH C;
   END TRY;
   BEGIN CATCH
@@ -9132,7 +9156,7 @@ The statement ending at line XXXX
 
 SELECT id, rate
   FROM (SELECT id, rate
-  FROM bar);
+      FROM bar);
 
   {select_stmt}: select: { id: integer notnull, rate: longint }
   | {select_core_list}: select: { id: integer notnull, rate: longint }
@@ -9178,7 +9202,7 @@ The statement ending at line XXXX
 
 SELECT id, rate
   FROM (SELECT *
-  FROM bar);
+      FROM bar);
 
   {select_stmt}: select: { id: integer notnull, rate: longint }
   | {select_core_list}: select: { id: integer notnull, rate: longint }
@@ -9569,7 +9593,8 @@ The statement ending at line XXXX
 
 CREATE PROC cursors_cannot_be_used_as_out_args ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT 0 AS x;
+  DECLARE c CURSOR FOR
+    SELECT 0 AS x;
   CALL test_proc3(c);
 END;
 
@@ -11448,7 +11473,8 @@ test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0055: all columns in the se
 
 The statement ending at line XXXX
 
-DECLARE curs CURSOR FOR CALL with_result_set();
+DECLARE curs CURSOR FOR
+  CALL with_result_set();
 
   {declare_cursor}: curs: with_result_set: { id: integer notnull, name: text, rate: longint } variable dml_proc
   | {name curs}: curs: with_result_set: { id: integer notnull, name: text, rate: longint } variable dml_proc
@@ -11457,7 +11483,8 @@ DECLARE curs CURSOR FOR CALL with_result_set();
 
 The statement ending at line XXXX
 
-DECLARE curs2 CURSOR FOR CALL with_result_set(1);
+DECLARE curs2 CURSOR FOR
+  CALL with_result_set(1);
 
 test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0235: too many arguments provided to procedure 'with_result_set'
 
@@ -11479,7 +11506,8 @@ test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0214: procedures with results
 
 The statement ending at line XXXX
 
-DECLARE curs CURSOR FOR CALL proc1();
+DECLARE curs CURSOR FOR
+  CALL proc1();
 
 test/sem_test.sql:XXXX:1: error: in call_stmt : CQL0199: cursor requires a procedure that returns a result set via select 'curs'
 
@@ -11826,7 +11854,7 @@ The statement ending at line XXXX
 SELECT *
   FROM foo
   WHERE EXISTS (SELECT *
-  FROM foo);
+    FROM foo);
 
   {select_stmt}: select: { id: integer notnull }
   | {select_core_list}: select: { id: integer notnull }
@@ -11868,7 +11896,7 @@ The statement ending at line XXXX
 SELECT *
   FROM foo
   WHERE NOT EXISTS (SELECT *
-  FROM foo);
+    FROM foo);
 
   {select_stmt}: select: { id: integer notnull }
   | {select_core_list}: select: { id: integer notnull }
@@ -11911,7 +11939,7 @@ The statement ending at line XXXX
 SELECT *
   FROM foo
   WHERE EXISTS (SELECT NOT 'x'
-  FROM foo);
+    FROM foo);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -11957,7 +11985,7 @@ The statement ending at line XXXX
 SELECT *
   FROM foo
   WHERE NOT EXISTS (SELECT NOT 'x'
-  FROM foo);
+    FROM foo);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -12002,7 +12030,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 SET X := EXISTS (SELECT *
-  FROM foo);
+    FROM foo);
 
 test/sem_test.sql:XXXX:1: error: in exists_expr : CQL0080: function may not appear in this context 'exists'
 
@@ -12029,7 +12057,7 @@ test/sem_test.sql:XXXX:1: error: in exists_expr : CQL0080: function may not appe
 The statement ending at line XXXX
 
 SET X := NOT EXISTS (SELECT *
-  FROM foo);
+    FROM foo);
 
 test/sem_test.sql:XXXX:1: error: in exists_expr : CQL0080: function may not appear in this context 'exists'
 
@@ -12074,7 +12102,8 @@ test/sem_test.sql:XXXX:1: error: in rollback_trans_stmt : CQL0220: savepoint has
 
 The statement ending at line XXXX
 
-DECLARE shape_storage CURSOR FOR SELECT 1 AS one, 2 AS two;
+DECLARE shape_storage CURSOR FOR
+  SELECT 1 AS one, 2 AS two;
 
   {declare_cursor}: shape_storage: select: { one: integer notnull, two: integer notnull } variable dml_proc
   | {name shape_storage}: shape_storage: select: { one: integer notnull, two: integer notnull } variable dml_proc shape_storage serialize
@@ -12523,10 +12552,12 @@ SELECT *
 The statement ending at line XXXX
 
 SELECT *
-  FROM (foo AS A,
-foo AS B)
-  INNER JOIN (foo AS C,
-foo AS D);
+  FROM (
+    foo AS A,
+    foo AS B)
+  INNER JOIN (
+    foo AS C,
+    foo AS D);
 
   {select_stmt}: select: { id: integer notnull, id: integer notnull, id: integer notnull, id: integer notnull }
   | {select_core_list}: select: { id: integer notnull, id: integer notnull, id: integer notnull, id: integer notnull }
@@ -12572,8 +12603,9 @@ foo AS D);
 The statement ending at line XXXX
 
 SELECT id
-  FROM (foo
-  INNER JOIN bar ON NOT 'x')
+  FROM (
+    foo
+    INNER JOIN bar ON NOT 'x')
   INNER JOIN foo ON 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
@@ -13283,9 +13315,8 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0080: function may not appear in t
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = 1,
-id = 3
-  WHERE id = 2;
+  SET id = 1, id = 3
+    WHERE id = 2;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0153: duplicate target column name in update statement 'id'
 
@@ -15069,8 +15100,9 @@ CREATE TABLE CC3(
 The statement ending at line XXXX
 
 SELECT *
-  FROM (AA1 AS A,
-BB2 AS B)
+  FROM (
+    AA1 AS A,
+    BB2 AS B)
   LEFT OUTER JOIN CC3 AS C ON C.id3 = A.id1;
 
   {select_stmt}: select: { id1: integer notnull, id2: integer notnull, id3: integer }
@@ -15694,7 +15726,11 @@ The statement ending at line XXXX
 
 SELECT 1 AS x, 2 AS x, 3 AS y
 UNION ALL
-SELECT 0 AS u, 1 AS x, 2 AS x, 3 AS z;
+SELECT 
+    0 AS u,
+    1 AS x,
+    2 AS x,
+    3 AS z;
 
 test/sem_test.sql:XXXX:1: error: in select_core : CQL0057: if multiple selects, all must have the same column count
 test/sem_test.sql:XXXX:1: error: in select_core : additional difference diagnostic info:
@@ -18537,7 +18573,9 @@ test/sem_test.sql:XXXX:1: error: in const : CQL0353: evaluation of constant fail
 The statement ending at line XXXX
 
 WITH
-some_cte (a, a) AS (SELECT 1, 2)
+  some_cte (a, a) AS (
+    SELECT 1, 2
+  )
 SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'a'
@@ -18587,8 +18625,12 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'a'
 The statement ending at line XXXX
 
 WITH
-some_cte (a, b) AS (SELECT 1, 2),
-some_cte (a, b) AS (SELECT 1, 2)
+  some_cte (a, b) AS (
+    SELECT 1, 2
+  ),
+  some_cte (a, b) AS (
+    SELECT 1, 2
+  )
 SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0100: duplicate common table name 'some_cte'
@@ -18663,7 +18705,9 @@ test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0100: duplicate common table n
 The statement ending at line XXXX
 
 WITH
-some_cte (a) AS (SELECT 1, 2)
+  some_cte (a) AS (
+    SELECT 1, 2
+  )
 SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0101: too few column names specified in common table expression 'some_cte'
@@ -18711,7 +18755,9 @@ test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0101: too few column names spe
 The statement ending at line XXXX
 
 WITH
-some_cte (a, b, c) AS (SELECT 1, 2)
+  some_cte (a, b, c) AS (
+    SELECT 1, 2
+  )
 SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0102: too many column names specified in common table expression 'some_cte'
@@ -18763,7 +18809,9 @@ test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0102: too many column names sp
 The statement ending at line XXXX
 
 WITH
-some_cte (a) AS (SELECT NOT 'x')
+  some_cte (a) AS (
+    SELECT NOT 'x'
+  )
 SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
@@ -18809,7 +18857,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 WITH
-some_cte (a) AS (SELECT 1)
+  some_cte (a) AS (
+    SELECT 1
+  )
 SELECT NOT 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
@@ -18855,7 +18905,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 WITH
-some_cte (a, b) AS (SELECT 1, 2)
+  some_cte (a, b) AS (
+    SELECT 1, 2
+  )
 SELECT a, b
   FROM some_cte;
 
@@ -18910,9 +18962,11 @@ SELECT a, b
 The statement ending at line XXXX
 
 WITH
-some_cte (a) AS (SELECT 1 AS x
-UNION ALL
-SELECT NULL AS x)
+  some_cte (a) AS (
+    SELECT 1 AS x
+    UNION ALL
+    SELECT NULL AS x
+  )
 SELECT *
   FROM some_cte;
 
@@ -18974,17 +19028,23 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-x (a, b) AS (SELECT 1, 2)
+  x (a, b) AS (
+    SELECT 1, 2
+  )
 SELECT *
   FROM x AS X
-  INNER JOIN (WITH
-y (a, b) AS (SELECT 1, 3)
-SELECT *
-  FROM y) AS Y ON X.a = Y.a
-  INNER JOIN (WITH
-y (a, b) AS (SELECT 1, 3)
-SELECT *
-  FROM y) AS Z ON X.a = Z.a;
+  INNER JOIN (    WITH
+      y (a, b) AS (
+        SELECT 1, 3
+      )
+    SELECT *
+      FROM y) AS Y ON X.a = Y.a
+  INNER JOIN (    WITH
+      y (a, b) AS (
+        SELECT 1, 3
+      )
+    SELECT *
+      FROM y) AS Z ON X.a = Z.a;
 
   {with_select_stmt}: select: { a: integer notnull, b: integer notnull, a: integer notnull, b: integer notnull, a: integer notnull, b: integer notnull }
   | {with}
@@ -19153,11 +19213,13 @@ SELECT *
 The statement ending at line XXXX
 
 WITH RECURSIVE
-cnt (current) AS (SELECT 1
-UNION ALL
-SELECT current + 1
-  FROM cnt
-LIMIT 10)
+  cnt (current) AS (
+    SELECT 1
+    UNION ALL
+    SELECT current + 1
+      FROM cnt
+    LIMIT 10
+  )
 SELECT current
   FROM cnt;
 
@@ -19223,15 +19285,21 @@ SELECT current
 The statement ending at line XXXX
 
 WITH
-some_cte (u, v) AS (SELECT 1 AS u, 2 AS v),
-another_cte (x, y) AS (WITH
-baz (x, y) AS (SELECT 2.0 AS x, 3.0 AS y
-UNION ALL
-SELECT *
-  FROM baz
-LIMIT 5)
-SELECT *
-  FROM baz)
+  some_cte (u, v) AS (
+    SELECT 1 AS u, 2 AS v
+  ),
+  another_cte (x, y) AS (
+    WITH
+      baz (x, y) AS (
+        SELECT 2.0 AS x, 3.0 AS y
+        UNION ALL
+        SELECT *
+          FROM baz
+        LIMIT 5
+      )
+    SELECT *
+      FROM baz
+  )
 SELECT *
   FROM another_cte
   INNER JOIN some_cte;
@@ -19364,7 +19432,9 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-foo (*) AS (SELECT 1 AS x)
+  foo (*) AS (
+    SELECT 1 AS x
+  )
 SELECT *
   FROM foo;
 
@@ -19413,7 +19483,9 @@ test/sem_test.sql:XXXX:1: error: in cte_decl : CQL0437: common table name shadow
 The statement ending at line XXXX
 
 WITH
-MyView (*) AS (SELECT 1 AS x)
+  MyView (*) AS (
+    SELECT 1 AS x
+  )
 SELECT *
   FROM MyView;
 
@@ -19465,11 +19537,15 @@ The statement ending at line XXXX
 CREATE PROC shadows_an_existing_table ()
 BEGIN
   WITH
-  foo (*) LIKE (SELECT 1 AS x)
+    foo (*) LIKE (
+      SELECT 1 AS x
+    )
   SELECT *
     FROM foo;
   WITH
-  MyView (*) AS (SELECT 1 AS x)
+    MyView (*) AS (
+      SELECT 1 AS x
+    )
   SELECT *
     FROM MyView;
 END;
@@ -19573,7 +19649,9 @@ The statement ending at line XXXX
 CREATE PROC does_not_shadow_an_existing_table ()
 BEGIN
   WITH
-  table_not_yet_defined (x) AS (SELECT 1 AS x)
+    table_not_yet_defined (x) AS (
+      SELECT 1 AS x
+    )
   SELECT *
     FROM table_not_yet_defined;
 END;
@@ -19650,7 +19728,7 @@ CREATE TABLE table_not_yet_defined(
 The statement ending at line XXXX
 
 WITH
-does_not_shadow_an_existing_table (x) AS (CALL does_not_shadow_an_existing_table())
+  does_not_shadow_an_existing_table (x) AS (CALL does_not_shadow_an_existing_table())
 SELECT *
   FROM does_not_shadow_an_existing_table;
 
@@ -19959,12 +20037,12 @@ CREATE PROC ok_conditional_duplicate_cte_names ()
 BEGIN
   IF 1 THEN
     WITH
-    X (x, y, z) LIKE a_shared_frag
+      X (x, y, z) LIKE a_shared_frag
     SELECT *
       FROM X;
   ELSE
     WITH
-    X (x, y, z) LIKE a_shared_frag
+      X (x, y, z) LIKE a_shared_frag
     SELECT *
       FROM X;
   END IF;
@@ -20055,11 +20133,11 @@ CREATE PROC bogus_conditional_duplicate_cte_names ()
 BEGIN
   IF 1 THEN
     WITH
-    bogus_cte (x, y, z) LIKE a_shared_frag
+      bogus_cte (x, y, z) LIKE a_shared_frag
     SELECT 1 AS x;
   ELSE
     WITH
-    bogus_cte (id) LIKE foo
+      bogus_cte (id) LIKE foo
     SELECT 1 AS x;
   END IF;
 END;
@@ -20392,7 +20470,7 @@ The statement ending at line XXXX
 CREATE PROC shared_frag2 (x INTEGER NOT NULL, y INTEGER NOT NULL)
 BEGIN
   WITH
-  source (x, y, z) LIKE a_shared_frag
+    source (x, y, z) LIKE a_shared_frag
   SELECT *
     FROM source;
 END;
@@ -20453,7 +20531,7 @@ END;
 The statement ending at line XXXX
 
 WITH
-shared_frag2 (*) AS (CALL shared_frag2(1, 2))
+  shared_frag2 (*) AS (CALL shared_frag2(1, 2))
 SELECT *
   FROM a_shared_frag;
 
@@ -20515,7 +20593,7 @@ The statement ending at line XXXX
 CREATE PROC shared_frag3 ()
 BEGIN
   WITH
-  source (id, name) LIKE frag_type
+    source (id, name) LIKE frag_type
   SELECT *
     FROM source;
 END;
@@ -20614,7 +20692,7 @@ CREATE TABLE bad_jobstuff(
 The statement ending at line XXXX
 
 WITH
-data (id, name) AS (CALL shared_frag3() USING jobstuff AS source)
+  data (id, name) AS (CALL shared_frag3() USING jobstuff AS source)
 SELECT *
   FROM data;
 
@@ -20655,7 +20733,7 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-data (*) AS (CALL shared_frag3() USING bad_jobstuff AS source)
+  data (*) AS (CALL shared_frag3() USING bad_jobstuff AS source)
 SELECT *
   FROM data;
 
@@ -20698,7 +20776,7 @@ The statement ending at line XXXX
 CREATE PROC shared_frag_bad_like ()
 BEGIN
   WITH
-  source (*) LIKE there_is_no_such_source
+    source (*) LIKE there_is_no_such_source
   SELECT 1 AS x, 2 AS y, 3.0 AS z;
 END;
 
@@ -20753,7 +20831,7 @@ test/sem_test.sql:XXXX:1: error: in like : CQL0202: must be a cursor, proc, tabl
 The statement ending at line XXXX
 
 WITH
-source (*) LIKE there_is_no_such_source
+  source (*) LIKE there_is_no_such_source
 SELECT 1 AS x, 2 AS y, 3.0 AS z;
 
 test/sem_test.sql:XXXX:1: error: in like : CQL0427: LIKE CTE form may only be used inside a shared fragment at the top level i.e. @attribute(cql:shared_fragment)
@@ -20799,7 +20877,7 @@ The statement ending at line XXXX
 CREATE PROC not_a_shared_fragment ()
 BEGIN
   WITH
-  source (*) LIKE there_is_no_such_source
+    source (*) LIKE there_is_no_such_source
   SELECT 1 AS x, 2 AS y, 3.0 AS z;
 END;
 
@@ -20848,8 +20926,10 @@ test/sem_test.sql:XXXX:1: error: in like : CQL0427: LIKE CTE form may only be us
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (SELECT 1 AS x, 2 AS y, 3.0 AS z),
-x (*) AS (CALL a_shared_frag(1, 2) USING some_cte AS foo)
+  some_cte (x, y, z) AS (
+    SELECT 1 AS x, 2 AS y, 3.0 AS z
+  ),
+  x (*) AS (CALL a_shared_frag(1, 2) USING some_cte AS foo)
 SELECT *
   FROM x;
 
@@ -20929,8 +21009,10 @@ test/sem_test.sql:XXXX:1: error: in cte_binding_list : CQL0429: called procedure
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (SELECT 1 AS x, 2 AS y, 3.0 AS z),
-x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS foo)
+  some_cte (x, y, z) AS (
+    SELECT 1 AS x, 2 AS y, 3.0 AS z
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS foo)
 SELECT *
   FROM x;
 
@@ -21010,8 +21092,10 @@ test/sem_test.sql:XXXX:1: error: in cte_binding_list : CQL0430: no actual table 
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (SELECT 1 AS x, 2 AS y, 3.0 AS z),
-x (*) AS (CALL shared_frag2(1, 2) USING source AS bar, source AS bar)
+  some_cte (x, y, z) AS (
+    SELECT 1 AS x, 2 AS y, 3.0 AS z
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING source AS bar, source AS bar)
 SELECT *
   FROM x;
 
@@ -21095,8 +21179,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0428: duplicate binding of table in
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (SELECT 1 AS x, 2 AS y, 3.0 AS z),
-x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source, some_cte AS bogus)
+  some_cte (x, y, z) AS (
+    SELECT 1 AS x, 2 AS y, 3.0 AS z
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source, some_cte AS bogus)
 SELECT *
   FROM x;
 
@@ -21180,8 +21266,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0431: an actual table was provided 
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (SELECT 1 AS x, 2 AS y, 3.0 AS z),
-x (*) AS (CALL shared_frag2(1, 2) USING bogus AS source)
+  some_cte (x, y, z) AS (
+    SELECT 1 AS x, 2 AS y, 3.0 AS z
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING bogus AS source)
 SELECT *
   FROM x;
 
@@ -21261,8 +21349,14 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0095: table/view not defined 'bogus
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z, u) AS (SELECT 1 AS x, 2 AS y, 3.0 AS z, 4 AS u),
-x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source)
+  some_cte (x, y, z, u) AS (
+    SELECT 
+        1 AS x,
+        2 AS y,
+        3.0 AS z,
+        4 AS u
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source)
 SELECT *
   FROM x;
 
@@ -21349,8 +21443,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0432: table provided must have the 
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, w) AS (SELECT 1 AS x, 2 AS y, 3.0 AS w),
-x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source)
+  some_cte (x, y, w) AS (
+    SELECT 1 AS x, 2 AS y, 3.0 AS w
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source)
 SELECT *
   FROM x;
 
@@ -21430,8 +21526,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0433: table argument 'source' requi
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (SELECT 1 AS x, 2 AS y, '3.0' AS z),
-x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source)
+  some_cte (x, y, z) AS (
+    SELECT 1 AS x, 2 AS y, '3.0' AS z
+  ),
+  x (*) AS (CALL shared_frag2(1, 2) USING some_cte AS source)
 SELECT *
   FROM x;
 
@@ -21514,10 +21612,12 @@ The statement ending at line XXXX
 CREATE PROC bogus_like_in_shared ()
 BEGIN
   WITH
-  data (*) AS (WITH
-  source (*) LIKE there_is_no_such_source
-  SELECT *
-    FROM source)
+    data (*) AS (
+      WITH
+        source (*) LIKE there_is_no_such_source
+      SELECT *
+        FROM source
+    )
   SELECT 1 AS x, 2 AS y, 3.0 AS z;
 END;
 
@@ -21598,7 +21698,7 @@ The statement ending at line XXXX
 CREATE PROC shared_frag_bad_like_decl ()
 BEGIN
   WITH
-  source (u) LIKE a_shared_frag
+    source (u) LIKE a_shared_frag
   SELECT 1 AS x, 2 AS y, 3.0 AS z;
 END;
 
@@ -21657,7 +21757,9 @@ The statement ending at line XXXX
 CREATE PROC shared_frag_bogus_cte_columns ()
 BEGIN
   WITH
-  source (id, id) LIKE (SELECT 1 AS x, 2 AS y)
+    source (id, id) LIKE (
+      SELECT 1 AS x, 2 AS y
+    )
   SELECT 1 AS x, 2 AS y, 3.0 AS z;
 END;
 
@@ -21735,7 +21837,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'id'
 The statement ending at line XXXX
 
 WITH
-some_cte (id, id) AS (CALL a_shared_frag(1, 2))
+  some_cte (id, id) AS (CALL a_shared_frag(1, 2))
 SELECT *
   FROM some_cte;
 
@@ -21778,10 +21880,14 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'id'
 The statement ending at line XXXX
 
 WITH
-some_cte (*) AS (WITH
-garbonzo (goo, goo) AS (SELECT 1 AS x, 2 AS y)
-SELECT *
-  FROM garbonzo)
+  some_cte (*) AS (
+    WITH
+      garbonzo (goo, goo) AS (
+        SELECT 1 AS x, 2 AS y
+      )
+    SELECT *
+      FROM garbonzo
+  )
 SELECT *
   FROM some_cte;
 
@@ -21861,10 +21967,14 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'goo'
 The statement ending at line XXXX
 
 WITH
-some_cte (goo, goo) AS (WITH
-garbonzo (x, y) AS (SELECT 1 AS x, 2 AS y)
-SELECT *
-  FROM garbonzo)
+  some_cte (goo, goo) AS (
+    WITH
+      garbonzo (x, y) AS (
+        SELECT 1 AS x, 2 AS y
+      )
+    SELECT *
+      FROM garbonzo
+  )
 SELECT *
   FROM some_cte;
 
@@ -21947,7 +22057,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'goo'
 The statement ending at line XXXX
 
 WITH
-some_cte (x, y, z) AS (CALL a_shared_frag(1, 2))
+  some_cte (x, y, z) AS (CALL a_shared_frag(1, 2))
 SELECT *
   FROM some_cte;
 
@@ -21990,7 +22100,7 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-some_cte (*) AS (CALL return_with_attr())
+  some_cte (*) AS (CALL return_with_attr())
 SELECT *
   FROM some_cte;
 
@@ -22026,7 +22136,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0224: a CALL statement inside SQL m
 The statement ending at line XXXX
 
 WITH
-some_cte (*) AS (CALL this_is_not_even_a_proc())
+  some_cte (*) AS (CALL this_is_not_even_a_proc())
 SELECT *
   FROM some_cte;
 
@@ -22065,13 +22175,17 @@ The statement ending at line XXXX
 CREATE PROC test_shared_fragment_with_CTEs (id_ INTEGER NOT NULL)
 BEGIN
   WITH
-  t1 (id) AS (SELECT id
-    FROM foo
-    WHERE id = id_
-  LIMIT 20),
-  t2 (x, y, z) AS (SELECT t1.id, name, rate
-    FROM bar
-    INNER JOIN t1 ON t1.id = bar.id)
+    t1 (id) AS (
+      SELECT id
+        FROM foo
+        WHERE id = id_
+      LIMIT 20
+    ),
+    t2 (x, y, z) AS (
+      SELECT t1.id, name, rate
+        FROM bar
+        INNER JOIN t1 ON t1.id = bar.id
+    )
   SELECT *
     FROM t2;
 END;
@@ -22372,11 +22486,13 @@ test/sem_test.sql:XXXX:1: error: in declare_vars_type : CQL0441: shared fragment
 The statement ending at line XXXX
 
 WITH RECURSIVE
-cnt (current, current) AS (SELECT 1
-UNION ALL
-SELECT current + 1
-  FROM cnt
-LIMIT 10)
+  cnt (current, current) AS (
+    SELECT 1
+    UNION ALL
+    SELECT current + 1
+      FROM cnt
+    LIMIT 10
+  )
 SELECT current
   FROM cnt;
 
@@ -22446,11 +22562,13 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0206: duplicate name in list 'curre
 The statement ending at line XXXX
 
 WITH RECURSIVE
-cnt (current) AS (SELECT NOT 'x'
-UNION ALL
-SELECT current + 1
-  FROM cnt
-LIMIT 10)
+  cnt (current) AS (
+    SELECT NOT 'x'
+    UNION ALL
+    SELECT current + 1
+      FROM cnt
+    LIMIT 10
+  )
 SELECT current
   FROM cnt;
 
@@ -22519,9 +22637,11 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 WITH RECURSIVE
-cnt (current) AS (SELECT 1
-UNION ALL
-SELECT NOT 'x')
+  cnt (current) AS (
+    SELECT 1
+    UNION ALL
+    SELECT NOT 'x'
+  )
 SELECT current
   FROM cnt;
 
@@ -22583,11 +22703,13 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 The statement ending at line XXXX
 
 WITH RECURSIVE
-cnt (current) AS (SELECT 1
-UNION ALL
-SELECT current + 1
-  FROM cnt
-LIMIT 10)
+  cnt (current) AS (
+    SELECT 1
+    UNION ALL
+    SELECT current + 1
+      FROM cnt
+    LIMIT 10
+  )
 SELECT NOT 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
@@ -22706,7 +22828,9 @@ The statement ending at line XXXX
 
 CREATE VIEW view_with_cte AS
 WITH
-goo (x) AS (SELECT 1)
+  goo (x) AS (
+    SELECT 1
+  )
 SELECT *
   FROM goo;
 
@@ -22875,9 +22999,13 @@ SELECT 0 AS _first, T.*, 3 AS _last
 
 The statement ending at line XXXX
 
-SELECT 0 AS _first, T.*, S.*, 3 AS _last
+SELECT 
+    0 AS _first,
+    T.*,
+    S.*,
+    3 AS _last
   FROM (SELECT 1 AS A, 2 AS B) AS T,
-(SELECT 1 AS C) AS S;
+  (SELECT 1 AS C) AS S;
 
   {select_stmt}: select: { _first: integer notnull, A: integer notnull, B: integer notnull, C: integer notnull, _last: integer notnull }
   | {select_core_list}: select: { _first: integer notnull, A: integer notnull, B: integer notnull, C: integer notnull, _last: integer notnull }
@@ -23954,7 +24082,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) VALUES(1, '2', 3);
+INSERT INTO bar(id, name, rate)
+  VALUES(1, '2', 3);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -23985,7 +24114,8 @@ INSERT INTO bar(id, name, rate) VALUES(1, '2', 3);
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(NULL);
+INSERT INTO foo(id)
+  VALUES(NULL);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -24008,7 +24138,8 @@ INSERT INTO foo(id) VALUES(NULL);
 
 The statement ending at line XXXX
 
-INSERT INTO bar(name) VALUES('x');
+INSERT INTO bar(name)
+  VALUES('x');
 
 test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0158: required column missing in INSERT statement 'id'
 
@@ -24033,7 +24164,8 @@ test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0158: required column missi
 
 The statement ending at line XXXX
 
-INSERT INTO bar(garbonzo) VALUES('x');
+INSERT INTO bar(garbonzo)
+  VALUES('x');
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0171: name not found 'garbonzo'
 
@@ -24058,7 +24190,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0171: name not found 'garbonzo'
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, id) VALUES('x');
+INSERT INTO bar(id, id)
+  VALUES('x');
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0172: name list has duplicate name 'id'
 
@@ -24085,7 +24218,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0172: name list has duplicate name 
 
 The statement ending at line XXXX
 
-INSERT INTO booly(id) VALUES(1);
+INSERT INTO booly(id)
+  VALUES(1);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -24108,7 +24242,8 @@ INSERT INTO booly(id) VALUES(1);
 
 The statement ending at line XXXX
 
-INSERT INTO MyView(id) VALUES(1);
+INSERT INTO MyView(id)
+  VALUES(1);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0161: cannot insert into a view 'MyView'
 
@@ -24133,7 +24268,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0161: cannot insert into a view 'My
 
 The statement ending at line XXXX
 
-INSERT INTO garbonzo(id) VALUES('x');
+INSERT INTO garbonzo(id)
+  VALUES('x');
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement does not exist 'garbonzo'
 
@@ -24204,7 +24340,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(NULL, NULL);
+INSERT INTO foo(id)
+  VALUES(NULL, NULL);
 
 test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0157: count of columns differs from count of values
 
@@ -24231,7 +24368,8 @@ test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0157: count of columns diff
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(NOT 'x');
+INSERT INTO foo(id)
+  VALUES(NOT 'x');
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -24257,7 +24395,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(1);
+INSERT INTO foo(id)
+  VALUES(1);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -24280,7 +24419,8 @@ INSERT INTO foo(id) VALUES(1);
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id) VALUES('x');
+INSERT INTO bar(id)
+  VALUES('x');
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'id'
 
@@ -25079,7 +25219,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0151: table in delete statement doe
 
 The statement ending at line XXXX
 
-INSERT INTO versioned_table VALUES(1);
+INSERT INTO versioned_table
+  VALUES(1);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement does not exist (hidden by @delete) 'versioned_table'
 
@@ -25101,7 +25242,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement doe
 
 The statement ending at line XXXX
 
-INSERT INTO versioned_table(id) VALUES(1);
+INSERT INTO versioned_table(id)
+  VALUES(1);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement does not exist (hidden by @delete) 'versioned_table'
 
@@ -25427,9 +25569,10 @@ The statement ending at line XXXX
 
 CREATE PROC bogus_fetch ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM foo AS T1
-    INNER JOIN foo AS T2 ON T1.id = T2.id;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM foo AS T1
+      INNER JOIN foo AS T2 ON T1.id = T2.id;
   FETCH C;
 END;
 
@@ -25636,7 +25779,8 @@ test/sem_test.sql:XXXX:1: error: in schema_upgrade_script_stmt : CQL0226: schema
 
 The statement ending at line XXXX
 
-INSERT INTO hides_id_not_name(name) VALUES('x');
+INSERT INTO hides_id_not_name(name)
+  VALUES('x');
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -26057,7 +26201,8 @@ INSERT INTO bar(id, name, rate) VALUES(_seed_, printf('name_%d', _seed_), _seed_
 
 The statement ending at line XXXX
 
-INSERT INTO booly(flag) VALUES(1);
+INSERT INTO booly(flag)
+  VALUES(1);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -26494,8 +26639,9 @@ The statement ending at line XXXX
 CREATE PROC bogus_object_read ()
 BEGIN
   DECLARE o1, o2, o3 OBJECT;
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   FETCH C INTO o1, o2, o3;
 END;
 
@@ -26645,7 +26791,8 @@ The statement ending at line XXXX
 
 CREATE PROC out_cursor_proc ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   OUT C;
 END;
@@ -26754,7 +26901,8 @@ The statement ending at line XXXX
 CREATE PROC out_cursor_proc_not_shape_storage ()
 BEGIN
   DECLARE a, b INTEGER NOT NULL;
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C INTO a, b;
   OUT C;
 END;
@@ -26809,8 +26957,10 @@ The statement ending at line XXXX
 CREATE PROC out_cursor_proc_incompat_results ()
 BEGIN
   DECLARE a, b INTEGER NOT NULL;
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
-  DECLARE D CURSOR FOR SELECT 1 AS A, 2 AS C;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
+  DECLARE D CURSOR FOR
+    SELECT 1 AS A, 2 AS C;
   FETCH C;
   FETCH D;
   OUT C;
@@ -26900,7 +27050,8 @@ The statement ending at line XXXX
 CREATE PROC out_cursor_proc_mixed_cursor_select ()
 BEGIN
   DECLARE a, b INTEGER NOT NULL;
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   OUT C;
   SELECT 1 AS A, 2 AS B;
@@ -26973,7 +27124,8 @@ The statement ending at line XXXX
 CREATE PROC out_cursor_proc_mixed_cursor_select_select_first ()
 BEGIN
   DECLARE a, b INTEGER NOT NULL;
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   SELECT 1 AS A, 2 AS B;
   OUT C;
@@ -27046,7 +27198,8 @@ The statement ending at line XXXX
 CREATE PROC out_cursor_proc_mixed_cursor_select_then_union ()
 BEGIN
   DECLARE a, b INTEGER NOT NULL;
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   SELECT 1 AS A, 2 AS B;
   OUT UNION C;
@@ -27118,7 +27271,8 @@ The statement ending at line XXXX
 
 CREATE PROC out_union_dml ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   OUT UNION C;
 END;
@@ -27239,7 +27393,8 @@ The statement ending at line XXXX
 
 CREATE PROC out_union_call_and_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   OUT UNION C;
   CALL out_union_dml();
@@ -27285,7 +27440,8 @@ The statement ending at line XXXX
 
 CREATE PROC out_union_call_and_out_union_other_order ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C;
   CALL out_union_dml();
   OUT UNION C;
@@ -27998,9 +28154,10 @@ The statement ending at line XXXX
 
 CREATE PROC blob_out ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT CASE WHEN 1 THEN CAST('x' AS BLOB)
-  ELSE NULL
-  END AS B;
+  DECLARE C CURSOR FOR
+    SELECT CASE WHEN 1 THEN CAST('x' AS BLOB)
+    ELSE NULL
+    END AS B;
   FETCH C;
   OUT C;
 END;
@@ -28390,7 +28547,8 @@ The statement ending at line XXXX
 CREATE PROC fetch_to_statement_cursor_from_cursor ()
 BEGIN
   DECLARE C0 CURSOR LIKE SELECT 1 AS A, 2 AS B;
-  DECLARE C1 CURSOR FOR SELECT 1 AS A, 2 AS B;
+  DECLARE C1 CURSOR FOR
+    SELECT 1 AS A, 2 AS B;
   FETCH C0(A, B) FROM VALUES(1, 2);
   FETCH C1 FROM C0;
 END;
@@ -28572,7 +28730,8 @@ CREATE PROC fetch_to_cursor_from_cursor_without_fields ()
 BEGIN
   DECLARE X INTEGER;
   DECLARE Y REAL;
-  DECLARE C0 CURSOR FOR SELECT 1 AS A, 2.5;
+  DECLARE C0 CURSOR FOR
+    SELECT 1 AS A, 2.5;
   DECLARE C1 CURSOR LIKE C0;
   FETCH C0 INTO X, Y;
   FETCH C1(A, _anon) FROM C0(A, _anon);
@@ -28969,7 +29128,7 @@ The statement ending at line XXXX
 
 SELECT T1.rowid
   FROM foo AS T1,
-bar AS T2;
+  bar AS T2;
 
   {select_stmt}: select: { rowid: longint notnull }
   | {select_core_list}: select: { rowid: longint notnull }
@@ -29002,7 +29161,7 @@ The statement ending at line XXXX
 
 SELECT T1.rowid
   FROM foo AS T2,
-foo AS T3;
+  foo AS T3;
 
 test/sem_test.sql:XXXX:1: error: in dot : CQL0069: name not found 'T1.rowid'
 
@@ -29037,7 +29196,7 @@ The statement ending at line XXXX
 
 SELECT rowid
   FROM foo AS T1,
-foo AS T2;
+  foo AS T2;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0066: identifier is ambiguous 'rowid'
 
@@ -29178,7 +29337,7 @@ test/sem_test.sql:XXXX:1: error: in name_list : CQL0272: columns referenced in t
 The statement ending at line XXXX
 
 UPDATE This_Table_Does_Not_Exist
-SET x = 1;
+  SET x = 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0154: table in update statement does not exist 'This_Table_Does_Not_Exist'
 
@@ -29440,11 +29599,15 @@ The statement ending at line XXXX
 CREATE PROC cte_test ()
 BEGIN
   WITH
-  should_not_conflict (a, b) AS (SELECT 111, 222)
+    should_not_conflict (a, b) AS (
+      SELECT 111, 222
+    )
   SELECT *
     FROM should_not_conflict;
   WITH
-  should_not_conflict (a, b) AS (SELECT 111, 222)
+    should_not_conflict (a, b) AS (
+      SELECT 111, 222
+    )
   SELECT *
     FROM should_not_conflict;
 END;
@@ -29545,11 +29708,14 @@ The statement ending at line XXXX
 CREATE PROC with_insert_form ()
 BEGIN
   WITH
-  x (a, b, c) AS (SELECT 12, 'foo', 35L)
-  INSERT INTO bar(id, name, rate) VALUES(ifnull(( SELECT a
-    FROM x ), 0), ifnull(( SELECT b
-    FROM x ), 'foo'), ifnull(( SELECT 1L AS c
-    WHERE 0 ), 0));
+    x (a, b, c) AS (
+      SELECT 12, 'foo', 35L
+    )
+  INSERT INTO bar(id, name, rate)
+    VALUES(ifnull(( SELECT a
+      FROM x ), 0), ifnull(( SELECT b
+      FROM x ), 'foo'), ifnull(( SELECT 1L AS c
+      WHERE 0 ), 0));
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -29690,11 +29856,14 @@ The statement ending at line XXXX
 CREATE PROC with_column_spec_form ()
 BEGIN
   WITH
-  x (a, b, c) AS (SELECT 12, 'foo', 35L)
-  INSERT INTO bar(id, name, rate) VALUES(ifnull(( SELECT a
-    FROM x ), 0), ifnull(( SELECT b
-    FROM x ), 'foo'), ifnull(( SELECT 1L AS c
-    WHERE 0 ), 0));
+    x (a, b, c) AS (
+      SELECT 12, 'foo', 35L
+    )
+  INSERT INTO bar(id, name, rate)
+    VALUES(ifnull(( SELECT a
+      FROM x ), 0), ifnull(( SELECT b
+      FROM x ), 'foo'), ifnull(( SELECT 1L AS c
+      WHERE 0 ), 0));
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -29835,8 +30004,11 @@ The statement ending at line XXXX
 CREATE PROC with_insert_bogus_cte ()
 BEGIN
   WITH
-  x (a) AS (SELECT NOT 'x')
-  INSERT INTO bar(id, name, rate) VALUES(1, 'x', 2);
+    x (a) AS (
+      SELECT NOT 'x'
+    )
+  INSERT INTO bar(id, name, rate)
+    VALUES(1, 'x', 2);
 END;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
@@ -29900,8 +30072,11 @@ The statement ending at line XXXX
 CREATE PROC with_insert_bogus_insert ()
 BEGIN
   WITH
-  x (a) AS (SELECT 1)
-  INSERT INTO bar(id, name, rate) VALUES(1, NOT 'x', 1);
+    x (a) AS (
+      SELECT 1
+    )
+  INSERT INTO bar(id, name, rate)
+    VALUES(1, NOT 'x', 1);
 END;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
@@ -29962,9 +30137,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) SELECT *
-  FROM bar
-  WHERE id > 5;
+INSERT INTO bar(id, name, rate)
+  SELECT *
+    FROM bar
+    WHERE id > 5;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -30001,8 +30177,9 @@ INSERT INTO bar(id, name, rate) SELECT *
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) SELECT id
-  FROM bar;
+INSERT INTO bar(id, name, rate)
+  SELECT id
+    FROM bar;
 
 test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0157: count of columns differs from count of values
 
@@ -30038,8 +30215,9 @@ test/sem_test.sql:XXXX:1: error: in insert_stmt : CQL0157: count of columns diff
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) SELECT name, id, rate
-  FROM bar;
+INSERT INTO bar(id, name, rate)
+  SELECT name, id, rate
+    FROM bar;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in expression 'id'
 
@@ -30081,7 +30259,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in express
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name, rate) SELECT NOT 'x';
+INSERT INTO bar(id, name, rate)
+  SELECT NOT 'x';
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 
@@ -32347,9 +32526,10 @@ CREATE TRIGGER trigger3
   WHEN old.b > 1 AND new.b < 3
 BEGIN
   UPDATE bar
-  SET id = 7
-    WHERE rate > old.b AND rate < new.b;
-  INSERT INTO bar(id, name, rate) VALUES(7, 'goo', 17L);
+    SET id = 7
+      WHERE rate > old.b AND rate < new.b;
+  INSERT INTO bar(id, name, rate)
+    VALUES(7, 'goo', 17L);
 END;
 
   {create_trigger_stmt}: ok
@@ -32435,9 +32615,10 @@ CREATE TRIGGER trigger3
   WHEN old.b > 1 AND new.b < 3
 BEGIN
   UPDATE bar
-  SET id = 7
-    WHERE rate > old.b AND rate < new.b;
-  INSERT INTO bar(id, name, rate) VALUES(7, 'goo', 17L);
+    SET id = 7
+      WHERE rate > old.b AND rate < new.b;
+  INSERT INTO bar(id, name, rate)
+    VALUES(7, 'goo', 17L);
 END;
 
   {create_trigger_stmt}: ok alias
@@ -32530,10 +32711,11 @@ test/sem_test.sql:XXXX:1: error: in create_trigger_stmt : CREATE TRIGGER trigger
   WHEN old.b > 1 AND new.b < 3
 BEGIN
 UPDATE bar
-SET id = 7
-  WHERE rate > old.b AND rate < new.b;
+  SET id = 7
+    WHERE rate > old.b AND rate < new.b;
 
-INSERT INTO bar(id, name, rate) VALUES(7, 'goo', 17L);
+INSERT INTO bar(id, name, rate)
+  VALUES(7, 'goo', 17L);
 END
 test/sem_test.sql:XXXX:1: error: in create_trigger_stmt : CREATE TRIGGER trigger3
   INSTEAD OF UPDATE ON ViewShape
@@ -33373,7 +33555,8 @@ The statement ending at line XXXX
 
 CREATE PROC fetch_null_column ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT NULL AS n;
+  DECLARE C CURSOR FOR
+    SELECT NULL AS n;
   FETCH C;
 END;
 
@@ -33460,7 +33643,13 @@ The statement ending at line XXXX
 
 CREATE PROC get_sensitive ()
 BEGIN
-  SELECT 1 AS safe, info + 1 AS sensitive_1, name AS sensitive_2, 'x' AS not_sensitive_1, -info AS sensitive_3, info BETWEEN 1 AND 3 AS sensitive_4
+  SELECT 
+      1 AS safe,
+      info + 1 AS sensitive_1,
+      name AS sensitive_2,
+      'x' AS not_sensitive_1,
+      -info AS sensitive_3,
+      info BETWEEN 1 AND 3 AS sensitive_4
     FROM with_sensitive;
 END;
 
@@ -34268,7 +34457,7 @@ SET _sens := 0 IS NOT 0;
 The statement ending at line XXXX
 
 SET _sens := ( SELECT EXISTS (SELECT *
-  FROM with_sensitive) );
+    FROM with_sensitive) );
 
   {assign}: _sens: integer variable sensitive was_set
   | {name _sens}: _sens: integer variable sensitive was_set
@@ -34306,7 +34495,7 @@ SET _sens := ( SELECT EXISTS (SELECT *
 The statement ending at line XXXX
 
 SET _sens := ( SELECT EXISTS (SELECT info
-  FROM with_sensitive) );
+    FROM with_sensitive) );
 
   {assign}: _sens: integer variable sensitive was_set
   | {name _sens}: _sens: integer variable sensitive was_set
@@ -34345,7 +34534,7 @@ SET _sens := ( SELECT EXISTS (SELECT info
 The statement ending at line XXXX
 
 SET _sens := ( SELECT EXISTS (SELECT id
-  FROM with_sensitive) );
+    FROM with_sensitive) );
 
   {assign}: _sens: integer variable sensitive was_set
   | {name _sens}: _sens: integer variable sensitive was_set
@@ -34478,8 +34667,9 @@ SET _sens := ( SELECT id
 
 The statement ending at line XXXX
 
-INSERT INTO without_sensitive(name) SELECT name
-  FROM with_sensitive;
+INSERT INTO without_sensitive(name)
+  SELECT name
+    FROM with_sensitive;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0014: cannot assign/copy sensitive expression to non-sensitive target 'name'
 
@@ -35278,7 +35468,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0210: proc out parameter: arg must 
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(coalesce(_sens, 0));
+INSERT INTO foo(id)
+  VALUES(coalesce(_sens, 0));
 
 test/sem_test.sql:XXXX:1: error: in call : CQL0014: cannot assign/copy sensitive expression to non-sensitive target 'id'
 
@@ -35311,8 +35502,8 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0014: cannot assign/copy sensitive
 The statement ending at line XXXX
 
 UPDATE bar
-SET id = coalesce(_sens, 0)
-  WHERE name = 'x';
+  SET id = coalesce(_sens, 0)
+    WHERE name = 'x';
 
 test/sem_test.sql:XXXX:1: error: in call : CQL0014: cannot assign/copy sensitive expression to non-sensitive target 'id'
 
@@ -35430,7 +35621,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0014: cannot assign/copy sensitive 
 The statement ending at line XXXX
 
 UPDATE foo
-SET id = CAST('1' AS INTEGER);
+  SET id = CAST('1' AS INTEGER);
 
   {update_stmt}: foo: { id: integer notnull primary_key autoinc }
   | {name foo}: foo: { id: integer notnull primary_key autoinc }
@@ -35450,9 +35641,11 @@ The statement ending at line XXXX
 CREATE PROC with_delete_form ()
 BEGIN
   WITH
-  x (id) AS (SELECT 1
-  UNION ALL
-  SELECT 2)
+    x (id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT 2
+    )
   DELETE FROM bar WHERE id IN (SELECT *
     FROM x);
 END;
@@ -35522,9 +35715,11 @@ The statement ending at line XXXX
 CREATE PROC with_delete_form_bogus_cte ()
 BEGIN
   WITH
-  x (id) AS (SELECT 1
-  UNION ALL
-  SELECT 'x')
+    x (id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT 'x'
+    )
   DELETE FROM bar WHERE id IN (SELECT *
     FROM x);
 END;
@@ -35596,9 +35791,11 @@ The statement ending at line XXXX
 CREATE PROC with_delete_form_bogus_delete ()
 BEGIN
   WITH
-  x (id) AS (SELECT 1
-  UNION ALL
-  SELECT 2)
+    x (id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT 2
+    )
   DELETE FROM not_valid_table WHERE id IN (SELECT *
     FROM x);
 END;
@@ -35670,13 +35867,15 @@ The statement ending at line XXXX
 CREATE PROC with_update_form ()
 BEGIN
   WITH
-  x (id) AS (SELECT 1
-  UNION ALL
-  SELECT 2)
+    x (id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT 2
+    )
   UPDATE bar
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -35752,13 +35951,15 @@ The statement ending at line XXXX
 CREATE PROC with_update_form_bogus_cte ()
 BEGIN
   WITH
-  x (id) AS (SELECT 1
-  UNION ALL
-  SELECT 'x')
+    x (id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT 'x'
+    )
   UPDATE bar
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 
 test/sem_test.sql:XXXX:1: error: in select_core : CQL0012: incompatible types in expression '_anon'
@@ -35836,13 +36037,15 @@ The statement ending at line XXXX
 CREATE PROC with_update_form_bogus_delete ()
 BEGIN
   WITH
-  x (id) AS (SELECT 1
-  UNION ALL
-  SELECT 2)
+    x (id) AS (
+      SELECT 1
+      UNION ALL
+      SELECT 2
+    )
   UPDATE not_valid_table
-  SET name = 'xyzzy'
-    WHERE id IN (SELECT *
-    FROM x);
+    SET name = 'xyzzy'
+      WHERE id IN (SELECT *
+      FROM x);
 END;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0154: table in update statement does not exist 'not_valid_table'
@@ -39118,7 +39321,9 @@ test/sem_test.sql:XXXX:1: error: in create_index_stmt : CQL0066: if a table is m
 The statement ending at line XXXX
 
 SET x := ( WITH
-threads2 (count) AS (SELECT 1 AS foo)
+  threads2 (count) AS (
+    SELECT 1 AS foo
+  )
 SELECT COUNT(*)
   FROM threads2 );
 
@@ -40638,7 +40843,7 @@ The statement ending at line XXXX
 
 SELECT *
   FROM foo,
-bar;
+  bar;
 
 test/sem_test.sql:XXXX:1: error: in table_or_subquery_list : CQL0263: non-ANSI joins are forbidden if strict join mode is enabled
 
@@ -40666,7 +40871,8 @@ The statement ending at line XXXX
 
 CREATE PROC bar ()
 BEGIN
-  DECLARE C CURSOR FOR CALL out_cursor_proc();
+  DECLARE C CURSOR FOR
+    CALL out_cursor_proc();
 END;
 
 test/sem_test.sql:XXXX:1: error: in declare_cursor : CQL0270: use FETCH FROM for procedures that returns a cursor with OUT 'C'
@@ -40711,9 +40917,10 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_do_nothing ()
 BEGIN
-  INSERT INTO foo(id) SELECT id
-    FROM bar
-    WHERE 1
+  INSERT INTO foo(id)
+    SELECT id
+      FROM bar
+      WHERE 1
   ON CONFLICT (id) DO NOTHING;
 END;
 
@@ -40760,10 +40967,13 @@ The statement ending at line XXXX
 CREATE PROC with_upsert_do_nothing ()
 BEGIN
   WITH
-  data (id) AS (VALUES(1), (2), (3))
-  INSERT INTO foo(id) SELECT id
-    FROM data
-    WHERE 1
+    data (id) AS (
+      VALUES(1), (2), (3)
+    )
+  INSERT INTO foo(id)
+    SELECT id
+      FROM data
+      WHERE 1
   ON CONFLICT (id) DO NOTHING;
 END;
 
@@ -40834,10 +41044,13 @@ The statement ending at line XXXX
 CREATE PROC with_upsert_cte_err ()
 BEGIN
   WITH
-  data (id) AS (VALUES(NOT 'x'))
-  INSERT INTO foo SELECT id
-    FROM data
-    WHERE 1
+    data (id) AS (
+      VALUES(NOT 'x')
+    )
+  INSERT INTO foo
+    SELECT id
+      FROM data
+      WHERE 1
   ON CONFLICT (id) DO NOTHING;
 END;
 
@@ -40902,10 +41115,13 @@ The statement ending at line XXXX
 CREATE PROC with_upsert_insert_err ()
 BEGIN
   WITH
-  data (id) AS (VALUES(1))
-  INSERT INTO foo(id) SELECT id
-    FROM data
-    WHERE NOT 'x'
+    data (id) AS (
+      VALUES(1)
+    )
+  INSERT INTO foo(id)
+    SELECT id
+      FROM data
+      WHERE NOT 'x'
   ON CONFLICT (id) DO NOTHING;
 END;
 
@@ -40972,7 +41188,8 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_without_conflict_target ()
 BEGIN
-  INSERT INTO foo(id) VALUES(1)
+  INSERT INTO foo(id)
+    VALUES(1)
   ON CONFLICT DO NOTHING;
 END;
 
@@ -41006,11 +41223,12 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_update ()
 BEGIN
-  INSERT INTO foo(id) VALUES(1)
+  INSERT INTO foo(id)
+    VALUES(1)
   ON CONFLICT (id) 
     WHERE id = 10 DO UPDATE
-  SET id = id + 1
-    WHERE id = 20;
+    SET id = id + 1
+      WHERE id = 20;
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -41065,7 +41283,8 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_conflict_on_unknown_column ()
 BEGIN
-  INSERT INTO foo(id) VALUES(1)
+  INSERT INTO foo(id)
+    VALUES(1)
   ON CONFLICT (id, bogus) DO NOTHING;
 END;
 
@@ -41107,9 +41326,10 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_invalid_update_stmt ()
 BEGIN
-  INSERT INTO foo(id) VALUES(1)
+  INSERT INTO foo(id)
+    VALUES(1)
   ON CONFLICT (id) DO UPDATE foo
-  SET id = 0;
+    SET id = 0;
 END;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0281: upsert statement does not include table name in the update statement 'foo'
@@ -41157,9 +41377,10 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_no_where_stmt ()
 BEGIN
-  INSERT INTO foo(id) SELECT id
-    FROM (SELECT *
-    FROM bar)
+  INSERT INTO foo(id)
+    SELECT id
+      FROM (SELECT *
+          FROM bar)
   ON CONFLICT (id) DO NOTHING;
 END;
 
@@ -41220,9 +41441,10 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_or_ignore ()
 BEGIN
-  INSERT OR IGNORE INTO foo SELECT id
-    FROM bar
-    WHERE 1
+  INSERT OR IGNORE INTO foo
+    SELECT id
+      FROM bar
+      WHERE 1
   ON CONFLICT (id) DO NOTHING;
 END;
 
@@ -41267,7 +41489,8 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_with_bogus_where_stmt ()
 BEGIN
-  INSERT INTO foo(id) VALUES(1)
+  INSERT INTO foo(id)
+    VALUES(1)
   ON CONFLICT (id) 
     WHERE bogus = 1 DO NOTHING;
 END;
@@ -41315,8 +41538,8 @@ BEGIN
     BEFORE DELETE ON bar
   BEGIN
     UPDATE
-    SET id = 1
-      WHERE id = 9;
+      SET id = 1
+        WHERE id = 9;
   END;
 END;
 
@@ -41360,7 +41583,8 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_conflict_target_column_not_unique_key ()
 BEGIN
-  INSERT INTO bar(id) VALUES(1)
+  INSERT INTO bar(id)
+    VALUES(1)
   ON CONFLICT (name) DO NOTHING;
 END;
 
@@ -41399,7 +41623,8 @@ The statement ending at line XXXX
 
 CREATE PROC upsert_conflict_target_columns_valid ()
 BEGIN
-  INSERT INTO simple_ak_table_2(a, b, c, d) VALUES(1, "t", 1.7, 1)
+  INSERT INTO simple_ak_table_2(a, b, c, d)
+    VALUES(1, "t", 1.7, 1)
   ON CONFLICT (a, b) DO NOTHING;
 END;
 
@@ -41456,7 +41681,8 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id) VALUES(1)
+INSERT INTO bar(id)
+  VALUES(1)
 ON CONFLICT DO NOTHING;
 
 test/sem_test.sql:XXXX:1: error: in upsert_stmt : CQL0289: upsert statement are forbidden if strict upsert statement mode is enabled
@@ -41492,7 +41718,8 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id) VALUES(1)
+INSERT INTO bar(id)
+  VALUES(1)
 ON CONFLICT DO NOTHING;
 
   {upsert_stmt}: ok
@@ -42822,10 +43049,10 @@ CREATE TABLE upsert_test(
 
 The statement ending at line XXXX
 
-INSERT INTO upsert_test(id, name) VALUES(1, 'name')
+INSERT INTO upsert_test(id, name)
+  VALUES(1, 'name')
 ON CONFLICT (id) DO UPDATE
-SET name = excluded.name,
-rate = id + 1;
+  SET name = excluded.name, rate = id + 1;
 
   {upsert_stmt}: ok
   | {insert_stmt}: ok
@@ -43373,8 +43600,8 @@ The statement ending at line XXXX
 
 EXPLAIN QUERY PLAN
 UPDATE bar
-SET id = 1
-  WHERE name = 'Stella';
+  SET id = 1
+    WHERE name = 'Stella';
 
   {explain_stmt}: explain_query: { iselectid: integer notnull, iorder: integer notnull, ifrom: integer notnull, zdetail: text notnull }
   | {int 2}
@@ -43448,10 +43675,11 @@ END;
 
 The statement ending at line XXXX
 
-DECLARE c CURSOR FOR EXPLAIN QUERY PLAN
-SELECT *
-  FROM foo
-  INNER JOIN bar;
+DECLARE c CURSOR FOR
+  EXPLAIN QUERY PLAN
+  SELECT *
+    FROM foo
+    INNER JOIN bar;
 
   {declare_cursor}: c: explain_query: { iselectid: integer notnull, iorder: integer notnull, ifrom: integer notnull, zdetail: text notnull } variable dml_proc
   | {name c}: c: explain_query: { iselectid: integer notnull, iorder: integer notnull, ifrom: integer notnull, zdetail: text notnull } variable dml_proc
@@ -43484,8 +43712,9 @@ The statement ending at line XXXX
 
 CREATE PROC explain_query_with_cursor ()
 BEGIN
-  DECLARE c CURSOR FOR EXPLAIN QUERY PLAN
-  SELECT 1;
+  DECLARE c CURSOR FOR
+    EXPLAIN QUERY PLAN
+    SELECT 1;
   FETCH c;
 END;
 
@@ -43600,9 +43829,11 @@ The statement ending at line XXXX
 CREATE PROC mixed_union_cte ()
 BEGIN
   WITH
-  core (x) AS (SELECT "x" AS X
-  UNION ALL
-  SELECT NULL AS X)
+    core (x) AS (
+      SELECT "x" AS X
+      UNION ALL
+      SELECT NULL AS X
+    )
   SELECT *
     FROM core;
 END;
@@ -46080,7 +46311,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0205: not a cursor 'X'
 The statement ending at line XXXX
 
 WITH
-some_cte (a, b, c) AS (SELECT 1 AS a, 'b' AS b, 3.0 AS c)
+  some_cte (a, b, c) AS (
+    SELECT 1 AS a, 'b' AS b, 3.0 AS c
+  )
 SELECT *
   FROM some_cte;
 
@@ -46142,7 +46375,9 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-some_cte (*) AS (SELECT 1)
+  some_cte (*) AS (
+    SELECT 1
+  )
 SELECT *
   FROM some_cte;
 
@@ -46629,7 +46864,8 @@ DECLARE id_name_cursor CURSOR LIKE SELECT 1 AS id, 'x' AS name;
 
 The statement ending at line XXXX
 
-INSERT INTO bar(id, name) VALUES(1, 'x');
+INSERT INTO bar(id, name)
+  VALUES(1, 'x');
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -46656,7 +46892,8 @@ INSERT INTO bar(id, name) VALUES(1, 'x');
 
 The statement ending at line XXXX
 
-INSERT INTO bar(LIKE not_a_symbol) VALUES(1, 'x');
+INSERT INTO bar(LIKE not_a_symbol)
+  VALUES(1, 'x');
 
 test/sem_test.sql:XXXX:1: error: in like : CQL0202: must be a cursor, proc, table, or view 'not_a_symbol'
 
@@ -46751,7 +46988,8 @@ DECLARE PROC out_union_user (x INTEGER) OUT UNION (id INTEGER, x TEXT);
 
 The statement ending at line XXXX
 
-DECLARE out_union_cursor CURSOR FOR CALL out_union_user(2);
+DECLARE out_union_cursor CURSOR FOR
+  CALL out_union_user(2);
 
   {declare_cursor}: out_union_cursor: out_union_user: { id: integer, x: text } variable uses_out_union
   | {name out_union_cursor}: out_union_cursor: out_union_user: { id: integer, x: text } variable uses_out_union
@@ -48290,7 +48528,8 @@ The statement ending at line XXXX
 
 CREATE PROC basic_wrapper_out ()
 BEGIN
-  DECLARE C CURSOR FOR CALL basic_source();
+  DECLARE C CURSOR FOR
+    CALL basic_source();
   FETCH C;
   OUT C;
 END;
@@ -48312,7 +48551,8 @@ The statement ending at line XXXX
 
 CREATE PROC basic_wrapper_out_union ()
 BEGIN
-  DECLARE C CURSOR FOR CALL basic_source();
+  DECLARE C CURSOR FOR
+    CALL basic_source();
   FETCH C;
   OUT UNION C;
 END;
@@ -48983,9 +49223,10 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in express
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(1)
-UNION
-VALUES(2) @DUMMY_SEED(1);
+INSERT INTO foo(id)
+  VALUES(1)
+  UNION
+  VALUES(2) @DUMMY_SEED(1);
 
 test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0334: @dummy_seed @dummy_nullables @dummy_defaults many only be used with a single VALUES row
 
@@ -49021,10 +49262,13 @@ test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0334: @dummy_seed @dummy_nu
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) WITH
-T (x) AS (VALUES(1), (2), (3))
-SELECT *
-  FROM T @DUMMY_SEED(1);
+INSERT INTO foo(id)
+  WITH
+    T (x) AS (
+      VALUES(1), (2), (3)
+    )
+  SELECT *
+    FROM T @DUMMY_SEED(1);
 
 test/sem_test.sql:XXXX:1: error: in with_select_stmt : CQL0334: @dummy_seed @dummy_nullables @dummy_defaults many only be used with a single VALUES row
 
@@ -49082,10 +49326,13 @@ test/sem_test.sql:XXXX:1: error: in with_select_stmt : CQL0334: @dummy_seed @dum
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) WITH
-T (x) AS (VALUES(1), (2), (3))
-SELECT *
-  FROM T;
+INSERT INTO foo(id)
+  WITH
+    T (x) AS (
+      VALUES(1), (2), (3)
+    )
+  SELECT *
+    FROM T;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -49138,7 +49385,8 @@ SELECT *
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) SELECT 1 @DUMMY_SEED(1);
+INSERT INTO foo(id)
+  SELECT 1 @DUMMY_SEED(1);
 
 test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0334: @dummy_seed @dummy_nullables @dummy_defaults many only be used with a single VALUES row
 
@@ -49170,7 +49418,8 @@ test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0334: @dummy_seed @dummy_nu
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(1), (2) @DUMMY_SEED(1);
+INSERT INTO foo(id)
+  VALUES(1), (2) @DUMMY_SEED(1);
 
 test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0334: @dummy_seed @dummy_nullables @dummy_defaults many only be used with a single VALUES row
 
@@ -49276,9 +49525,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'l'
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(1)
-UNION ALL
-SELECT 2 AS column1;
+INSERT INTO foo(id)
+  VALUES(1)
+  UNION ALL
+  SELECT 2 AS column1;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -49315,7 +49565,8 @@ SELECT 2 AS column1;
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(1), (2) @DUMMY_SEED(1);
+INSERT INTO foo(id)
+  VALUES(1), (2) @DUMMY_SEED(1);
 
 test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0334: @dummy_seed @dummy_nullables @dummy_defaults many only be used with a single VALUES row
 
@@ -49416,7 +49667,8 @@ CREATE TABLE values_table(
 
 The statement ending at line XXXX
 
-INSERT INTO values_table(name, id) VALUES("ok", NULL);
+INSERT INTO values_table(name, id)
+  VALUES("ok", NULL);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -49530,7 +49782,12 @@ The statement ending at line XXXX
 
 CREATE PROC exotic_literals ()
 BEGIN
-  SELECT 2147483647 AS a, 2147483648L AS b, 3.4e11 AS c, .001e+5 AS d, .4e-9 AS e;
+  SELECT 
+      2147483647 AS a,
+      2147483648L AS b,
+      3.4e11 AS c,
+      .001e+5 AS d,
+      .4e-9 AS e;
 END;
 
   {create_proc_stmt}: exotic_literals: { a: integer notnull, b: longint notnull, c: real notnull, d: real notnull, e: real notnull } dml_proc
@@ -49734,7 +49991,8 @@ The statement ending at line XXXX
 
 CREATE PROC shape_some_columns_statement_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x, 'y' AS y;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
   CALL shape_consumer(C.x, C.y);
 END;
 
@@ -50749,8 +51007,10 @@ CREATE PROC cql_cursor_diff_col_without_cursor_arg ()
 BEGIN
   DECLARE x INTEGER NOT NULL;
   DECLARE y TEXT NOT NULL;
-  DECLARE c1 CURSOR FOR SELECT 1 AS x, 'y' AS y;
-  DECLARE c2 CURSOR FOR SELECT 1 AS x, 'y' AS y;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
+  DECLARE c2 CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
   FETCH c1 INTO x, y;
   FETCH c2;
   SET a_string := cql_cursor_diff_col(c1, c2);
@@ -50841,7 +51101,8 @@ The statement ending at line XXXX
 
 CREATE PROC cql_cursor_unfetched ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   IF C THEN
   END IF;
 END;
@@ -50879,8 +51140,10 @@ The statement ending at line XXXX
 
 CREATE PROC cql_cursor_diff_col_wrong_cursor_type ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT 1 AS x;
-  DECLARE c2 CURSOR FOR SELECT '1' AS x;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS x;
+  DECLARE c2 CURSOR FOR
+    SELECT '1' AS x;
   FETCH c1;
   FETCH c2;
   SET a_string := cql_cursor_diff_col(c1, c2);
@@ -50947,8 +51210,10 @@ The statement ending at line XXXX
 
 CREATE PROC cql_cursor_diff_col_with_wrong_col_count_arg ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT 1 AS x, 'z' AS z;
-  DECLARE c2 CURSOR FOR SELECT 1 AS x;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS x, 'z' AS z;
+  DECLARE c2 CURSOR FOR
+    SELECT 1 AS x;
   FETCH c1;
   FETCH c2;
   SET a_string := cql_cursor_diff_col(c1, c2);
@@ -51020,8 +51285,10 @@ The statement ending at line XXXX
 
 CREATE PROC cql_cursor_diff_col_compatible_cursor_with_diff_col_name ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT 1 AS x, 'y' AS y;
-  DECLARE c2 CURSOR FOR SELECT 1 AS z, 'v' AS v;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
+  DECLARE c2 CURSOR FOR
+    SELECT 1 AS z, 'v' AS v;
   FETCH c1;
   FETCH c2;
   SET a_string := cql_cursor_diff_col(c1, c2);
@@ -51110,8 +51377,10 @@ The statement ending at line XXXX
 
 CREATE PROC cql_cursor_diff_col_with_shape_storage ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT 1 AS x, 'y' AS y;
-  DECLARE c2 CURSOR FOR SELECT 1 AS x, 'y' AS y;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
+  DECLARE c2 CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
   FETCH c1;
   FETCH c2;
   SET a_string := CASE WHEN c1.x IS NOT c2.x THEN 'x'
@@ -51202,8 +51471,10 @@ The statement ending at line XXXX
 
 CREATE PROC print_call_cql_cursor_diff_col ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT 1 AS x, 'y' AS y;
-  DECLARE c2 CURSOR FOR SELECT 1 AS x, 'v' AS y;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS x, 'y' AS y;
+  DECLARE c2 CURSOR FOR
+    SELECT 1 AS x, 'v' AS y;
   FETCH c1;
   FETCH c2;
   CALL printf(CASE WHEN c1.x IS NOT c2.x THEN 'x'
@@ -51295,8 +51566,10 @@ The statement ending at line XXXX
 
 CREATE PROC print_call_cql_cursor_diff_val ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT nullable(1) AS x, 'y' AS y;
-  DECLARE c2 CURSOR FOR SELECT nullable(1) AS x, 'v' AS y;
+  DECLARE c1 CURSOR FOR
+    SELECT nullable(1) AS x, 'y' AS y;
+  DECLARE c2 CURSOR FOR
+    SELECT nullable(1) AS x, 'v' AS y;
   FETCH c1;
   FETCH c2;
   CALL printf(CASE WHEN c1.x IS NOT c2.x THEN printf('column:%s c1:%s c2:%s', 'x', CASE WHEN c1.x IS NULL THEN 'null'
@@ -51981,7 +52254,14 @@ The statement ending at line XXXX
 
 CREATE PROC print_call_cql_cursor_format ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT TRUE AS a, 1 AS b, 99L AS c, 'x' AS d, nullable(1.1) AS e, CAST('y' AS BLOB) AS f;
+  DECLARE c1 CURSOR FOR
+    SELECT 
+        TRUE AS a,
+        1 AS b,
+        99L AS c,
+        'x' AS d,
+        nullable(1.1) AS e,
+        CAST('y' AS BLOB) AS f;
   FETCH c1;
   SET a_string := cql_cursor_format(c1);
 END;
@@ -52055,7 +52335,8 @@ The statement ending at line XXXX
 
 CREATE PROC select_cql_cursor_format ()
 BEGIN
-  DECLARE c1 CURSOR FOR SELECT 1 AS a;
+  DECLARE c1 CURSOR FOR
+    SELECT 1 AS a;
   FETCH c1;
   SELECT cql_cursor_format(c1) AS p;
 END;
@@ -52112,7 +52393,8 @@ The statement ending at line XXXX
 
 CREATE PROC print_call_cql_not_fetch_cursor_format ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT 1;
+  DECLARE c CURSOR FOR
+    SELECT 1;
   DECLARE x INTEGER NOT NULL;
   FETCH C INTO x;
   SET a_string := cql_cursor_format(c);
@@ -52317,8 +52599,9 @@ The statement ending at line XXXX
 
 CREATE PROC cursor_box (OUT B OBJECT<bar CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET B FROM CURSOR C;
 END;
 
@@ -52522,8 +52805,9 @@ The statement ending at line XXXX
 
 CREATE PROC cursor_box_not_a_shape (OUT box OBJECT<barf CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET box FROM CURSOR C;
 END;
 
@@ -52566,8 +52850,9 @@ The statement ending at line XXXX
 
 CREATE PROC cursor_box_wrong_shape (OUT box OBJECT<foo CURSOR>)
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET box FROM CURSOR C;
 END;
 
@@ -52644,8 +52929,9 @@ The statement ending at line XXXX
 
 CREATE PROC cursor_box_var_not_found ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM bar;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM bar;
   SET box FROM CURSOR C;
 END;
 
@@ -57120,9 +57406,10 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0070: expressions of different kind
 
 The statement ending at line XXXX
 
-INSERT INTO xy(x, y) SELECT xy.x, xy.y
-  FROM xy
-  WHERE xy.x = 1;
+INSERT INTO xy(x, y)
+  SELECT xy.x, xy.y
+    FROM xy
+    WHERE xy.x = 1;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -57167,9 +57454,10 @@ INSERT INTO xy(x, y) SELECT xy.x, xy.y
 
 The statement ending at line XXXX
 
-INSERT INTO xy(x, y) SELECT xy.y, xy.x
-  FROM xy
-  WHERE xy.x = 1;
+INSERT INTO xy(x, y)
+  SELECT xy.y, xy.x
+    FROM xy
+    WHERE xy.x = 1;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0070: expressions of different kinds can't be mixed: 'y_coord' vs. 'x_coord'
 
@@ -57312,7 +57600,8 @@ test/sem_test.sql:XXXX:1: error: in select_core : CQL0070: expressions of differ
 
 The statement ending at line XXXX
 
-INSERT INTO xy(x, y) VALUES(x1, y1), (x2, y2);
+INSERT INTO xy(x, y)
+  VALUES(x1, y1), (x2, y2);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -57344,7 +57633,8 @@ INSERT INTO xy(x, y) VALUES(x1, y1), (x2, y2);
 
 The statement ending at line XXXX
 
-INSERT INTO xy(x, y) VALUES(x1, y1), (y2, x2), (x3, y3);
+INSERT INTO xy(x, y)
+  VALUES(x1, y1), (y2, x2), (x3, y3);
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0070: expressions of different kinds can't be mixed: 'x_coord' vs. 'y_coord'
 
@@ -60566,7 +60856,9 @@ SELECT ( SELECT 1 + 3
 The statement ending at line XXXX
 
 SELECT ( WITH
-y (x) AS (SELECT 1 AS x)
+  y (x) AS (
+    SELECT 1 AS x
+  )
 SELECT *
   FROM y );
 
@@ -60681,7 +60973,8 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) SELECT 1;
+INSERT INTO foo(id)
+  SELECT 1;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -60708,9 +61001,10 @@ INSERT INTO foo(id) SELECT 1;
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) SELECT 1
-UNION ALL
-SELECT 1;
+INSERT INTO foo(id)
+  SELECT 1
+  UNION ALL
+  SELECT 1;
 
 test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0370: due to a memory leak bug in old SQLite versions, the select part of an insert must not have a top level join or compound operator. Use WITH and a CTE, or a nested select to work around this.
 
@@ -60751,9 +61045,10 @@ test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0370: due to a memory leak 
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) SELECT 1
-  FROM (SELECT 1) AS T1
-  INNER JOIN (SELECT 2) AS T2;
+INSERT INTO foo(id)
+  SELECT 1
+    FROM (SELECT 1) AS T1
+    INNER JOIN (SELECT 2) AS T2;
 
 test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0370: due to a memory leak bug in old SQLite versions, the select part of an insert must not have a top level join or compound operator. Use WITH and a CTE, or a nested select to work around this.
 
@@ -60821,10 +61116,13 @@ test/sem_test.sql:XXXX:1: error: in select_stmt : CQL0370: due to a memory leak 
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) WITH
-cte (id) AS (SELECT 1)
-SELECT *
-  FROM cte;
+INSERT INTO foo(id)
+  WITH
+    cte (id) AS (
+      SELECT 1
+    )
+  SELECT *
+    FROM cte;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -60875,7 +61173,8 @@ SELECT *
 
 The statement ending at line XXXX
 
-INSERT INTO foo(id) VALUES(1), (2), (3);
+INSERT INTO foo(id)
+  VALUES(1), (2), (3);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -62025,7 +62324,8 @@ END;
 
 The statement ending at line XXXX
 
-INSERT INTO with_kind(id, cost, value) SELECT 1 AS id, 3.5 AS cost, 4.8 AS value;
+INSERT INTO with_kind(id, cost, value)
+  SELECT 1 AS id, 3.5 AS cost, 4.8 AS value;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -62139,10 +62439,13 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
 
 The statement ending at line XXXX
 
-INSERT INTO with_kind(id, cost, value) WITH
-goo (x) AS (SELECT 1)
-SELECT goo.x AS id, 3.5 AS cost, 4.8 AS value
-  FROM goo;
+INSERT INTO with_kind(id, cost, value)
+  WITH
+    goo (x) AS (
+      SELECT 1
+    )
+  SELECT goo.x AS id, 3.5 AS cost, 4.8 AS value
+    FROM goo;
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -62525,11 +62828,14 @@ BEGIN
   DECLARE b TEXT;
   DECLARE c TEXT;
   IF a IS NOT NULL AND (b IS NOT NULL OR c IS NOT NULL) THEN
-    DECLARE c0 CURSOR FOR SELECT a AS a0, b AS b0, c AS c0;
+    DECLARE c0 CURSOR FOR
+      SELECT a AS a0, b AS b0, c AS c0;
     IF (b IS NOT NULL OR a LIKE "hello") AND c IS NOT NULL THEN
-      DECLARE c1 CURSOR FOR SELECT a AS a1, b AS b1, c AS c1;
+      DECLARE c1 CURSOR FOR
+        SELECT a AS a1, b AS b1, c AS c1;
       IF b IS NOT NULL THEN
-        DECLARE c2 CURSOR FOR SELECT a AS a2, b AS b2, c AS c2;
+        DECLARE c2 CURSOR FOR
+          SELECT a AS a2, b AS b2, c AS c2;
       END IF;
     END IF;
   END IF;
@@ -63383,8 +63689,9 @@ BEGIN
   DECLARE a INTEGER;
   DECLARE b INTEGER;
   DECLARE x INTEGER;
-  DECLARE c CURSOR FOR SELECT *
-    FROM tnull;
+  DECLARE c CURSOR FOR
+    SELECT *
+      FROM tnull;
   IF a IS NOT NULL AND b IS NOT NULL THEN
     LET x0 := a;
     LET y0 := b;
@@ -63548,8 +63855,9 @@ The statement ending at line XXXX
 
 CREATE PROC improvements_work_for_auto_cursors ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT *
-    FROM tnull;
+  DECLARE c CURSOR FOR
+    SELECT *
+      FROM tnull;
   FETCH c;
   LET x0 := c.xn;
   LET y0 := c.yn;
@@ -64756,10 +65064,14 @@ The statement ending at line XXXX
 
 CREATE PROC improvements_correctly_handle_nested_selects ()
 BEGIN
-  SELECT ( SELECT xn ), ( SELECT yn
-    FROM tnull ), ( SELECT yn
-    FROM tnull
-    WHERE yn IS NOT NULL ) AS yn0, ( SELECT yn ) AS yn1
+  SELECT 
+      ( SELECT xn ),
+      ( SELECT yn
+        FROM tnull ),
+      ( SELECT yn
+        FROM tnull
+        WHERE yn IS NOT NULL ) AS yn0,
+      ( SELECT yn ) AS yn1
     FROM tnull
     WHERE xn IS NOT NULL AND yn IS NOT NULL;
 END;
@@ -65396,7 +65708,9 @@ BEGIN
   DECLARE a INTEGER;
   IF a IS NOT NULL THEN
     WITH RECURSIVE
-    some_cte (b) AS (SELECT a)
+      some_cte (b) AS (
+        SELECT a
+      )
     SELECT b
       FROM some_cte;
   END IF;
@@ -65761,7 +66075,8 @@ The statement ending at line XXXX
 
 CREATE PROC guard_improvements_work_for_cursor_fields ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT nullable(1) AS a;
+  DECLARE c CURSOR FOR
+    SELECT nullable(1) AS a;
   FETCH c;
   IF 1 THEN
     IF c.a IS NULL THEN
@@ -67530,7 +67845,8 @@ BEGIN
   SET b := 1;
   LET x4 := a;
   LET y4 := b;
-  DECLARE foo CURSOR FOR SELECT 1 AS bar;
+  DECLARE foo CURSOR FOR
+    SELECT 1 AS bar;
   LOOP FETCH foo
   BEGIN
     LET x5 := a;
@@ -67731,7 +68047,8 @@ BEGIN
   SET b := 1;
   LET x3 := a;
   LET y3 := b;
-  DECLARE foo CURSOR FOR SELECT 1 AS bar;
+  DECLARE foo CURSOR FOR
+    SELECT 1 AS bar;
   LOOP FETCH foo
   BEGIN
     IF 0 THEN
@@ -68979,7 +69296,8 @@ The statement ending at line XXXX
 CREATE PROC fetch_into_initializes ()
 BEGIN
   DECLARE a TEXT NOT NULL;
-  DECLARE foo CURSOR FOR SELECT "text" AS bar;
+  DECLARE foo CURSOR FOR
+    SELECT "text" AS bar;
   FETCH foo INTO a;
   LET x := a;
 END;
@@ -69581,7 +69899,8 @@ The statement ending at line XXXX
 
 CREATE PROC improvements_work_for_dots_that_shadow_globals (X_id INTEGER, X_t TEXT, X_t1 TEXT NOT NULL, X_b BLOB, OUT X_x INTEGER NOT NULL)
 BEGIN
-  DECLARE Y CURSOR FOR SELECT nullable(1) AS id;
+  DECLARE Y CURSOR FOR
+    SELECT nullable(1) AS id;
   FETCH Y;
   IF X.id IS NOT NULL AND Y.id IS NOT NULL THEN
     LET x_ := X.id;
@@ -73331,18 +73650,18 @@ CREATE PROC conditional_frag (bb INTEGER NOT NULL)
 BEGIN
   IF bb = 1 THEN
     WITH
-    source (id) LIKE foo
+      source (id) LIKE foo
     SELECT *
       FROM source;
   ELSE IF bb = 2 THEN
     WITH
-    source2 (id) LIKE foo
+      source2 (id) LIKE foo
     SELECT *
       FROM source2
       WHERE x <> bb;
   ELSE
     WITH
-    source (id) LIKE foo
+      source (id) LIKE foo
     SELECT *
       FROM source
       WHERE x = bb;
@@ -73472,7 +73791,7 @@ The statement ending at line XXXX
 CREATE PROC conditional_user (xx INTEGER NOT NULL)
 BEGIN
   WITH
-  D (id) AS (CALL conditional_frag(1) USING foo AS source, foo AS source2)
+    D (id) AS (CALL conditional_frag(1) USING foo AS source, foo AS source2)
   SELECT *
     FROM D;
 END;
@@ -73531,9 +73850,13 @@ The statement ending at line XXXX
 CREATE PROC fragtest_0_0 ()
 BEGIN
   WITH
-  source (x) LIKE (SELECT 1 AS x),
-  possible_conflict (x) AS (SELECT *
-    FROM source)
+    source (x) LIKE (
+      SELECT 1 AS x
+    ),
+    possible_conflict (x) AS (
+      SELECT *
+        FROM source
+    )
   SELECT *
     FROM possible_conflict;
 END;
@@ -73618,8 +73941,10 @@ The statement ending at line XXXX
 CREATE PROC fragtest_0_1 ()
 BEGIN
   WITH
-  source (x) LIKE (SELECT 1 AS x),
-  fragtest_0_0 (x) AS (CALL fragtest_0_0() USING source AS source)
+    source (x) LIKE (
+      SELECT 1 AS x
+    ),
+    fragtest_0_0 (x) AS (CALL fragtest_0_0() USING source AS source)
   SELECT *
     FROM fragtest_0_0;
 END;
@@ -73695,8 +74020,10 @@ The statement ending at line XXXX
 CREATE PROC fragtest_0_2 ()
 BEGIN
   WITH
-  source (x) LIKE (SELECT 1 AS x),
-  fragtest_0_1 (x) AS (CALL fragtest_0_1() USING source AS source)
+    source (x) LIKE (
+      SELECT 1 AS x
+    ),
+    fragtest_0_1 (x) AS (CALL fragtest_0_1() USING source AS source)
   SELECT *
     FROM fragtest_0_1;
 END;
@@ -73769,7 +74096,9 @@ END;
 The statement ending at line XXXX
 
 WITH
-possible_conflict (x) AS (SELECT 1 AS x)
+  possible_conflict (x) AS (
+    SELECT 1 AS x
+  )
 SELECT *
   FROM (CALL fragtest_0_2() USING possible_conflict AS source);
 
@@ -73830,7 +74159,9 @@ The above originated from CALL fragtest_0_2 USING possible_conflict AS source
 The statement ending at line XXXX
 
 WITH
-source (x) AS (SELECT 1 AS x)
+  source (x) AS (
+    SELECT 1 AS x
+  )
 SELECT *
   FROM (CALL fragtest_0_2() USING source AS source);
 
@@ -73887,9 +74218,13 @@ The statement ending at line XXXX
 CREATE PROC fragtest_1_0 ()
 BEGIN
   WITH
-  source (x) LIKE (SELECT 1 AS x),
-  possible_conflict (x) AS (SELECT *
-    FROM source)
+    source (x) LIKE (
+      SELECT 1 AS x
+    ),
+    possible_conflict (x) AS (
+      SELECT *
+        FROM source
+    )
   SELECT *
     FROM possible_conflict;
 END;
@@ -73974,8 +74309,10 @@ The statement ending at line XXXX
 CREATE PROC fragtest_1_1 ()
 BEGIN
   WITH
-  possible_conflict (x) AS (SELECT 1 AS x),
-  fragtest_1_0 (*) AS (CALL fragtest_1_0() USING possible_conflict AS source)
+    possible_conflict (x) AS (
+      SELECT 1 AS x
+    ),
+    fragtest_1_0 (*) AS (CALL fragtest_1_0() USING possible_conflict AS source)
   SELECT *
     FROM fragtest_1_0;
 END;
@@ -74054,7 +74391,9 @@ The statement ending at line XXXX
 CREATE PROC fragtest_2_0 ()
 BEGIN
   WITH
-  possible_conflict (x) AS (SELECT 1 AS x)
+    possible_conflict (x) AS (
+      SELECT 1 AS x
+    )
   SELECT *
     FROM possible_conflict;
 END;
@@ -74116,8 +74455,10 @@ The statement ending at line XXXX
 CREATE PROC fragtest_2_1 ()
 BEGIN
   WITH
-  source (x) LIKE (SELECT 1 AS x),
-  fragtest_2_0 (x) AS (CALL fragtest_2_0())
+    source (x) LIKE (
+      SELECT 1 AS x
+    ),
+    fragtest_2_0 (x) AS (CALL fragtest_2_0())
   SELECT source.x
     FROM source
     INNER JOIN fragtest_2_0;
@@ -74196,7 +74537,9 @@ END;
 The statement ending at line XXXX
 
 WITH
-possible_conflict (x) AS (SELECT 1 AS x)
+  possible_conflict (x) AS (
+    SELECT 1 AS x
+  )
 SELECT *
   FROM (CALL fragtest_2_1() USING possible_conflict AS source);
 
@@ -74253,7 +74596,9 @@ The statement ending at line XXXX
 CREATE PROC frag_not_really_a_conflict ()
 BEGIN
   WITH
-  possible_conflict (x) LIKE (SELECT 1 AS x)
+    possible_conflict (x) LIKE (
+      SELECT 1 AS x
+    )
   SELECT *
     FROM (CALL fragtest_1_0() USING possible_conflict AS source);
 END;
@@ -74884,7 +75229,12 @@ test/sem_test.sql:XXXX:1: error: in select_expr_list_con : CQL0053: select colum
 
 The statement ending at line XXXX
 
-SELECT 1 AS y, T.id, T.t, T.u, 1 AS x
+SELECT 
+    1 AS y,
+    T.id,
+    T.t,
+    T.u,
+    1 AS x
   FROM simple_shape2 AS T;
 
   {select_stmt}: select: { y: integer notnull, id: integer, t: text, u: text, x: integer notnull }
@@ -75227,11 +75577,13 @@ The statement ending at line XXXX
 CREATE PROC do_inline_math ()
 BEGIN
   WITH
-  N (i) AS (SELECT 1 AS i
-  UNION ALL
-  SELECT i + 1 AS i
-    FROM N
-  LIMIT 20)
+    N (i) AS (
+      SELECT 1 AS i
+      UNION ALL
+      SELECT i + 1 AS i
+        FROM N
+      LIMIT 20
+    )
   SELECT inline_math(i, i + 3) AS result
     FROM N;
 END;
@@ -75784,7 +76136,7 @@ The statement ending at line XXXX
 CREATE PROC uses_declared_shared_fragment ()
 BEGIN
   WITH
-  x (*) AS (CALL declared_shared_fragment())
+    x (*) AS (CALL declared_shared_fragment())
   SELECT *
     FROM x;
 END;
@@ -75911,8 +76263,8 @@ The statement ending at line XXXX
 @ATTRIBUTE(cql:shared_fragment)
 CREATE PROC nested_expression_fragment (x INTEGER NOT NULL, y INTEGER NOT NULL)
 BEGIN
-  SELECT ( WITH
-  no_args_frag (x, y, z) AS (CALL no_args_frag())
+  SELECT (   WITH
+    no_args_frag (x, y, z) AS (CALL no_args_frag())
   SELECT f.x
     FROM no_args_frag AS f ) AS val;
 END;
@@ -76031,8 +76383,8 @@ The statement ending at line XXXX
 @ATTRIBUTE(cql:shared_fragment)
 CREATE PROC nested_expression_fragment_with_args1 (x INTEGER NOT NULL, y INTEGER NOT NULL)
 BEGIN
-  SELECT ( WITH
-  a_shared_frag (x, y, z) AS (CALL a_shared_frag(LOCALS.x, LOCALS.y))
+  SELECT (   WITH
+    a_shared_frag (x, y, z) AS (CALL a_shared_frag(LOCALS.x, LOCALS.y))
   SELECT f.x
     FROM a_shared_frag AS f ) AS val;
 END;
@@ -76364,26 +76716,36 @@ The statement ending at line XXXX
 
 CREATE PROC ShapeTrix ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT Shape_xy.*, 1 AS u, 2 AS v
-    FROM Shape_xy;
+  DECLARE C CURSOR FOR
+    SELECT Shape_xy.*, 1 AS u, 2 AS v
+      FROM Shape_xy;
   FETCH C;
-  INSERT INTO Shape_xy(x, y) VALUES(C.x, C.y);
-  INSERT INTO Shape_xy(x, y) VALUES(1, 2), (3, 4), (C.x, C.y);
-  DECLARE D CURSOR FOR SELECT *
-    FROM Shape_uv;
+  INSERT INTO Shape_xy(x, y)
+    VALUES(C.x, C.y);
+  INSERT INTO Shape_xy(x, y)
+    VALUES(1, 2), (3, 4), (C.x, C.y);
+  DECLARE D CURSOR FOR
+    SELECT *
+      FROM Shape_uv;
   FETCH D;
   DECLARE R CURSOR LIKE Shape_uvxy;
   FETCH R(x, y, u, v) FROM VALUES(C.x, C.y, D.u, D.v);
   UPDATE CURSOR R(x, y, u, v) FROM VALUES(C.x, C.y, D.u, D.v);
-  DECLARE S CURSOR FOR WITH
-  cte1 (l, m, n, o) AS (VALUES(C.x, C.y, D.u, D.v))
-  SELECT *
-    FROM cte1;
+  DECLARE S CURSOR FOR
+    WITH
+      cte1 (l, m, n, o) AS (
+        VALUES(C.x, C.y, D.u, D.v)
+      )
+    SELECT *
+      FROM cte1;
   FETCH S;
-  DECLARE T CURSOR FOR WITH
-  cte2 (l, m, n, o) AS (VALUES(1, 2, '3', '4'), (C.x, C.y, D.u, D.v))
-  SELECT *
-    FROM cte2;
+  DECLARE T CURSOR FOR
+    WITH
+      cte2 (l, m, n, o) AS (
+        VALUES(1, 2, '3', '4'), (C.x, C.y, D.u, D.v)
+      )
+    SELECT *
+      FROM cte2;
   FETCH S;
 END;
 
@@ -76696,7 +77058,8 @@ The statement ending at line XXXX
 
 CREATE PROC ShapeTrixError1 ()
 BEGIN
-  INSERT INTO Shape_xy(x, y) VALUES(FROM not_a_cursor LIKE Shape_xy);
+  INSERT INTO Shape_xy(x, y)
+    VALUES(FROM not_a_cursor LIKE Shape_xy);
 END;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'not_a_cursor'
@@ -76830,7 +77193,8 @@ The statement ending at line XXXX
 
 CREATE PROC ShapeTrixError4 ()
 BEGIN
-  INSERT INTO Shape_xy(x, y) VALUES(1, 2), (FROM not_a_cursor LIKE Shape_xy);
+  INSERT INTO Shape_xy(x, y)
+    VALUES(1, 2), (FROM not_a_cursor LIKE Shape_xy);
 END;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'not_a_cursor'
@@ -77258,7 +77622,7 @@ The statement ending at line XXXX
 CREATE PROC use_enum_and_backing ()
 BEGIN
   WITH
-  backed (rowid, status_id, global_connection_state) AS (CALL _backed())
+    backed (rowid, status_id, global_connection_state) AS (CALL _backed())
   SELECT 1 AS x
     FROM backed;
 END;
@@ -79032,7 +79396,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'foo' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'foo' AS name;
   FETCH C;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
@@ -80397,9 +80762,12 @@ CREATE TABLE bt_default(
 The statement ending at line XXXX
 
 WITH
-_vals (pk1, x) AS (VALUES(1, 2))
-INSERT INTO simple_backing_table(k, v) SELECT cql_blob_create(bt_default, V.pk1, bt_default.pk1, 99, bt_default.pk2), cql_blob_create(bt_default, V.x, bt_default.x, 42, bt_default.y)
-  FROM _vals AS V;
+  _vals (pk1, x) AS (
+    VALUES(1, 2)
+  )
+INSERT INTO simple_backing_table(k, v)
+  SELECT cql_blob_create(bt_default, V.pk1, bt_default.pk1, 99, bt_default.pk2), cql_blob_create(bt_default, V.x, bt_default.x, 42, bt_default.y)
+    FROM _vals AS V;
 
   {with_insert_stmt}: ok
   | {with}
@@ -80497,9 +80865,12 @@ INSERT INTO simple_backing_table(k, v) SELECT cql_blob_create(bt_default, V.pk1,
 The statement ending at line XXXX
 
 WITH
-_vals (id, name) AS (VALUES(1, 'foo'))
-INSERT INTO simple_backing_table(k, v) SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
-  FROM _vals AS V
+  _vals (id, name) AS (
+    VALUES(1, 'foo')
+  )
+INSERT INTO simple_backing_table(k, v)
+  SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
+    FROM _vals AS V
 ON CONFLICT (k) DO NOTHING;
 
   {with_upsert_stmt}: ok
@@ -80592,17 +80963,20 @@ ON CONFLICT (k) DO NOTHING;
 The statement ending at line XXXX
 
 WITH
-basic_table (rowid, id, name) AS (CALL _basic_table()),
-_vals (id, name) AS (SELECT id + 3, name
-  FROM basic_table
-  WHERE id < 100)
-INSERT INTO simple_backing_table(k, v) SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
-  FROM _vals AS V
+  basic_table (rowid, id, name) AS (CALL _basic_table()),
+  _vals (id, name) AS (
+    SELECT id + 3, name
+      FROM basic_table
+      WHERE id < 100
+  )
+INSERT INTO simple_backing_table(k, v)
+  SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
+    FROM _vals AS V
 ON CONFLICT (k) DO UPDATE
-SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
-  WHERE rowid IN (SELECT rowid
-  FROM basic_table
-  WHERE id < 100);
+  SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
+    WHERE rowid IN (SELECT rowid
+    FROM basic_table
+    WHERE id < 100);
 
   {with_upsert_stmt}: ok
   | {with}
@@ -80775,7 +81149,8 @@ SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
 
 The statement ending at line XXXX
 
-INSERT INTO bogus_table_not_present VALUES(1, 2)
+INSERT INTO bogus_table_not_present
+  VALUES(1, 2)
 ON CONFLICT (id) DO NOTHING;
 
 test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement does not exist 'bogus_table_not_present'
@@ -80807,18 +81182,23 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0160: table in insert statement doe
 The statement ending at line XXXX
 
 WITH
-basic_table (rowid, id, name) AS (CALL _basic_table()),
-a_useless_cte (x, y) AS (SELECT 1, 2),
-_vals (id, name) AS (SELECT id + 3, name
-  FROM basic_table
-  WHERE id < 100)
-INSERT INTO simple_backing_table(k, v) SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
-  FROM _vals AS V
+  basic_table (rowid, id, name) AS (CALL _basic_table()),
+  a_useless_cte (x, y) AS (
+    SELECT 1, 2
+  ),
+  _vals (id, name) AS (
+    SELECT id + 3, name
+      FROM basic_table
+      WHERE id < 100
+  )
+INSERT INTO simple_backing_table(k, v)
+  SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
+    FROM _vals AS V
 ON CONFLICT (k) DO UPDATE
-SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
-  WHERE rowid IN (SELECT rowid
-  FROM basic_table
-  WHERE id < 100);
+  SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
+    WHERE rowid IN (SELECT rowid
+    FROM basic_table
+    WHERE id < 100);
 
   {with_upsert_stmt}: ok
   | {with}
@@ -81565,7 +81945,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test_type_mismatch ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 5 AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 5 AS name;
   FETCH C;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
@@ -81615,7 +81996,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test_type_not_a_table ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'name' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'name' AS name;
   FETCH C;
   DECLARE B BLOB<not_a_table>;
   SET B FROM CURSOR C;
@@ -81665,7 +82047,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test_type_is_a_view ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'name' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'name' AS name;
   FETCH C;
   DECLARE B BLOB<MyView>;
   SET B FROM CURSOR C;
@@ -81715,7 +82098,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test_type_has_no_kind ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 'name' AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 'name' AS name;
   FETCH C;
   DECLARE B BLOB;
   SET B FROM CURSOR C;
@@ -81764,7 +82148,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test_no_storage ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 5 AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 5 AS name;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR C;
 END;
@@ -81811,7 +82196,8 @@ The statement ending at line XXXX
 
 CREATE PROC blob_serialization_test_valid_cursor ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS id, 5 AS name;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS id, 5 AS name;
   DECLARE B BLOB<structured_storage>;
   SET B FROM CURSOR not_a_cursor;
 END;
@@ -82577,8 +82963,9 @@ The statement ending at line XXXX
 
 CREATE PROC has_row_check_required_before_using_nonnull_reference_field ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT *
-    FROM has_row_check_table;
+  DECLARE c CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
   FETCH c;
   LET x := c.a;
   LET y := c.b;
@@ -82625,8 +83012,9 @@ The statement ending at line XXXX
 
 CREATE PROC has_row_checks_can_be_positive_or_negative ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT *
-    FROM has_row_check_table;
+  DECLARE c CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
   FETCH c;
   LET x0 := c.a;
   IF c THEN
@@ -82717,8 +83105,9 @@ BEGIN
   DECLARE c2 CURSOR LIKE has_row_check_blob;
   FETCH c2 FROM BLOB b;
   LET x2 := c2.a;
-  DECLARE c3 CURSOR FOR SELECT *
-    FROM has_row_check_table;
+  DECLARE c3 CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
   FETCH c3;
   LET x3 := c3.a;
 END;
@@ -82838,8 +83227,9 @@ The statement ending at line XXXX
 
 CREATE PROC fetching_again_requires_another_check ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT *
-    FROM has_row_check_table;
+  DECLARE c CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
   FETCH c;
   IF NOT c THEN
     RETURN;
@@ -82912,8 +83302,9 @@ The statement ending at line XXXX
 
 CREATE PROC fetching_with_loop_requires_no_check ()
 BEGIN
-  DECLARE c CURSOR FOR SELECT *
-    FROM has_row_check_table;
+  DECLARE c CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
   LOOP FETCH c
   BEGIN
     LET x0 := c.a;
@@ -82964,10 +83355,12 @@ The statement ending at line XXXX
 
 CREATE PROC refetching_within_loop_may_unimprove_cursor_earlier_in_loop ()
 BEGIN
-  DECLARE c0 CURSOR FOR SELECT *
-    FROM has_row_check_table;
-  DECLARE c1 CURSOR FOR SELECT *
-    FROM has_row_check_table;
+  DECLARE c0 CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
+  DECLARE c1 CURSOR FOR
+    SELECT *
+      FROM has_row_check_table;
   FETCH c0;
   IF NOT c0 THEN
     RETURN;
@@ -85613,14 +86006,16 @@ BEGIN
   DECLARE __result__0 BOOL NOT NULL;
   DECLARE __key__0 CURSOR LIKE test_child(x);
   LET __partition__0 := cql_partition_create();
-  DECLARE __child_cursor__0 CURSOR FOR CALL test_child(1);
+  DECLARE __child_cursor__0 CURSOR FOR
+    CALL test_child(1);
   LOOP FETCH __child_cursor__0
   BEGIN
     FETCH __key__0(x) FROM VALUES(__child_cursor__0.x);
     SET __result__0 := cql_partition_cursor(__partition__0, __key__0, __child_cursor__0);
   END;
   DECLARE __out_cursor__0 CURSOR LIKE (x INTEGER, my_child OBJECT<test_child SET> NOT NULL);
-  DECLARE __parent__0 CURSOR FOR CALL test_parent(2);
+  DECLARE __parent__0 CURSOR FOR
+    CALL test_parent(2);
   LOOP FETCH __parent__0
   BEGIN
     FETCH __key__0(x) FROM VALUES(__parent__0.x);
@@ -85751,14 +86146,16 @@ BEGIN
   DECLARE __result__1 BOOL NOT NULL;
   DECLARE __key__1 CURSOR LIKE test_child(x);
   LET __partition__1 := cql_partition_create();
-  DECLARE __child_cursor__1 CURSOR FOR CALL test_child(1);
+  DECLARE __child_cursor__1 CURSOR FOR
+    CALL test_child(1);
   LOOP FETCH __child_cursor__1
   BEGIN
     FETCH __key__1(x) FROM VALUES(__child_cursor__1.x);
     SET __result__1 := cql_partition_cursor(__partition__1, __key__1, __child_cursor__1);
   END;
   DECLARE __out_cursor__1 CURSOR LIKE (x INTEGER, child1 OBJECT<test_child SET> NOT NULL);
-  DECLARE __parent__1 CURSOR FOR CALL test_parent(2);
+  DECLARE __parent__1 CURSOR FOR
+    CALL test_parent(2);
   LOOP FETCH __parent__1
   BEGIN
     FETCH __key__1(x) FROM VALUES(__parent__1.x);
@@ -86020,10 +86417,11 @@ CREATE TABLE dummy_table_for_backed_test(
 
 The statement ending at line XXXX
 
-DECLARE backed_cursor CURSOR FOR WITH
-simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
-SELECT *
-  FROM simple_backed_table;
+DECLARE backed_cursor CURSOR FOR
+  WITH
+    simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
+  SELECT *
+    FROM simple_backed_table;
 
   {declare_cursor}: backed_cursor: select: { rowid: longint notnull, id: integer notnull, name: text<cool_text> notnull } variable dml_proc
   | {name backed_cursor}: backed_cursor: select: { rowid: longint notnull, id: integer notnull, name: text<cool_text> notnull } variable dml_proc
@@ -86062,9 +86460,10 @@ SELECT *
 The statement ending at line XXXX
 
 WITH
-simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
-INSERT INTO dummy_table_for_backed_test(id) SELECT id
-  FROM simple_backed_table;
+  simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
+INSERT INTO dummy_table_for_backed_test(id)
+  SELECT id
+    FROM simple_backed_table;
 
   {with_insert_stmt}: ok
   | {with}
@@ -86110,7 +86509,7 @@ INSERT INTO dummy_table_for_backed_test(id) SELECT id
 The statement ending at line XXXX
 
 WITH
-simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
+  simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
 DELETE FROM dummy_table_for_backed_test WHERE id IN (SELECT id
   FROM simple_backed_table);
 
@@ -86155,11 +86554,11 @@ DELETE FROM dummy_table_for_backed_test WHERE id IN (SELECT id
 The statement ending at line XXXX
 
 WITH
-simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
+  simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
 UPDATE dummy_table_for_backed_test
-SET id = id + 1
-  WHERE id IN (SELECT id
-  FROM simple_backed_table);
+  SET id = id + 1
+    WHERE id IN (SELECT id
+    FROM simple_backed_table);
 
   {with_update_stmt}: dummy_table_for_backed_test: { id: integer }
   | {with}
@@ -86293,9 +86692,9 @@ CREATE TABLE update_test_2(
 The statement ending at line XXXX
 
 UPDATE update_from_target
-SET name = update_test_2.name FROM update_test_1
+  SET name = update_test_2.nameFROM update_test_1
   INNER JOIN update_test_2 ON update_test_1.id = update_test_2.id
-  WHERE update_test_1.name = 'x' AND update_from_target.id = update_test_1.id;
+    WHERE update_test_1.name = 'x' AND update_from_target.id = update_test_1.id;
 
   {update_stmt}: update_from_target: { id: integer notnull primary_key, name: text }
   | {name update_from_target}: update_from_target: { id: integer notnull primary_key, name: text }
@@ -86345,7 +86744,7 @@ SET name = update_test_2.name FROM update_test_1
 The statement ending at line XXXX
 
 UPDATE update_from_target
-SET name = update_test_2.name FROM table_does_not_exist;
+  SET name = update_test_2.nameFROM table_does_not_exist;
 
 test/sem_test.sql:XXXX:1: error: in table_or_subquery : CQL0095: table/view not defined 'table_does_not_exist'
 
@@ -86368,7 +86767,7 @@ test/sem_test.sql:XXXX:1: error: in table_or_subquery : CQL0095: table/view not 
 The statement ending at line XXXX
 
 UPDATE simple_backed_table
-SET id = 5 FROM update_test_1;
+  SET id = 5FROM update_test_1;
 
 test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0497: FROM clause not supported when updating backed table 'simple_backed_table'
 
@@ -86396,7 +86795,7 @@ The statement ending at line XXXX
 The statement ending at line XXXX
 
 UPDATE update_from_target
-SET name = update_test_2.name FROM update_test_1;
+  SET name = update_test_2.nameFROM update_test_1;
 
 test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
 
@@ -88435,8 +88834,9 @@ The statement ending at line XXXX
 
 CREATE PROC qid_t1 ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM `xyz``abc`;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM `xyz``abc`;
   LOOP FETCH C
   BEGIN
     CALL printf("%d %d", C.x, C.`a b`);
@@ -88486,8 +88886,9 @@ The statement ending at line XXXX
 
 CREATE PROC qid_t2 ()
 BEGIN
-  DECLARE D CURSOR FOR SELECT `xyz``abc`.*
-    FROM `xyz``abc`;
+  DECLARE D CURSOR FOR
+    SELECT `xyz``abc`.*
+      FROM `xyz``abc`;
   LOOP FETCH D
   BEGIN
     CALL printf("%d %d", D.x, D.`a b`);
@@ -88805,7 +89206,7 @@ CREATE TABLE qid_ref_4(
 The statement ending at line XXXX
 
 UPDATE `xyz``abc`
-SET `a b` = 5;
+  SET `a b` = 5;
 
   {update_stmt}: X_xyzX60abc: { x: integer notnull, `a b`: integer notnull unique_key qid } qid
   | {name `xyz``abc`}: X_xyzX60abc: { x: integer notnull, `a b`: integer notnull unique_key qid } qid
@@ -88820,7 +89221,8 @@ SET `a b` = 5;
 
 The statement ending at line XXXX
 
-INSERT INTO `xyz``abc`(x, `a b`) VALUES(1, 5);
+INSERT INTO `xyz``abc`(x, `a b`)
+  VALUES(1, 5);
 
   {insert_stmt}: ok
   | {insert_normal}
@@ -88912,10 +89314,12 @@ The statement ending at line XXXX
 
 CREATE PROC quoted_from_forms ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT *
-    FROM `xyz``abc`;
+  DECLARE C CURSOR FOR
+    SELECT *
+      FROM `xyz``abc`;
   FETCH C;
-  INSERT INTO `xyz``abc`(x, `a b`) VALUES(C.x, C.`a b`);
+  INSERT INTO `xyz``abc`(x, `a b`)
+    VALUES(C.x, C.`a b`);
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -89062,7 +89466,8 @@ The statement ending at line XXXX
 
 CREATE PROC cursor_boxing_with_qid ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT 1 AS x;
+  DECLARE C CURSOR FOR
+    SELECT 1 AS x;
   DECLARE `box obj` OBJECT<C CURSOR>;
   SET `box obj` FROM CURSOR C;
 END;
@@ -89314,7 +89719,7 @@ CREATE PROC presult_4 ()
 BEGIN
   SELECT *
     FROM (SELECT *
-    FROM qnamed_table);
+        FROM qnamed_table);
 END;
 
   {create_proc_stmt}: presult_4: { `x y`: integer qid, `a b`: integer qid } dml_proc
@@ -89359,7 +89764,7 @@ CREATE PROC presult_5 ()
 BEGIN
   SELECT T1.*
     FROM (SELECT *
-    FROM qnamed_table) AS T1;
+        FROM qnamed_table) AS T1;
 END;
 
   {create_proc_stmt}: presult_5: { `x y`: integer qid, `a b`: integer qid } dml_proc

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -23896,3 +23896,9 @@ create proc presult_5()
 begin
   select T1.* from (select * from qnamed_table) T1;
 end;
+
+-- TEST: verifies identifier creation based resolution
+-- + DECLARE foobar2 REAL;
+-- + {declare_vars_type}: real
+-- + {name foobar2}: foobar2: real variable
+declare @ID("foo", "bar", "2") @id("real");

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -6718,7 +6718,8 @@ end;
 
 -- TEST: try to use the non-column insert syntax on a table with deleted columns
 -- we should get a fully formed insert on the non deleted column
--- + INSERT INTO hides_id_not_name(name) VALUES('x');
+-- + INSERT INTO hides_id_not_name(name)
+-- +   VALUES('x');
 -- + {name hides_id_not_name}: hides_id_not_name: { name: text }
 insert into hides_id_not_name values('x');
 
@@ -12321,7 +12322,9 @@ update cursor X(one) from values (2);
 -- TEST -- CTE * rewrite
 -- This is just sugar so all we have to do is verify that we
 -- did the rewrite correctly
--- + some_cte (a, b, c) AS (SELECT 1 AS a, 'b' AS b, 3.0 AS c)
+-- + some_cte (a, b, c) AS (
+-- +   SELECT 1 AS a, 'b' AS b, 3.0 AS c
+-- + )
 -- + {with_select_stmt}: select: { a: integer notnull, b: text notnull, c: real notnull }
 -- - error:
 with some_cte(*) as (select 1 a, 'b' b, 3.0 c)
@@ -12407,7 +12410,8 @@ fetch nully_cursor(like not_a_symbol) from values (1, 2);
 declare id_name_cursor cursor like select 1 id, 'x' name;
 
 -- TEST: rewrite the columns of an insert from a cursor source
--- + INSERT INTO bar(id, name) VALUES(1, 'x');
+-- + INSERT INTO bar(id, name)
+-- +   VALUES(1, 'x');
 -- + {insert_stmt}: ok
 -- - error:
 insert into bar(like id_name_cursor) values(1, 'x');
@@ -13223,7 +13227,12 @@ END;
 
 -- TEST: complex floating point and integer literals
 -- first verify round trip through the AST
--- + SELECT 2147483647 AS a, 2147483648L AS b, 3.4e11 AS c, .001e+5 AS d, .4e-9 AS e;
+-- + SELECT
+-- +    2147483647 AS a,
+-- +    2147483648L AS b,
+-- +    3.4e11 AS c,
+-- +    .001e+5 AS d,
+-- +    .4e-9 AS e;
 -- + {int 2147483647}: integer notnull
 -- + {longint 2147483648}: longint notnull
 -- + {dbl 3.4e11}: real notnull
@@ -13772,7 +13781,14 @@ set sens_text := (select trim("xyz", name) result from with_sensitive);
 
 -- TEST: call cql_cursor_format on a auto cursor
 -- + {create_proc_stmt}: ok dml_proc
--- + DECLARE c1 CURSOR FOR SELECT TRUE AS a, 1 AS b, 99L AS c, 'x' AS d, nullable(1.1) AS e, CAST('y' AS BLOB) AS f;
+-- + DECLARE c1 CURSOR FOR
+-- +  SELECT
+-- +     TRUE AS a,
+-- +     1 AS b,
+-- +     99L AS c,
+-- +     'x' AS d,
+-- +     nullable(1.1) AS e,
+-- +     CAST('y' AS BLOB) AS f;
 -- + FETCH c1;
 -- this is a normal function call now
 -- + SET a_string := cql_cursor_format(c1);
@@ -16774,7 +16790,8 @@ end;
 -- TEST: try the select using form
 -- we only need to verify the rewrite, all else is normal processing
 -- {insert_stmt}: ok
--- + INSERT INTO with_kind(id, cost, value) SELECT 1 AS id, 3.5 AS cost, 4.8 AS value;
+-- + INSERT INTO with_kind(id, cost, value)
+-- +   SELECT 1 AS id, 3.5 AS cost, 4.8 AS value;
 -- - error:
 insert into with_kind using
   select 1 id, 3.5 cost, 4.8 value;
@@ -16796,10 +16813,13 @@ insert into with_kind using
 -- TEST: try the select using form (and with clause)
 -- we only need to verify the rewrite, all else is normal processing
 -- {insert_stmt}: ok
--- + INSERT INTO with_kind(id, cost, value) WITH
--- + goo (x) AS (SELECT 1)
--- + SELECT goo.x AS id, 3.5 AS cost, 4.8 AS value
--- + FROM goo;
+-- + INSERT INTO with_kind(id, cost, value)
+-- + WITH
+-- +   goo (x) AS (
+-- +     SELECT 1
+-- +   )
+-- +   SELECT goo.x AS id, 3.5 AS cost, 4.8 AS value
+-- +   FROM goo;
 -- - error:
 insert into with_kind using
    with goo(x) as (select 1)
@@ -20185,7 +20205,12 @@ select @columns(simple_shape like with_kind) from simple_shape;
 select @columns(like foo);
 
 -- TEST: ensure that consecutive column rewrites link up properly
--- + SELECT 1 AS y, T.id, T.t, T.u, 1 AS x
+-- + SELECT
+-- +   1 AS y,
+-- +   T.id,
+-- +   T.t,
+-- +   T.u,
+-- +   1 AS x
 -- - error:
 select 1 y, @columns(distinct T.id), @columns(T.t, T.u), 1 x from simple_shape2 T;
 
@@ -20444,12 +20469,18 @@ create table Shape_uvxy (like Shape_xy, like Shape_uv);
 -- TEST: expand various insert_list forms using the FROM syntax
 -- these are all rewrites so we verify that the rewrite was correct
 -- these four forms are exhaustive
--- + INSERT INTO Shape_xy(x, y) VALUES(C.x, C.y);
--- + INSERT INTO Shape_xy(x, y) VALUES(1, 2), (3, 4), (C.x, C.y);
+-- + INSERT INTO Shape_xy(x, y)
+-- +   VALUES(C.x, C.y);
+-- + INSERT INTO Shape_xy(x, y)
+-- +   VALUES(1, 2), (3, 4), (C.x, C.y);
 -- + FETCH R(x, y, u, v) FROM VALUES(C.x, C.y, D.u, D.v);
 -- + UPDATE CURSOR R(x, y, u, v) FROM VALUES(C.x, C.y, D.u, D.v);
--- + cte1 (l, m, n, o) AS (VALUES(C.x, C.y, D.u, D.v))
--- + cte2 (l, m, n, o) AS (VALUES(1, 2, '3', '4'), (C.x, C.y, D.u, D.v))
+-- + cte1 (l, m, n, o) AS (
+-- +   VALUES(C.x, C.y, D.u, D.v)
+-- + )
+-- + cte2 (l, m, n, o) AS (
+-- +  VALUES(1, 2, '3', '4'), (C.x, C.y, D.u, D.v)
+-- + )
 -- - error:
 create proc ShapeTrix()
 begin
@@ -21397,7 +21428,9 @@ create table bt_default(
 
 -- TEST: generate defaults for pk2 and y but pk1 and x
 -- + WITH
--- + _vals (pk1, x) AS (VALUES(1, 2))
+-- + _vals (pk1, x) AS (
+-- +   VALUES(1, 2)
+-- + )
 -- + INSERT INTO simple_backing_table(k, v)
 -- + cql_blob_create(bt_default, V.pk1, bt_default.pk1, 99, bt_default.pk2),
 -- + cql_blob_create(bt_default, V.x, bt_default.x, 42, bt_default.y)
@@ -21411,7 +21444,9 @@ insert into bt_default(pk1,x) values (1, 2);
 -- verify rewrite
 -- + {with_upsert_stmt}: ok
 -- + WITH
--- + _vals (id, name) AS (VALUES(1, 'foo'))
+-- + _vals (id, name) AS (
+-- +  VALUES(1, 'foo')
+-- + )
 -- + INSERT INTO simple_backing_table(k, v)
 -- + SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
 -- + FROM _vals AS V
@@ -21447,10 +21482,13 @@ INSERT INTO bogus_table_not_present VALUES(1,2) on conflict(id) do nothing;
 -- + {update_stmt}: simple_backing_table: { k: blob notnull primary_key, v: blob notnull } backing
 -- + WITH
 -- + basic_table (rowid, id, name) AS (CALL _basic_table()),
--- + a_useless_cte (x, y) AS (SELECT 1, 2),
--- + _vals (id, name) AS (SELECT id + 3, name
--- + FROM basic_table
--- + WHERE id < 100)
+-- + a_useless_cte (x, y) AS (
+-- +  SELECT 1, 2
+-- + ),
+-- + _vals (id, name) AS (
+-- +   SELECT id + 3, name
+-- +   FROM basic_table
+-- +   WHERE id < 100)
 -- + INSERT INTO simple_backing_table(k, v)
 -- + SELECT cql_blob_create(basic_table, V.id, basic_table.id), cql_blob_create(basic_table, V.name, basic_table.name)
 -- + FROM _vals AS V
@@ -22782,14 +22820,16 @@ end;
 -- +   DECLARE __result__0 BOOL NOT NULL;
 -- +   DECLARE __key__0 CURSOR LIKE test_child(x);
 -- +   LET __partition__0 := cql_partition_create();
--- +   DECLARE __child_cursor__0 CURSOR FOR CALL test_child(1);
+-- +   DECLARE __child_cursor__0 CURSOR FOR
+-- +     CALL test_child(1);
 -- +   LOOP FETCH __child_cursor__0
 -- +   BEGIN
 -- +     FETCH __key__0(x) FROM VALUES(__child_cursor__0.x);
 -- +     SET __result__0 := cql_partition_cursor(__partition__0, __key__0, __child_cursor__0);
 -- +   END;
 -- +   DECLARE __out_cursor__0 CURSOR LIKE (x INTEGER, my_child OBJECT<test_child SET> NOT NULL);
--- +   DECLARE __parent__0 CURSOR FOR CALL test_parent(2);
+-- +   DECLARE __parent__0 CURSOR FOR
+-- +     CALL test_parent(2);
 -- +   LOOP FETCH __parent__0
 -- +   BEGIN
 -- +     FETCH __key__0(x) FROM VALUES(__parent__0.x);
@@ -23522,7 +23562,8 @@ create table `xyz``abc`
 
 -- TEST: make a cursor on an exotic name and fetch from it
 -- verify that echoing is re-emitting the escaped text
--- + DECLARE C CURSOR FOR SELECT *
+-- + DECLARE C CURSOR FOR
+-- +   SELECT *
 -- + FROM `xyz``abc`;
 -- + CALL printf("%d %d", C.x, C.`a b`);
 -- + {declare_cursor}: C: select: { x: integer notnull, `a b`: integer notnull qid } variable dml_proc
@@ -23541,7 +23582,8 @@ end;
 
 -- TEST: Test several expansions
 -- verify that echoing is re-emitting the escaped text
--- + DECLARE D CURSOR FOR SELECT `xyz``abc`.*
+-- + DECLARE D CURSOR FOR
+-- +   SELECT `xyz``abc`.*
 -- + FROM `xyz``abc`;
 -- + CALL printf("%d %d", D.x, D.`a b`);
 -- + {declare_cursor}: D: select: { x: integer notnull, `a b`: integer notnull qid } variable dml_proc
@@ -23670,7 +23712,8 @@ update `xyz``abc` set `a b` = 5;
 
 -- TEST: insert statement vanilla with quoted names
 -- verify that echoing is re-emitting the escaped text
--- + INSERT INTO `xyz``abc`(x, `a b`) VALUES(1, 5);
+-- + INSERT INTO `xyz``abc`(x, `a b`)
+-- +   VALUES(1, 5);
 -- + {name `xyz``abc`}: X_xyzX60abc: { x: integer notnull, `a b`: integer notnull unique_key qid } qid
 -- - error:
 insert into `xyz``abc` values (1, 5);
@@ -23698,9 +23741,11 @@ insert into `xyz``abc`(x) values(2) @dummy_seed(500);
 
 -- TEST: create a cursor and expand it using the from form
 -- verify that echoing is re-emitting the escaped text
--- + DECLARE C CURSOR FOR SELECT *
+-- + DECLARE C CURSOR FOR
+-- +   SELECT *
 -- + FROM `xyz``abc`;
--- + INSERT INTO `xyz``abc`(x, `a b`) VALUES(C.x, C.`a b`);
+-- + INSERT INTO `xyz``abc`(x, `a b`)
+-- +   VALUES(C.x, C.`a b`);
 -- + {name `xyz``abc`}: X_xyzX60abc: { x: integer notnull, `a b`: integer notnull unique_key qid } qid
 -- + {name `a b`}
 -- - error:
@@ -23762,7 +23807,8 @@ end;
 
 -- TEST: boxed cursor constructs and unusual box object
 -- verify that echoing is re-emitting the escaped text
--- + DECLARE C CURSOR FOR SELECT 1 AS x;
+-- + DECLARE C CURSOR FOR
+-- +  SELECT 1 AS x;
 -- + DECLARE `box obj` OBJECT<C CURSOR>;
 -- + SET `box obj` FROM CURSOR C;
 -- + {name `box obj`}: X_boxX20obj: object<C CURSOR> variable

--- a/sources/test/sem_test_migrate.out.ref
+++ b/sources/test/sem_test_migrate.out.ref
@@ -893,8 +893,8 @@ The statement ending at line XXXX
 CREATE PROC MyAdHocMigration ()
 BEGIN
   UPDATE foo
-  SET id = 1
-    WHERE id = 2;
+    SET id = 1
+      WHERE id = 2;
 END;
 
   {create_proc_stmt}: ok dml_proc

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -155,27 +155,43 @@ SELECT a AS b, c AS d
 
 SELECT a, b
   FROM c
-    INNER JOIN d;
+  INNER JOIN d;
 
 SELECT a, b
   FROM c
-    INNER JOIN d ON e = f;
+  INNER JOIN d ON e = f;
 
 SELECT a, b
   FROM c
-    INNER JOIN d ON e.f = g.h;
+  INNER JOIN d ON e.f = g.h;
 
 SELECT a, b
   FROM c
-    LEFT OUTER JOIN d ON e.f = g.h;
+  LEFT OUTER JOIN d ON e.f = g.h;
 
-SELECT P.thread_key, P.contact_id, P.is_admin, P.nickname, P.read_watermark_timestamp_ms, P.delivered_watermark_timestamp_ms, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, C.name, C.is_messenger_user
+SELECT 
+    P.thread_key,
+    P.contact_id,
+    P.is_admin,
+    P.nickname,
+    P.read_watermark_timestamp_ms,
+    P.delivered_watermark_timestamp_ms,
+    C.profile_picture_url,
+    C.profile_picture_fallback_url,
+    C.profile_picture_url_expiration_timestamp_ms,
+    C.name,
+    C.is_messenger_user
   FROM participants AS P
-    LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
+  LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
 
-SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
+SELECT 
+    T.thread_key,
+    T.thread_type,
+    UTN.thread_name AS thread_name,
+    T.thread_picture_url,
+    T.mute_expire_time_ms
   FROM threads AS T
-    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT *
   FROM foo;
@@ -183,9 +199,14 @@ SELECT *
 SELECT a
   FROM b;
 
-SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
+SELECT 
+    T.thread_key,
+    T.thread_type,
+    UTN.thread_name AS thread_name,
+    T.thread_picture_url,
+    T.mute_expire_time_ms
   FROM threads AS T
-    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT 2 <> 3;
 
@@ -201,7 +222,14 @@ SELECT a, b
   FROM c
 ORDER BY f;
 
-SELECT C.id AS contact_id, C.contact_type, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, C.name, C.rank
+SELECT 
+    C.id AS contact_id,
+    C.contact_type,
+    C.profile_picture_url,
+    C.profile_picture_fallback_url,
+    C.profile_picture_url_expiration_timestamp_ms,
+    C.name,
+    C.rank
   FROM contacts AS C
   WHERE C.name IS NOT NULL AND C.name <> ''
 ORDER BY C.name;
@@ -248,7 +276,8 @@ DELETE FROM a;
 
 DELETE FROM a WHERE b > c AND e <= f;
 
-INSERT INTO _sync_status VALUES(1, NULL, NULL);
+INSERT INTO _sync_status
+  VALUES(1, NULL, NULL);
 
 SELECT a.b - (c('now') - 2440587) * 86400000 > 0 OR d < 0;
 
@@ -259,15 +288,29 @@ SELECT 12.3;
 CREATE VIEW zzz AS
 SELECT DISTINCT a, b AS c, d
   FROM e AS E
-    LEFT OUTER JOIN f AS F ON F.g = e.g
-    LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
+  LEFT OUTER JOIN f AS F ON F.g = e.g
+  LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
 ORDER BY o.p DESC;
 
 CREATE VIEW thread_messages AS
-SELECT DISTINCT M.message_id, M.thread_key, M.offline_threading_id, M.sender_id, M.send_status, C.name, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, M.body, M.sticker_id, M.timestamp_ms, A.has_xma OR A.has_media AS has_attachment, M.is_admin_message
+SELECT DISTINCT 
+    M.message_id,
+    M.thread_key,
+    M.offline_threading_id,
+    M.sender_id,
+    M.send_status,
+    C.name,
+    C.profile_picture_url,
+    C.profile_picture_fallback_url,
+    C.profile_picture_url_expiration_timestamp_ms,
+    M.body,
+    M.sticker_id,
+    M.timestamp_ms,
+    A.has_xma OR A.has_media AS has_attachment,
+    M.is_admin_message
   FROM messages AS M
-    LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
-    LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
+  LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
+  LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
 ORDER BY M.timestamp_ms DESC;
 
 SELECT *
@@ -282,14 +325,12 @@ LIMIT 20
 OFFSET 7;
 
 SELECT a
-  FROM (
-    SELECT b
+  FROM (SELECT b
       FROM c) AS X;
 
 CREATE VIEW unread_not_muted_threads_count AS
 SELECT count(*) AS count
-  FROM (
-    SELECT *
+  FROM (SELECT *
       FROM threads
     ORDER BY last_activity_timestamp_ms DESC
     LIMIT 20) AS T
@@ -314,17 +355,15 @@ CREATE TABLE pending_query_changes(
 );
 
 UPDATE a
-SET b = 1;
+  SET b = 1;
 
 UPDATE a
-SET x = 1,
-y = 2
-  WHERE z = 3;
+  SET x = 1, y = 2
+    WHERE z = 3;
 
 UPDATE a
-SET x = 1,
-y = 2
-  WHERE z = 3;
+  SET x = 1, y = 2
+    WHERE z = 3;
 
 SET a1 := 20;
 
@@ -332,26 +371,26 @@ SET b3 := 40.75;
 
 CREATE PROC a ()
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   UPDATE g
-  SET h = j,
-  k = l;
+    SET h = j, k = l;
 END;
 
 CREATE PROC a (b INTEGER, c TEXT)
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   UPDATE g
-  SET h = j,
-  k = l;
+    SET h = j, k = l;
 END;
 
 CREATE PROC a (b INTEGER, IN c TEXT, OUT d LONG_INT, INOUT f TEXT)
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   UPDATE g
-  SET h = j,
-  k = l;
+    SET h = j, k = l;
 END;
 
 CLOSE y;
@@ -364,11 +403,13 @@ DECLARE a, b, c INTEGER;
 
 DECLARE var_a, var_b, var_c INTEGER;
 
-DECLARE a CURSOR FOR SELECT b
-  FROM c;
+DECLARE a CURSOR FOR
+  SELECT b
+    FROM c;
 
-DECLARE a CURSOR FOR SELECT b
-  FROM c;
+DECLARE a CURSOR FOR
+  SELECT b
+    FROM c;
 
 DECLARE a CURSOR LIKE (a INTEGER, b TEXT);
 
@@ -376,7 +417,8 @@ DECLARE a CURSOR LIKE (id INTEGER);
 
 LOOP FETCH a INTO b
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   FETCH a INTO x, y;
   LEAVE;
   CONTINUE;
@@ -386,15 +428,15 @@ CLOSE a;
 
 IF x > 20 THEN
   UPDATE x
-  SET y = z;
+    SET y = z;
 END IF;
 
 IF x > 20 THEN
   UPDATE x
-  SET y = z;
+    SET y = z;
 ELSE
   UPDATE w
-  SET k = m;
+    SET k = m;
 END IF;
 
 IF a > 1 THEN
@@ -575,13 +617,12 @@ SELECT 1 AND 3 IN (3, 4);
 
 SELECT x, y
   FROM T
-    INNER JOIN Y USING (a, b, c);
+  INNER JOIN Y USING (a, b, c);
 
 UPDATE X
-SET x = 1,
-y = 2
-  WHERE z = 5
-LIMIT 3;
+  SET x = 1, y = 2
+    WHERE z = 5
+  LIMIT 3;
 
 SELECT *
   FROM foo
@@ -597,27 +638,27 @@ SELECT ALL x, y
 
 SELECT a, b
   FROM X
-    INNER JOIN Y;
+  INNER JOIN Y;
 
 SELECT a, b
   FROM X
-    LEFT JOIN Y;
+  LEFT JOIN Y;
 
 SELECT a, b
   FROM X AS XX
-    RIGHT JOIN Y;
+  RIGHT JOIN Y;
 
 SELECT a, b
   FROM X
-    RIGHT OUTER JOIN Y;
+  RIGHT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-    LEFT OUTER JOIN Y;
+  LEFT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-    CROSS JOIN Y;
+  CROSS JOIN Y;
 
 SELECT CASE 1 WHEN 1 THEN 'a'
 WHEN 2 THEN 'b'
@@ -625,9 +666,10 @@ ELSE 'c'
 END;
 
 SELECT x
-  FROM (A,
-  B,
-  C);
+  FROM (
+    A,
+    B,
+    C);
 
 SELECT x
   FROM A
@@ -642,9 +684,9 @@ SELECT x, y
   GROUP BY a, b;
 
 UPDATE bar
-SET x = 1
-ORDER BY a
-LIMIT 5;
+  SET x = 1
+  ORDER BY a
+  LIMIT 5;
 
 CALL foo();
 
@@ -706,34 +748,38 @@ ROLLBACK TO @PROC;
 
 ROLLBACK TO @PROC;
 
-DECLARE test CURSOR FOR CALL foo(1, 2);
+DECLARE test CURSOR FOR
+  CALL foo(1, 2);
 
-DECLARE test CURSOR FOR CALL foo(1, 2);
+DECLARE test CURSOR FOR
+  CALL foo(1, 2);
 
 SELECT *
   FROM foo
-  WHERE EXISTS (
-  SELECT *
+  WHERE EXISTS (SELECT *
     FROM bar);
 
 SELECT *
   FROM foo
-  WHERE NOT EXISTS (
-  SELECT *
+  WHERE NOT EXISTS (SELECT *
     FROM bar);
 
 FETCH my_cursor;
 
 SELECT a
-  FROM (X
+  FROM (
+    X
     INNER JOIN Y)
-    LEFT OUTER JOIN (W
+  LEFT OUTER JOIN (
+    W
     INNER JOIN Q);
 
 SELECT a
-  FROM (X
+  FROM (
+    X
     INNER JOIN Y)
-    LEFT OUTER JOIN (W
+  LEFT OUTER JOIN (
+    W
     INNER JOIN Q);
 
 SELECT a, b
@@ -796,46 +842,50 @@ OFFSET 3;
 
 SELECT nullable(1);
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 SELECT a, b
   FROM x;
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2),
+    SELECT 1, 2
+  ),
   y (c, d) AS (
-    SELECT 5.4, 7.3)
+    SELECT 5.4, 7.3
+  )
 SELECT a, b
   FROM x
-    INNER JOIN y ON x.a = y.c;
+  INNER JOIN y ON x.a = y.c;
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 SELECT *
   FROM x AS X
-    INNER JOIN (
-      WITH
+  INNER JOIN (    WITH
       y (a, b) AS (
-        SELECT 1, 3)
+        SELECT 1, 3
+      )
     SELECT *
       FROM y) AS Y ON X.a = y.A;
 
-  WITH RECURSIVE
+WITH RECURSIVE
   cnt (x) AS (
     SELECT 1
     UNION ALL
     SELECT x + 1
       FROM cnt
-    LIMIT 20)
+    LIMIT 20
+  )
 SELECT x
   FROM cnt;
 
 SELECT T.*
-  FROM (
-    SELECT 1) AS T;
+  FROM (SELECT 1) AS T;
 
 DECLARE FUNC foo (x INTEGER, y TEXT NOT NULL) INTEGER NOT NULL;
 
@@ -853,11 +903,14 @@ DECLARE foo_obj OBJECT<Foo>;
 
 SELECT valid_utf8_or_null('xxx');
 
-INSERT INTO foo(a, b) VALUES(1, 2);
+INSERT INTO foo(a, b)
+  VALUES(1, 2);
 
-INSERT OR REPLACE INTO foo(a, b) VALUES(1, 2);
+INSERT OR REPLACE INTO foo(a, b)
+  VALUES(1, 2);
 
-INSERT OR IGNORE INTO foo(a, b) VALUES(1, 2);
+INSERT OR IGNORE INTO foo(a, b)
+  VALUES(1, 2);
 
 CREATE TEMP VIEW foo AS
 SELECT 1 AS A;
@@ -913,9 +966,11 @@ CREATE INDEX foo ON bazzle (goo) @DELETE(7);
 
 DROP INDEX foo;
 
-INSERT INTO foo(x, y) VALUES(1, 2) @DUMMY_SEED(1 + 2 * 3) @DUMMY_DEFAULTS @DUMMY_NULLABLES;
+INSERT INTO foo(x, y)
+  VALUES(1, 2) @DUMMY_SEED(1 + 2 * 3) @DUMMY_DEFAULTS @DUMMY_NULLABLES;
 
-INSERT INTO foo() VALUES();
+INSERT INTO foo()
+  VALUES();
 
 DECLARE foo BLOB;
 
@@ -996,22 +1051,27 @@ CREATE TABLE foo3(
   id INTEGER
 ) @RECREATE(foo3_group) @DELETE;
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 111, 222)
-INSERT INTO foo VALUES(( SELECT a
-  FROM x ), ( SELECT b
-  FROM x ));
+    SELECT 111, 222
+  )
+INSERT INTO foo
+  VALUES(( SELECT a
+    FROM x ), ( SELECT b
+    FROM x ));
 
-  WITH RECURSIVE
+WITH RECURSIVE
   x (a, b) AS (
-    SELECT 111, 222)
-INSERT INTO foo(a, b) VALUES(( SELECT a
-  FROM x ), ( SELECT b
-  FROM x ));
+    SELECT 111, 222
+  )
+INSERT INTO foo(a, b)
+  VALUES(( SELECT a
+    FROM x ), ( SELECT b
+    FROM x ));
 
-INSERT INTO foo() SELECT 1, 2, 3
-  FROM bar;
+INSERT INTO foo()
+  SELECT 1, 2, 3
+    FROM bar;
 
 DECLARE SELECT FUNC foo (id INTEGER) INTEGER NOT NULL;
 
@@ -1085,9 +1145,10 @@ CREATE TRIGGER trigger3
   INSTEAD OF UPDATE ON target_table3
 BEGIN
   UPDATE goo
-  SET foo = bar
-    WHERE miz = wiz;
-  INSERT INTO stew VALUES(1);
+    SET foo = bar
+      WHERE miz = wiz;
+  INSERT INTO stew
+    VALUES(1);
 END;
 
 CREATE TRIGGER trigger4
@@ -1125,19 +1186,21 @@ CREATE TABLE with_sensitive(
   name TEXT @SENSITIVE
 );
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 DELETE FROM foo WHERE foo.id IN (SELECT *
   FROM x);
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 UPDATE foo
-SET xyzzy = 7
-  WHERE foo.id IN (SELECT *
-  FROM x);
+  SET xyzzy = 7
+    WHERE foo.id IN (SELECT *
+    FROM x);
 
 @ENFORCE_STRICT FOREIGN KEY ON UPDATE;
 
@@ -1191,7 +1254,7 @@ DECLARE SELECT FUNC garbonzo (id INTEGER) (t TEXT);
 
 SELECT *
   FROM garbonzo(1, 2, 3) AS T1
-    INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
+  INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
 
 CREATE TRIGGER deleted_trigger
   AFTER INSERT ON target_table2
@@ -1199,18 +1262,21 @@ BEGIN
   DELETE FROM foo WHERE id = 1;
 END @DELETE(100);
 
-INSERT INTO foo SELECT C11
-  FROM T1
-  WHERE 1
+INSERT INTO foo
+  SELECT C11
+    FROM T1
+    WHERE 1
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO foo(id) VALUES(1)
+INSERT INTO foo(id)
+  VALUES(1)
 ON CONFLICT (id) 
   WHERE id = 10 DO UPDATE
-SET id = id + 1
-  WHERE id = 20;
+  SET id = id + 1
+    WHERE id = 20;
 
-INSERT INTO foo(id) VALUES(1)
+INSERT INTO foo(id)
+  VALUES(1)
 ON CONFLICT DO NOTHING;
 
 SELECT 10 * a AS T
@@ -1223,8 +1289,9 @@ SELECT *
 EXPLAIN
 SELECT 1;
 
-DECLARE E CURSOR FOR EXPLAIN
-SELECT 1;
+DECLARE E CURSOR FOR
+  EXPLAIN
+  SELECT 1;
 
 @SCHEMA_AD_HOC_MIGRATION(11, YourProcHere);
 
@@ -1277,9 +1344,10 @@ UPDATE CURSOR d(a, b) FROM VALUES(1, 'x');
 
 UPDATE CURSOR d USING 1 AS a, 'x' AS b;
 
-  WITH
+WITH
   foo (*) AS (
-    SELECT 1 AS x, '2' AS y)
+    SELECT 1 AS x, '2' AS y
+  )
 SELECT *
   FROM foo;
 
@@ -1714,19 +1782,19 @@ DECLARE CONST GROUP foo (
 
 @EMIT_CONSTANTS foo;
 
-  WITH
+WITH
   foo (*) AS (CALL bar(1, 2) USING a AS x, b AS y)
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   foo (*) AS (CALL bar(1, 2))
 SELECT *
   FROM foo;
 
 CALL foo(*);
 
-  WITH
+WITH
   bar (*) AS (CALL bar(1, 5) USING goo AS too),
   tar (*) AS (CALL tar(3) USING soo AS woo, goo AS too)
 SELECT *
@@ -1770,21 +1838,26 @@ CREATE TABLE V(
 
 CREATE PROC p ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT T.*, 1 AS u, 2 AS v
-    FROM T;
+  DECLARE C CURSOR FOR
+    SELECT T.*, 1 AS u, 2 AS v
+      FROM T;
   FETCH C;
-  INSERT INTO T VALUES(FROM C LIKE T);
-  DECLARE D CURSOR FOR SELECT *
-    FROM U;
+  INSERT INTO T
+    VALUES(FROM C LIKE T);
+  DECLARE D CURSOR FOR
+    SELECT *
+      FROM U;
   FETCH D;
   DECLARE R CURSOR LIKE V;
   FETCH R FROM VALUES(FROM C LIKE T, FROM D);
   UPDATE CURSOR R FROM VALUES(FROM C LIKE T, FROM D);
-  DECLARE S CURSOR FOR   WITH
-    cte (l, m, n, o) AS (
-      VALUES(FROM C LIKE T, FROM D))
-  SELECT *
-    FROM cte;
+  DECLARE S CURSOR FOR
+    WITH
+      cte (l, m, n, o) AS (
+        VALUES(FROM C LIKE T, FROM D)
+      )
+    SELECT *
+      FROM cte;
   FETCH S;
 END;
 
@@ -1869,9 +1942,9 @@ CREATE TABLE backing(
 @ENFORCE_STRICT UPDATE FROM;
 
 UPDATE foo
-SET name = baz.name FROM bar
+  SET name = baz.nameFROM bar
   INNER JOIN baz ON bar.id = baz.id
-  WHERE bar.name = 'x' AND foo.id = bar.id;
+    WHERE bar.name = 'x' AND foo.id = bar.id;
 
 @ATTRIBUTE(cql:private)
 @ATTRIBUTE(cql:potato=bar)
@@ -1992,7 +2065,7 @@ CREATE TABLE yy(
 @MACRO(QUERY_PARTS) qp!()
 BEGIN
   xx AS T1
-    INNER JOIN yy AS T2 ON T1.x = T2.y
+  INNER JOIN yy AS T2 ON T1.x = T2.y
 END;
 
 @MACRO(STMT_LIST) sel!(e! EXPR, q! QUERY_PARTS)
@@ -2003,7 +2076,7 @@ END;
 
 SELECT *
   FROM qp!()
-    INNER JOIN yy;
+  INNER JOIN yy;
 
 SELECT *
   FROM qp!() AS T1;
@@ -2016,42 +2089,48 @@ SELECT *
 @MACRO(CTE_TABLES) cte!()
 BEGIN
   foo (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   bar (*) AS (
-    SELECT 3 AS u, 4 AS v)
+    SELECT 3 AS u, 4 AS v
+  )
 END;
 
-  WITH
+WITH
   vv (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   cte!(),
   uu (*) AS (
-    SELECT 1 AS x, 2 AS y)
+    SELECT 1 AS x, 2 AS y
+  )
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   cte!(),
   uu (*) AS (
-    SELECT 1 AS x, 2 AS y)
+    SELECT 1 AS x, 2 AS y
+  )
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   cte!()
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   vv (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   cte!()
 SELECT *
   FROM foo;
 
 @MACRO(STMT_LIST) query!(u! CTE_TABLES)
 BEGIN
-    WITH
+  WITH
     u!
   SELECT *
     FROM foo;
@@ -2059,7 +2138,8 @@ END;
 
 query!(WITH(
   foo (*) AS (
-    SELECT 100 AS x, 200 AS y)
+    SELECT 100 AS x, 200 AS y
+  )
 ));
 
 @MACRO(SELECT_CORE) selcor!(x! EXPR)
@@ -2140,15 +2220,15 @@ LET z := macro2!(x, y);
 
 SET z := 151;
 
-LET zz := macro3!(FROM((
-  SELECT 1 AS x, 2 AS y) AS T));
+LET zz := macro3!(FROM((SELECT 1 AS x, 2 AS y) AS T));
 
 SET zz := macro3!(FROM(T1
-  INNER JOIN T2 ON T1.id = T2.id));
+INNER JOIN T2 ON T1.id = T2.id));
 
 SET zz := macro4!(WITH(
   x (*) AS (
-    SELECT 1 AS x, 2 AS y)
+    SELECT 1 AS x, 2 AS y
+  )
 ));
 
 SET zz := macro5!(ALL(SELECT 1 AS x
@@ -2184,14 +2264,15 @@ BEGIN
 END;
 
 mondo2!(1 + 2, FROM(x
-  INNER JOIN y), ALL(SELECT 1
+INNER JOIN y), ALL(SELECT 1
   FROM foo
 UNION
 SELECT 2
   FROM bar), SELECT(20 AS xx), WITH(
   f (*) AS (
     SELECT 99
-      FROM yy)
+      FROM yy
+  )
 ), 
 BEGIN
   LET qq := 201;

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -155,27 +155,27 @@ SELECT a AS b, c AS d
 
 SELECT a, b
   FROM c
-  INNER JOIN d;
+    INNER JOIN d;
 
 SELECT a, b
   FROM c
-  INNER JOIN d ON e = f;
+    INNER JOIN d ON e = f;
 
 SELECT a, b
   FROM c
-  INNER JOIN d ON e.f = g.h;
+    INNER JOIN d ON e.f = g.h;
 
 SELECT a, b
   FROM c
-  LEFT OUTER JOIN d ON e.f = g.h;
+    LEFT OUTER JOIN d ON e.f = g.h;
 
 SELECT P.thread_key, P.contact_id, P.is_admin, P.nickname, P.read_watermark_timestamp_ms, P.delivered_watermark_timestamp_ms, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, C.name, C.is_messenger_user
   FROM participants AS P
-  LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
+    LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
 
 SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
   FROM threads AS T
-  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT *
   FROM foo;
@@ -185,7 +185,7 @@ SELECT a
 
 SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
   FROM threads AS T
-  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT 2 <> 3;
 
@@ -241,7 +241,7 @@ SELECT b
 CREATE VIEW _self_thread_name AS
 SELECT UI.facebook_user_id AS thread_key, C.name AS thread_name
   FROM _user_info AS UI,
-contacts AS C
+  contacts AS C
   WHERE UI.facebook_user_id = C.id;
 
 DELETE FROM a;
@@ -259,15 +259,15 @@ SELECT 12.3;
 CREATE VIEW zzz AS
 SELECT DISTINCT a, b AS c, d
   FROM e AS E
-  LEFT OUTER JOIN f AS F ON F.g = e.g
-  LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
+    LEFT OUTER JOIN f AS F ON F.g = e.g
+    LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
 ORDER BY o.p DESC;
 
 CREATE VIEW thread_messages AS
 SELECT DISTINCT M.message_id, M.thread_key, M.offline_threading_id, M.sender_id, M.send_status, C.name, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, M.body, M.sticker_id, M.timestamp_ms, A.has_xma OR A.has_media AS has_attachment, M.is_admin_message
   FROM messages AS M
-  LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
-  LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
+    LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
+    LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
 ORDER BY M.timestamp_ms DESC;
 
 SELECT *
@@ -282,15 +282,17 @@ LIMIT 20
 OFFSET 7;
 
 SELECT a
-  FROM (SELECT b
-  FROM c) AS X;
+  FROM (
+    SELECT b
+      FROM c) AS X;
 
 CREATE VIEW unread_not_muted_threads_count AS
 SELECT count(*) AS count
-  FROM (SELECT *
-  FROM threads
-ORDER BY last_activity_timestamp_ms DESC
-LIMIT 20) AS T
+  FROM (
+    SELECT *
+      FROM threads
+    ORDER BY last_activity_timestamp_ms DESC
+    LIMIT 20) AS T
   WHERE T.last_activity_timestamp_ms > T.last_read_watermark_timestamp_ms AND (T.mute_expire_time_ms >= 0 AND T.mute_expire_time_ms - strftime('%s', 'now') * 1000 <= 0) AND T.folder_name = 'inbox';
 
 CREATE TABLE pending_tasks(
@@ -573,7 +575,7 @@ SELECT 1 AND 3 IN (3, 4);
 
 SELECT x, y
   FROM T
-  INNER JOIN Y USING (a, b, c);
+    INNER JOIN Y USING (a, b, c);
 
 UPDATE X
 SET x = 1,
@@ -595,27 +597,27 @@ SELECT ALL x, y
 
 SELECT a, b
   FROM X
-  INNER JOIN Y;
+    INNER JOIN Y;
 
 SELECT a, b
   FROM X
-  LEFT JOIN Y;
+    LEFT JOIN Y;
 
 SELECT a, b
   FROM X AS XX
-  RIGHT JOIN Y;
+    RIGHT JOIN Y;
 
 SELECT a, b
   FROM X
-  RIGHT OUTER JOIN Y;
+    RIGHT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-  LEFT OUTER JOIN Y;
+    LEFT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-  CROSS JOIN Y;
+    CROSS JOIN Y;
 
 SELECT CASE 1 WHEN 1 THEN 'a'
 WHEN 2 THEN 'b'
@@ -624,8 +626,8 @@ END;
 
 SELECT x
   FROM (A,
-B,
-C);
+  B,
+  C);
 
 SELECT x
   FROM A
@@ -710,27 +712,29 @@ DECLARE test CURSOR FOR CALL foo(1, 2);
 
 SELECT *
   FROM foo
-  WHERE EXISTS (SELECT *
-  FROM bar);
+  WHERE EXISTS (
+  SELECT *
+    FROM bar);
 
 SELECT *
   FROM foo
-  WHERE NOT EXISTS (SELECT *
-  FROM bar);
+  WHERE NOT EXISTS (
+  SELECT *
+    FROM bar);
 
 FETCH my_cursor;
 
 SELECT a
   FROM (X
-  INNER JOIN Y)
-  LEFT OUTER JOIN (W
-  INNER JOIN Q);
+    INNER JOIN Y)
+    LEFT OUTER JOIN (W
+    INNER JOIN Q);
 
 SELECT a
   FROM (X
-  INNER JOIN Y)
-  LEFT OUTER JOIN (W
-  INNER JOIN Q);
+    INNER JOIN Y)
+    LEFT OUTER JOIN (W
+    INNER JOIN Q);
 
 SELECT a, b
   FROM x
@@ -792,38 +796,46 @@ OFFSET 3;
 
 SELECT nullable(1);
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 SELECT a, b
   FROM x;
 
-WITH
-x (a, b) AS (SELECT 1, 2),
-y (c, d) AS (SELECT 5.4, 7.3)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2),
+  y (c, d) AS (
+    SELECT 5.4, 7.3)
 SELECT a, b
   FROM x
-  INNER JOIN y ON x.a = y.c;
+    INNER JOIN y ON x.a = y.c;
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 SELECT *
   FROM x AS X
-  INNER JOIN (WITH
-y (a, b) AS (SELECT 1, 3)
-SELECT *
-  FROM y) AS Y ON X.a = y.A;
+    INNER JOIN (
+      WITH
+      y (a, b) AS (
+        SELECT 1, 3)
+    SELECT *
+      FROM y) AS Y ON X.a = y.A;
 
-WITH RECURSIVE
-cnt (x) AS (SELECT 1
-UNION ALL
-SELECT x + 1
-  FROM cnt
-LIMIT 20)
+  WITH RECURSIVE
+  cnt (x) AS (
+    SELECT 1
+    UNION ALL
+    SELECT x + 1
+      FROM cnt
+    LIMIT 20)
 SELECT x
   FROM cnt;
 
 SELECT T.*
-  FROM (SELECT 1) AS T;
+  FROM (
+    SELECT 1) AS T;
 
 DECLARE FUNC foo (x INTEGER, y TEXT NOT NULL) INTEGER NOT NULL;
 
@@ -984,14 +996,16 @@ CREATE TABLE foo3(
   id INTEGER
 ) @RECREATE(foo3_group) @DELETE;
 
-WITH
-x (a, b) AS (SELECT 111, 222)
+  WITH
+  x (a, b) AS (
+    SELECT 111, 222)
 INSERT INTO foo VALUES(( SELECT a
   FROM x ), ( SELECT b
   FROM x ));
 
-WITH RECURSIVE
-x (a, b) AS (SELECT 111, 222)
+  WITH RECURSIVE
+  x (a, b) AS (
+    SELECT 111, 222)
 INSERT INTO foo(a, b) VALUES(( SELECT a
   FROM x ), ( SELECT b
   FROM x ));
@@ -1111,13 +1125,15 @@ CREATE TABLE with_sensitive(
   name TEXT @SENSITIVE
 );
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 DELETE FROM foo WHERE foo.id IN (SELECT *
   FROM x);
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 UPDATE foo
 SET xyzzy = 7
   WHERE foo.id IN (SELECT *
@@ -1175,7 +1191,7 @@ DECLARE SELECT FUNC garbonzo (id INTEGER) (t TEXT);
 
 SELECT *
   FROM garbonzo(1, 2, 3) AS T1
-  INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
+    INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
 
 CREATE TRIGGER deleted_trigger
   AFTER INSERT ON target_table2
@@ -1261,8 +1277,9 @@ UPDATE CURSOR d(a, b) FROM VALUES(1, 'x');
 
 UPDATE CURSOR d USING 1 AS a, 'x' AS b;
 
-WITH
-foo (*) AS (SELECT 1 AS x, '2' AS y)
+  WITH
+  foo (*) AS (
+    SELECT 1 AS x, '2' AS y)
 SELECT *
   FROM foo;
 
@@ -1697,24 +1714,24 @@ DECLARE CONST GROUP foo (
 
 @EMIT_CONSTANTS foo;
 
-WITH
-foo (*) AS (CALL bar(1, 2) USING a AS x, b AS y)
+  WITH
+  foo (*) AS (CALL bar(1, 2) USING a AS x, b AS y)
 SELECT *
   FROM foo;
 
-WITH
-foo (*) AS (CALL bar(1, 2))
+  WITH
+  foo (*) AS (CALL bar(1, 2))
 SELECT *
   FROM foo;
 
 CALL foo(*);
 
-WITH
-bar (*) AS (CALL bar(1, 5) USING goo AS too),
-tar (*) AS (CALL tar(3) USING soo AS woo, goo AS too)
+  WITH
+  bar (*) AS (CALL bar(1, 5) USING goo AS too),
+  tar (*) AS (CALL tar(3) USING soo AS woo, goo AS too)
 SELECT *
   FROM bar,
-tar;
+  tar;
 
 SELECT *
   FROM (CALL foo() USING stuff AS source);
@@ -1763,8 +1780,9 @@ BEGIN
   DECLARE R CURSOR LIKE V;
   FETCH R FROM VALUES(FROM C LIKE T, FROM D);
   UPDATE CURSOR R FROM VALUES(FROM C LIKE T, FROM D);
-  DECLARE S CURSOR FOR WITH
-  cte (l, m, n, o) AS (VALUES(FROM C LIKE T, FROM D))
+  DECLARE S CURSOR FOR   WITH
+    cte (l, m, n, o) AS (
+      VALUES(FROM C LIKE T, FROM D))
   SELECT *
     FROM cte;
   FETCH S;
@@ -1985,7 +2003,7 @@ END;
 
 SELECT *
   FROM qp!()
-  INNER JOIN yy;
+    INNER JOIN yy;
 
 SELECT *
   FROM qp!() AS T1;
@@ -1997,44 +2015,51 @@ SELECT *
 
 @MACRO(CTE_TABLES) cte!()
 BEGIN
-  foo (*) AS (SELECT 1 AS x, 2 AS y),
-  bar (*) AS (SELECT 3 AS u, 4 AS v)
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v)
 END;
 
-WITH
-vv (*) AS (SELECT 1 AS x, 2 AS y),
-cte!(),
-uu (*) AS (SELECT 1 AS x, 2 AS y)
+  WITH
+  vv (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  cte!(),
+  uu (*) AS (
+    SELECT 1 AS x, 2 AS y)
 SELECT *
   FROM foo;
 
-WITH
-cte!(),
-uu (*) AS (SELECT 1 AS x, 2 AS y)
+  WITH
+  cte!(),
+  uu (*) AS (
+    SELECT 1 AS x, 2 AS y)
 SELECT *
   FROM foo;
 
-WITH
-cte!()
+  WITH
+  cte!()
 SELECT *
   FROM foo;
 
-WITH
-vv (*) AS (SELECT 1 AS x, 2 AS y),
-cte!()
+  WITH
+  vv (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  cte!()
 SELECT *
   FROM foo;
 
 @MACRO(STMT_LIST) query!(u! CTE_TABLES)
 BEGIN
-  WITH
-  u!
+    WITH
+    u!
   SELECT *
     FROM foo;
 END;
 
 query!(WITH(
-  foo (*) AS (SELECT 100 AS x, 200 AS y)
+  foo (*) AS (
+    SELECT 100 AS x, 200 AS y)
 ));
 
 @MACRO(SELECT_CORE) selcor!(x! EXPR)
@@ -2115,13 +2140,15 @@ LET z := macro2!(x, y);
 
 SET z := 151;
 
-LET zz := macro3!(FROM((SELECT 1 AS x, 2 AS y) AS T));
+LET zz := macro3!(FROM((
+  SELECT 1 AS x, 2 AS y) AS T));
 
 SET zz := macro3!(FROM(T1
   INNER JOIN T2 ON T1.id = T2.id));
 
 SET zz := macro4!(WITH(
-  x (*) AS (SELECT 1 AS x, 2 AS y)
+  x (*) AS (
+    SELECT 1 AS x, 2 AS y)
 ));
 
 SET zz := macro5!(ALL(SELECT 1 AS x
@@ -2162,8 +2189,9 @@ mondo2!(1 + 2, FROM(x
 UNION
 SELECT 2
   FROM bar), SELECT(20 AS xx), WITH(
-  f (*) AS (SELECT 99
-    FROM yy)
+  f (*) AS (
+    SELECT 99
+      FROM yy)
 ), 
 BEGIN
   LET qq := 201;

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -169,7 +169,7 @@ SELECT a, b
   FROM c
   LEFT OUTER JOIN d ON e.f = g.h;
 
-SELECT 
+SELECT
     P.thread_key,
     P.contact_id,
     P.is_admin,
@@ -184,7 +184,7 @@ SELECT
   FROM participants AS P
   LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
 
-SELECT 
+SELECT
     T.thread_key,
     T.thread_type,
     UTN.thread_name AS thread_name,
@@ -199,7 +199,7 @@ SELECT *
 SELECT a
   FROM b;
 
-SELECT 
+SELECT
     T.thread_key,
     T.thread_type,
     UTN.thread_name AS thread_name,
@@ -222,7 +222,7 @@ SELECT a, b
   FROM c
 ORDER BY f;
 
-SELECT 
+SELECT
     C.id AS contact_id,
     C.contact_type,
     C.profile_picture_url,
@@ -293,7 +293,7 @@ SELECT DISTINCT a, b AS c, d
 ORDER BY o.p DESC;
 
 CREATE VIEW thread_messages AS
-SELECT DISTINCT 
+SELECT DISTINCT
     M.message_id,
     M.thread_key,
     M.offline_threading_id,
@@ -2031,6 +2031,8 @@ foo(q).r;
 foo::bar().baz;
 
 column := 1;
+
+DECLARE @ID("foo") @ID("int");
 
 @MACRO(EXPR) foo!(x! EXPR, z! EXPR)
 BEGIN

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1769,5 +1769,7 @@ foo::bar().baz;
 
 column := 1;
 
+declare @id("foo") @id("int");
+
 @include "macro_basic_parse_test.sql"
 @include "line_directive_parse_test.sql"

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -155,27 +155,43 @@ SELECT a AS b, c AS d
 
 SELECT a, b
   FROM c
-    INNER JOIN d;
+  INNER JOIN d;
 
 SELECT a, b
   FROM c
-    INNER JOIN d ON e = f;
+  INNER JOIN d ON e = f;
 
 SELECT a, b
   FROM c
-    INNER JOIN d ON e.f = g.h;
+  INNER JOIN d ON e.f = g.h;
 
 SELECT a, b
   FROM c
-    LEFT OUTER JOIN d ON e.f = g.h;
+  LEFT OUTER JOIN d ON e.f = g.h;
 
-SELECT P.thread_key, P.contact_id, P.is_admin, P.nickname, P.read_watermark_timestamp_ms, P.delivered_watermark_timestamp_ms, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, C.name, C.is_messenger_user
+SELECT 
+    P.thread_key,
+    P.contact_id,
+    P.is_admin,
+    P.nickname,
+    P.read_watermark_timestamp_ms,
+    P.delivered_watermark_timestamp_ms,
+    C.profile_picture_url,
+    C.profile_picture_fallback_url,
+    C.profile_picture_url_expiration_timestamp_ms,
+    C.name,
+    C.is_messenger_user
   FROM participants AS P
-    LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
+  LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
 
-SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
+SELECT 
+    T.thread_key,
+    T.thread_type,
+    UTN.thread_name AS thread_name,
+    T.thread_picture_url,
+    T.mute_expire_time_ms
   FROM threads AS T
-    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT *
   FROM foo;
@@ -183,9 +199,14 @@ SELECT *
 SELECT a
   FROM b;
 
-SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
+SELECT 
+    T.thread_key,
+    T.thread_type,
+    UTN.thread_name AS thread_name,
+    T.thread_picture_url,
+    T.mute_expire_time_ms
   FROM threads AS T
-    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT 2 <> 3;
 
@@ -201,7 +222,14 @@ SELECT a, b
   FROM c
 ORDER BY f;
 
-SELECT C.id AS contact_id, C.contact_type, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, C.name, C.rank
+SELECT 
+    C.id AS contact_id,
+    C.contact_type,
+    C.profile_picture_url,
+    C.profile_picture_fallback_url,
+    C.profile_picture_url_expiration_timestamp_ms,
+    C.name,
+    C.rank
   FROM contacts AS C
   WHERE C.name IS NOT NULL AND C.name <> ''
 ORDER BY C.name;
@@ -248,7 +276,8 @@ DELETE FROM a;
 
 DELETE FROM a WHERE b > c AND e <= f;
 
-INSERT INTO _sync_status VALUES(1, NULL, NULL);
+INSERT INTO _sync_status
+  VALUES(1, NULL, NULL);
 
 SELECT a.b - (c('now') - 2440587) * 86400000 > 0 OR d < 0;
 
@@ -259,15 +288,29 @@ SELECT 12.3;
 CREATE VIEW zzz AS
 SELECT DISTINCT a, b AS c, d
   FROM e AS E
-    LEFT OUTER JOIN f AS F ON F.g = e.g
-    LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
+  LEFT OUTER JOIN f AS F ON F.g = e.g
+  LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
 ORDER BY o.p DESC;
 
 CREATE VIEW thread_messages AS
-SELECT DISTINCT M.message_id, M.thread_key, M.offline_threading_id, M.sender_id, M.send_status, C.name, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, M.body, M.sticker_id, M.timestamp_ms, A.has_xma OR A.has_media AS has_attachment, M.is_admin_message
+SELECT DISTINCT 
+    M.message_id,
+    M.thread_key,
+    M.offline_threading_id,
+    M.sender_id,
+    M.send_status,
+    C.name,
+    C.profile_picture_url,
+    C.profile_picture_fallback_url,
+    C.profile_picture_url_expiration_timestamp_ms,
+    M.body,
+    M.sticker_id,
+    M.timestamp_ms,
+    A.has_xma OR A.has_media AS has_attachment,
+    M.is_admin_message
   FROM messages AS M
-    LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
-    LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
+  LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
+  LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
 ORDER BY M.timestamp_ms DESC;
 
 SELECT *
@@ -282,14 +325,12 @@ LIMIT 20
 OFFSET 7;
 
 SELECT a
-  FROM (
-    SELECT b
+  FROM (SELECT b
       FROM c) AS X;
 
 CREATE VIEW unread_not_muted_threads_count AS
 SELECT count(*) AS count
-  FROM (
-    SELECT *
+  FROM (SELECT *
       FROM threads
     ORDER BY last_activity_timestamp_ms DESC
     LIMIT 20) AS T
@@ -314,17 +355,15 @@ CREATE TABLE pending_query_changes(
 );
 
 UPDATE a
-SET b = 1;
+  SET b = 1;
 
 UPDATE a
-SET x = 1,
-y = 2
-  WHERE z = 3;
+  SET x = 1, y = 2
+    WHERE z = 3;
 
 UPDATE a
-SET x = 1,
-y = 2
-  WHERE z = 3;
+  SET x = 1, y = 2
+    WHERE z = 3;
 
 SET a1 := 20;
 
@@ -332,26 +371,26 @@ SET b3 := 40.75;
 
 CREATE PROC a ()
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   UPDATE g
-  SET h = j,
-  k = l;
+    SET h = j, k = l;
 END;
 
 CREATE PROC a (b INTEGER, c TEXT)
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   UPDATE g
-  SET h = j,
-  k = l;
+    SET h = j, k = l;
 END;
 
 CREATE PROC a (b INTEGER, IN c TEXT, OUT d LONG_INT, INOUT f TEXT)
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   UPDATE g
-  SET h = j,
-  k = l;
+    SET h = j, k = l;
 END;
 
 CLOSE y;
@@ -364,11 +403,13 @@ DECLARE a, b, c INTEGER;
 
 DECLARE var_a, var_b, var_c INTEGER;
 
-DECLARE a CURSOR FOR SELECT b
-  FROM c;
+DECLARE a CURSOR FOR
+  SELECT b
+    FROM c;
 
-DECLARE a CURSOR FOR SELECT b
-  FROM c;
+DECLARE a CURSOR FOR
+  SELECT b
+    FROM c;
 
 DECLARE a CURSOR LIKE (a INTEGER, b TEXT);
 
@@ -376,7 +417,8 @@ DECLARE a CURSOR LIKE (id INTEGER);
 
 LOOP FETCH a INTO b
 BEGIN
-  INSERT INTO d VALUES(e, f);
+  INSERT INTO d
+    VALUES(e, f);
   FETCH a INTO x, y;
   LEAVE;
   CONTINUE;
@@ -386,15 +428,15 @@ CLOSE a;
 
 IF x > 20 THEN
   UPDATE x
-  SET y = z;
+    SET y = z;
 END IF;
 
 IF x > 20 THEN
   UPDATE x
-  SET y = z;
+    SET y = z;
 ELSE
   UPDATE w
-  SET k = m;
+    SET k = m;
 END IF;
 
 IF a > 1 THEN
@@ -575,13 +617,12 @@ SELECT 1 AND 3 IN (3, 4);
 
 SELECT x, y
   FROM T
-    INNER JOIN Y USING (a, b, c);
+  INNER JOIN Y USING (a, b, c);
 
 UPDATE X
-SET x = 1,
-y = 2
-  WHERE z = 5
-LIMIT 3;
+  SET x = 1, y = 2
+    WHERE z = 5
+  LIMIT 3;
 
 SELECT *
   FROM foo
@@ -597,27 +638,27 @@ SELECT ALL x, y
 
 SELECT a, b
   FROM X
-    INNER JOIN Y;
+  INNER JOIN Y;
 
 SELECT a, b
   FROM X
-    LEFT JOIN Y;
+  LEFT JOIN Y;
 
 SELECT a, b
   FROM X AS XX
-    RIGHT JOIN Y;
+  RIGHT JOIN Y;
 
 SELECT a, b
   FROM X
-    RIGHT OUTER JOIN Y;
+  RIGHT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-    LEFT OUTER JOIN Y;
+  LEFT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-    CROSS JOIN Y;
+  CROSS JOIN Y;
 
 SELECT CASE 1 WHEN 1 THEN 'a'
 WHEN 2 THEN 'b'
@@ -625,9 +666,10 @@ ELSE 'c'
 END;
 
 SELECT x
-  FROM (A,
-  B,
-  C);
+  FROM (
+    A,
+    B,
+    C);
 
 SELECT x
   FROM A
@@ -642,9 +684,9 @@ SELECT x, y
   GROUP BY a, b;
 
 UPDATE bar
-SET x = 1
-ORDER BY a
-LIMIT 5;
+  SET x = 1
+  ORDER BY a
+  LIMIT 5;
 
 CALL foo();
 
@@ -706,34 +748,38 @@ ROLLBACK TO @PROC;
 
 ROLLBACK TO @PROC;
 
-DECLARE test CURSOR FOR CALL foo(1, 2);
+DECLARE test CURSOR FOR
+  CALL foo(1, 2);
 
-DECLARE test CURSOR FOR CALL foo(1, 2);
+DECLARE test CURSOR FOR
+  CALL foo(1, 2);
 
 SELECT *
   FROM foo
-  WHERE EXISTS (
-  SELECT *
+  WHERE EXISTS (SELECT *
     FROM bar);
 
 SELECT *
   FROM foo
-  WHERE NOT EXISTS (
-  SELECT *
+  WHERE NOT EXISTS (SELECT *
     FROM bar);
 
 FETCH my_cursor;
 
 SELECT a
-  FROM (X
+  FROM (
+    X
     INNER JOIN Y)
-    LEFT OUTER JOIN (W
+  LEFT OUTER JOIN (
+    W
     INNER JOIN Q);
 
 SELECT a
-  FROM (X
+  FROM (
+    X
     INNER JOIN Y)
-    LEFT OUTER JOIN (W
+  LEFT OUTER JOIN (
+    W
     INNER JOIN Q);
 
 SELECT a, b
@@ -796,46 +842,50 @@ OFFSET 3;
 
 SELECT nullable(1);
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 SELECT a, b
   FROM x;
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2),
+    SELECT 1, 2
+  ),
   y (c, d) AS (
-    SELECT 5.4, 7.3)
+    SELECT 5.4, 7.3
+  )
 SELECT a, b
   FROM x
-    INNER JOIN y ON x.a = y.c;
+  INNER JOIN y ON x.a = y.c;
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 SELECT *
   FROM x AS X
-    INNER JOIN (
-      WITH
+  INNER JOIN (    WITH
       y (a, b) AS (
-        SELECT 1, 3)
+        SELECT 1, 3
+      )
     SELECT *
       FROM y) AS Y ON X.a = y.A;
 
-  WITH RECURSIVE
+WITH RECURSIVE
   cnt (x) AS (
     SELECT 1
     UNION ALL
     SELECT x + 1
       FROM cnt
-    LIMIT 20)
+    LIMIT 20
+  )
 SELECT x
   FROM cnt;
 
 SELECT T.*
-  FROM (
-    SELECT 1) AS T;
+  FROM (SELECT 1) AS T;
 
 DECLARE FUNC foo (x INTEGER, y TEXT NOT NULL) INTEGER NOT NULL;
 
@@ -853,11 +903,14 @@ DECLARE foo_obj OBJECT<Foo>;
 
 SELECT valid_utf8_or_null('xxx');
 
-INSERT INTO foo(a, b) VALUES(1, 2);
+INSERT INTO foo(a, b)
+  VALUES(1, 2);
 
-INSERT OR REPLACE INTO foo(a, b) VALUES(1, 2);
+INSERT OR REPLACE INTO foo(a, b)
+  VALUES(1, 2);
 
-INSERT OR IGNORE INTO foo(a, b) VALUES(1, 2);
+INSERT OR IGNORE INTO foo(a, b)
+  VALUES(1, 2);
 
 CREATE TEMP VIEW foo AS
 SELECT 1 AS A;
@@ -913,9 +966,11 @@ CREATE INDEX foo ON bazzle (goo) @DELETE(7);
 
 DROP INDEX foo;
 
-INSERT INTO foo(x, y) VALUES(1, 2) @DUMMY_SEED(1 + 2 * 3) @DUMMY_DEFAULTS @DUMMY_NULLABLES;
+INSERT INTO foo(x, y)
+  VALUES(1, 2) @DUMMY_SEED(1 + 2 * 3) @DUMMY_DEFAULTS @DUMMY_NULLABLES;
 
-INSERT INTO foo() VALUES();
+INSERT INTO foo()
+  VALUES();
 
 DECLARE foo BLOB;
 
@@ -996,22 +1051,27 @@ CREATE TABLE foo3(
   id INTEGER
 ) @RECREATE(foo3_group) @DELETE;
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 111, 222)
-INSERT INTO foo VALUES(( SELECT a
-  FROM x ), ( SELECT b
-  FROM x ));
+    SELECT 111, 222
+  )
+INSERT INTO foo
+  VALUES(( SELECT a
+    FROM x ), ( SELECT b
+    FROM x ));
 
-  WITH RECURSIVE
+WITH RECURSIVE
   x (a, b) AS (
-    SELECT 111, 222)
-INSERT INTO foo(a, b) VALUES(( SELECT a
-  FROM x ), ( SELECT b
-  FROM x ));
+    SELECT 111, 222
+  )
+INSERT INTO foo(a, b)
+  VALUES(( SELECT a
+    FROM x ), ( SELECT b
+    FROM x ));
 
-INSERT INTO foo() SELECT 1, 2, 3
-  FROM bar;
+INSERT INTO foo()
+  SELECT 1, 2, 3
+    FROM bar;
 
 DECLARE SELECT FUNC foo (id INTEGER) INTEGER NOT NULL;
 
@@ -1085,9 +1145,10 @@ CREATE TRIGGER trigger3
   INSTEAD OF UPDATE ON target_table3
 BEGIN
   UPDATE goo
-  SET foo = bar
-    WHERE miz = wiz;
-  INSERT INTO stew VALUES(1);
+    SET foo = bar
+      WHERE miz = wiz;
+  INSERT INTO stew
+    VALUES(1);
 END;
 
 CREATE TRIGGER trigger4
@@ -1125,19 +1186,21 @@ CREATE TABLE with_sensitive(
   name TEXT @SENSITIVE
 );
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 DELETE FROM foo WHERE foo.id IN (SELECT *
   FROM x);
 
-  WITH
+WITH
   x (a, b) AS (
-    SELECT 1, 2)
+    SELECT 1, 2
+  )
 UPDATE foo
-SET xyzzy = 7
-  WHERE foo.id IN (SELECT *
-  FROM x);
+  SET xyzzy = 7
+    WHERE foo.id IN (SELECT *
+    FROM x);
 
 @ENFORCE_STRICT FOREIGN KEY ON UPDATE;
 
@@ -1191,7 +1254,7 @@ DECLARE SELECT FUNC garbonzo (id INTEGER) (t TEXT);
 
 SELECT *
   FROM garbonzo(1, 2, 3) AS T1
-    INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
+  INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
 
 CREATE TRIGGER deleted_trigger
   AFTER INSERT ON target_table2
@@ -1199,18 +1262,21 @@ BEGIN
   DELETE FROM foo WHERE id = 1;
 END @DELETE(100);
 
-INSERT INTO foo SELECT C11
-  FROM T1
-  WHERE 1
+INSERT INTO foo
+  SELECT C11
+    FROM T1
+    WHERE 1
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO foo(id) VALUES(1)
+INSERT INTO foo(id)
+  VALUES(1)
 ON CONFLICT (id) 
   WHERE id = 10 DO UPDATE
-SET id = id + 1
-  WHERE id = 20;
+  SET id = id + 1
+    WHERE id = 20;
 
-INSERT INTO foo(id) VALUES(1)
+INSERT INTO foo(id)
+  VALUES(1)
 ON CONFLICT DO NOTHING;
 
 SELECT 10 * a AS T
@@ -1223,8 +1289,9 @@ SELECT *
 EXPLAIN
 SELECT 1;
 
-DECLARE E CURSOR FOR EXPLAIN
-SELECT 1;
+DECLARE E CURSOR FOR
+  EXPLAIN
+  SELECT 1;
 
 @SCHEMA_AD_HOC_MIGRATION(11, YourProcHere);
 
@@ -1277,9 +1344,10 @@ UPDATE CURSOR d(a, b) FROM VALUES(1, 'x');
 
 UPDATE CURSOR d USING 1 AS a, 'x' AS b;
 
-  WITH
+WITH
   foo (*) AS (
-    SELECT 1 AS x, '2' AS y)
+    SELECT 1 AS x, '2' AS y
+  )
 SELECT *
   FROM foo;
 
@@ -1714,19 +1782,19 @@ DECLARE CONST GROUP foo (
 
 @EMIT_CONSTANTS foo;
 
-  WITH
+WITH
   foo (*) AS (CALL bar(1, 2) USING a AS x, b AS y)
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   foo (*) AS (CALL bar(1, 2))
 SELECT *
   FROM foo;
 
 CALL foo(*);
 
-  WITH
+WITH
   bar (*) AS (CALL bar(1, 5) USING goo AS too),
   tar (*) AS (CALL tar(3) USING soo AS woo, goo AS too)
 SELECT *
@@ -1770,21 +1838,26 @@ CREATE TABLE V(
 
 CREATE PROC p ()
 BEGIN
-  DECLARE C CURSOR FOR SELECT T.*, 1 AS u, 2 AS v
-    FROM T;
+  DECLARE C CURSOR FOR
+    SELECT T.*, 1 AS u, 2 AS v
+      FROM T;
   FETCH C;
-  INSERT INTO T VALUES(FROM C LIKE T);
-  DECLARE D CURSOR FOR SELECT *
-    FROM U;
+  INSERT INTO T
+    VALUES(FROM C LIKE T);
+  DECLARE D CURSOR FOR
+    SELECT *
+      FROM U;
   FETCH D;
   DECLARE R CURSOR LIKE V;
   FETCH R FROM VALUES(FROM C LIKE T, FROM D);
   UPDATE CURSOR R FROM VALUES(FROM C LIKE T, FROM D);
-  DECLARE S CURSOR FOR   WITH
-    cte (l, m, n, o) AS (
-      VALUES(FROM C LIKE T, FROM D))
-  SELECT *
-    FROM cte;
+  DECLARE S CURSOR FOR
+    WITH
+      cte (l, m, n, o) AS (
+        VALUES(FROM C LIKE T, FROM D)
+      )
+    SELECT *
+      FROM cte;
   FETCH S;
 END;
 
@@ -1869,9 +1942,9 @@ CREATE TABLE backing(
 @ENFORCE_STRICT UPDATE FROM;
 
 UPDATE foo
-SET name = baz.name FROM bar
+  SET name = baz.nameFROM bar
   INNER JOIN baz ON bar.id = baz.id
-  WHERE bar.name = 'x' AND foo.id = bar.id;
+    WHERE bar.name = 'x' AND foo.id = bar.id;
 
 @ATTRIBUTE(cql:private)
 @ATTRIBUTE(cql:potato=bar)
@@ -1991,7 +2064,7 @@ CREATE TABLE yy(
 @MACRO(QUERY_PARTS) qp!()
 BEGIN
   xx AS T1
-    INNER JOIN yy AS T2 ON T1.x = T2.y
+  INNER JOIN yy AS T2 ON T1.x = T2.y
 END;
 
 @MACRO(STMT_LIST) sel!(e! EXPR, q! QUERY_PARTS)
@@ -2001,81 +2074,100 @@ BEGIN
 END;
 
 SELECT *
-  FROM (xx AS T1
+  FROM (
+    xx AS T1
     INNER JOIN yy AS T2 ON T1.x = T2.y)
-    INNER JOIN yy;
+  INNER JOIN yy;
 
 SELECT *
-  FROM (xx AS T1
+  FROM (
+    xx AS T1
     INNER JOIN yy AS T2 ON T1.x = T2.y) AS T1;
 
 SELECT x
-  FROM (xx AS T1
+  FROM (
+    xx AS T1
     INNER JOIN yy AS T2 ON T1.x = T2.y) AS Q;
 
 SELECT *
-  FROM (xx AS T1
+  FROM (
+    xx AS T1
     INNER JOIN yy AS T2 ON T1.x = T2.y) AS T1;
 
 @MACRO(CTE_TABLES) cte!()
 BEGIN
   foo (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   bar (*) AS (
-    SELECT 3 AS u, 4 AS v)
+    SELECT 3 AS u, 4 AS v
+  )
 END;
 
-  WITH
+WITH
   vv (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   foo (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   bar (*) AS (
-    SELECT 3 AS u, 4 AS v),
+    SELECT 3 AS u, 4 AS v
+  ),
   uu (*) AS (
-    SELECT 1 AS x, 2 AS y)
+    SELECT 1 AS x, 2 AS y
+  )
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   foo (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   bar (*) AS (
-    SELECT 3 AS u, 4 AS v),
+    SELECT 3 AS u, 4 AS v
+  ),
   uu (*) AS (
-    SELECT 1 AS x, 2 AS y)
+    SELECT 1 AS x, 2 AS y
+  )
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   foo (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   bar (*) AS (
-    SELECT 3 AS u, 4 AS v)
+    SELECT 3 AS u, 4 AS v
+  )
 SELECT *
   FROM foo;
 
-  WITH
+WITH
   vv (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   foo (*) AS (
-    SELECT 1 AS x, 2 AS y),
+    SELECT 1 AS x, 2 AS y
+  ),
   bar (*) AS (
-    SELECT 3 AS u, 4 AS v)
+    SELECT 3 AS u, 4 AS v
+  )
 SELECT *
   FROM foo;
 
 @MACRO(STMT_LIST) query!(u! CTE_TABLES)
 BEGIN
-    WITH
+  WITH
     u!
   SELECT *
     FROM foo;
 END;
 
-  WITH
+WITH
   foo (*) AS (
-    SELECT 100 AS x, 200 AS y)
+    SELECT 100 AS x, 200 AS y
+  )
 SELECT *
   FROM foo;
 
@@ -2163,11 +2255,11 @@ LET z := x * (y + 5 + (y + 5) + 1);
 
 SET z := 151;
 
-LET zz := "(\n  SELECT 1 AS x, 2 AS y) AS T";
+LET zz := "(SELECT 1 AS x, 2 AS y) AS T";
 
-SET zz := "T1\n  INNER JOIN T2 ON T1.id = T2.id";
+SET zz := "T1\nINNER JOIN T2 ON T1.id = T2.id";
 
-SET zz := "x (*) AS (\n  SELECT 1 AS x, 2 AS y)\n";
+SET zz := "x (*) AS (\n  SELECT 1 AS x, 2 AS y\n)\n";
 
 SET zz := "SELECT 1 AS x\n  FROM foo";
 
@@ -2200,7 +2292,7 @@ BEGIN
   END);
 END;
 
-SET zz := "1 + 2x\n  INNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS xxf (*) AS (\n  SELECT 99\n    FROM yy)\nLET qq := 201;\n";
+SET zz := "1 + 2x\nINNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS xxf (*) AS (\n  SELECT 99\n    FROM yy\n)\nLET qq := 201;\n";
 
 LET expr := 1;
 

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -155,27 +155,27 @@ SELECT a AS b, c AS d
 
 SELECT a, b
   FROM c
-  INNER JOIN d;
+    INNER JOIN d;
 
 SELECT a, b
   FROM c
-  INNER JOIN d ON e = f;
+    INNER JOIN d ON e = f;
 
 SELECT a, b
   FROM c
-  INNER JOIN d ON e.f = g.h;
+    INNER JOIN d ON e.f = g.h;
 
 SELECT a, b
   FROM c
-  LEFT OUTER JOIN d ON e.f = g.h;
+    LEFT OUTER JOIN d ON e.f = g.h;
 
 SELECT P.thread_key, P.contact_id, P.is_admin, P.nickname, P.read_watermark_timestamp_ms, P.delivered_watermark_timestamp_ms, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, C.name, C.is_messenger_user
   FROM participants AS P
-  LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
+    LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
 
 SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
   FROM threads AS T
-  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT *
   FROM foo;
@@ -185,7 +185,7 @@ SELECT a
 
 SELECT T.thread_key, T.thread_type, UTN.thread_name AS thread_name, T.thread_picture_url, T.mute_expire_time_ms
   FROM threads AS T
-  LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
+    LEFT OUTER JOIN _unified_thread_name AS UTN ON UTN.thread_key = T.thread_key;
 
 SELECT 2 <> 3;
 
@@ -241,7 +241,7 @@ SELECT b
 CREATE VIEW _self_thread_name AS
 SELECT UI.facebook_user_id AS thread_key, C.name AS thread_name
   FROM _user_info AS UI,
-contacts AS C
+  contacts AS C
   WHERE UI.facebook_user_id = C.id;
 
 DELETE FROM a;
@@ -259,15 +259,15 @@ SELECT 12.3;
 CREATE VIEW zzz AS
 SELECT DISTINCT a, b AS c, d
   FROM e AS E
-  LEFT OUTER JOIN f AS F ON F.g = e.g
-  LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
+    LEFT OUTER JOIN f AS F ON F.g = e.g
+    LEFT OUTER JOIN x AS X ON y.z = q.w AND h.j = k.l
 ORDER BY o.p DESC;
 
 CREATE VIEW thread_messages AS
 SELECT DISTINCT M.message_id, M.thread_key, M.offline_threading_id, M.sender_id, M.send_status, C.name, C.profile_picture_url, C.profile_picture_fallback_url, C.profile_picture_url_expiration_timestamp_ms, M.body, M.sticker_id, M.timestamp_ms, A.has_xma OR A.has_media AS has_attachment, M.is_admin_message
   FROM messages AS M
-  LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
-  LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
+    LEFT OUTER JOIN contacts AS C ON C.id = M.sender_id
+    LEFT OUTER JOIN attachments AS A ON A.message_id = M.message_id AND A.thread_key = M.thread_key
 ORDER BY M.timestamp_ms DESC;
 
 SELECT *
@@ -282,15 +282,17 @@ LIMIT 20
 OFFSET 7;
 
 SELECT a
-  FROM (SELECT b
-  FROM c) AS X;
+  FROM (
+    SELECT b
+      FROM c) AS X;
 
 CREATE VIEW unread_not_muted_threads_count AS
 SELECT count(*) AS count
-  FROM (SELECT *
-  FROM threads
-ORDER BY last_activity_timestamp_ms DESC
-LIMIT 20) AS T
+  FROM (
+    SELECT *
+      FROM threads
+    ORDER BY last_activity_timestamp_ms DESC
+    LIMIT 20) AS T
   WHERE T.last_activity_timestamp_ms > T.last_read_watermark_timestamp_ms AND (T.mute_expire_time_ms >= 0 AND T.mute_expire_time_ms - strftime('%s', 'now') * 1000 <= 0) AND T.folder_name = 'inbox';
 
 CREATE TABLE pending_tasks(
@@ -573,7 +575,7 @@ SELECT 1 AND 3 IN (3, 4);
 
 SELECT x, y
   FROM T
-  INNER JOIN Y USING (a, b, c);
+    INNER JOIN Y USING (a, b, c);
 
 UPDATE X
 SET x = 1,
@@ -595,27 +597,27 @@ SELECT ALL x, y
 
 SELECT a, b
   FROM X
-  INNER JOIN Y;
+    INNER JOIN Y;
 
 SELECT a, b
   FROM X
-  LEFT JOIN Y;
+    LEFT JOIN Y;
 
 SELECT a, b
   FROM X AS XX
-  RIGHT JOIN Y;
+    RIGHT JOIN Y;
 
 SELECT a, b
   FROM X
-  RIGHT OUTER JOIN Y;
+    RIGHT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-  LEFT OUTER JOIN Y;
+    LEFT OUTER JOIN Y;
 
 SELECT a, b
   FROM X
-  CROSS JOIN Y;
+    CROSS JOIN Y;
 
 SELECT CASE 1 WHEN 1 THEN 'a'
 WHEN 2 THEN 'b'
@@ -624,8 +626,8 @@ END;
 
 SELECT x
   FROM (A,
-B,
-C);
+  B,
+  C);
 
 SELECT x
   FROM A
@@ -710,27 +712,29 @@ DECLARE test CURSOR FOR CALL foo(1, 2);
 
 SELECT *
   FROM foo
-  WHERE EXISTS (SELECT *
-  FROM bar);
+  WHERE EXISTS (
+  SELECT *
+    FROM bar);
 
 SELECT *
   FROM foo
-  WHERE NOT EXISTS (SELECT *
-  FROM bar);
+  WHERE NOT EXISTS (
+  SELECT *
+    FROM bar);
 
 FETCH my_cursor;
 
 SELECT a
   FROM (X
-  INNER JOIN Y)
-  LEFT OUTER JOIN (W
-  INNER JOIN Q);
+    INNER JOIN Y)
+    LEFT OUTER JOIN (W
+    INNER JOIN Q);
 
 SELECT a
   FROM (X
-  INNER JOIN Y)
-  LEFT OUTER JOIN (W
-  INNER JOIN Q);
+    INNER JOIN Y)
+    LEFT OUTER JOIN (W
+    INNER JOIN Q);
 
 SELECT a, b
   FROM x
@@ -792,38 +796,46 @@ OFFSET 3;
 
 SELECT nullable(1);
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 SELECT a, b
   FROM x;
 
-WITH
-x (a, b) AS (SELECT 1, 2),
-y (c, d) AS (SELECT 5.4, 7.3)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2),
+  y (c, d) AS (
+    SELECT 5.4, 7.3)
 SELECT a, b
   FROM x
-  INNER JOIN y ON x.a = y.c;
+    INNER JOIN y ON x.a = y.c;
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 SELECT *
   FROM x AS X
-  INNER JOIN (WITH
-y (a, b) AS (SELECT 1, 3)
-SELECT *
-  FROM y) AS Y ON X.a = y.A;
+    INNER JOIN (
+      WITH
+      y (a, b) AS (
+        SELECT 1, 3)
+    SELECT *
+      FROM y) AS Y ON X.a = y.A;
 
-WITH RECURSIVE
-cnt (x) AS (SELECT 1
-UNION ALL
-SELECT x + 1
-  FROM cnt
-LIMIT 20)
+  WITH RECURSIVE
+  cnt (x) AS (
+    SELECT 1
+    UNION ALL
+    SELECT x + 1
+      FROM cnt
+    LIMIT 20)
 SELECT x
   FROM cnt;
 
 SELECT T.*
-  FROM (SELECT 1) AS T;
+  FROM (
+    SELECT 1) AS T;
 
 DECLARE FUNC foo (x INTEGER, y TEXT NOT NULL) INTEGER NOT NULL;
 
@@ -984,14 +996,16 @@ CREATE TABLE foo3(
   id INTEGER
 ) @RECREATE(foo3_group) @DELETE;
 
-WITH
-x (a, b) AS (SELECT 111, 222)
+  WITH
+  x (a, b) AS (
+    SELECT 111, 222)
 INSERT INTO foo VALUES(( SELECT a
   FROM x ), ( SELECT b
   FROM x ));
 
-WITH RECURSIVE
-x (a, b) AS (SELECT 111, 222)
+  WITH RECURSIVE
+  x (a, b) AS (
+    SELECT 111, 222)
 INSERT INTO foo(a, b) VALUES(( SELECT a
   FROM x ), ( SELECT b
   FROM x ));
@@ -1111,13 +1125,15 @@ CREATE TABLE with_sensitive(
   name TEXT @SENSITIVE
 );
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 DELETE FROM foo WHERE foo.id IN (SELECT *
   FROM x);
 
-WITH
-x (a, b) AS (SELECT 1, 2)
+  WITH
+  x (a, b) AS (
+    SELECT 1, 2)
 UPDATE foo
 SET xyzzy = 7
   WHERE foo.id IN (SELECT *
@@ -1175,7 +1191,7 @@ DECLARE SELECT FUNC garbonzo (id INTEGER) (t TEXT);
 
 SELECT *
   FROM garbonzo(1, 2, 3) AS T1
-  INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
+    INNER JOIN xyzzy() AS T2 ON T1.id = T2.id;
 
 CREATE TRIGGER deleted_trigger
   AFTER INSERT ON target_table2
@@ -1261,8 +1277,9 @@ UPDATE CURSOR d(a, b) FROM VALUES(1, 'x');
 
 UPDATE CURSOR d USING 1 AS a, 'x' AS b;
 
-WITH
-foo (*) AS (SELECT 1 AS x, '2' AS y)
+  WITH
+  foo (*) AS (
+    SELECT 1 AS x, '2' AS y)
 SELECT *
   FROM foo;
 
@@ -1697,24 +1714,24 @@ DECLARE CONST GROUP foo (
 
 @EMIT_CONSTANTS foo;
 
-WITH
-foo (*) AS (CALL bar(1, 2) USING a AS x, b AS y)
+  WITH
+  foo (*) AS (CALL bar(1, 2) USING a AS x, b AS y)
 SELECT *
   FROM foo;
 
-WITH
-foo (*) AS (CALL bar(1, 2))
+  WITH
+  foo (*) AS (CALL bar(1, 2))
 SELECT *
   FROM foo;
 
 CALL foo(*);
 
-WITH
-bar (*) AS (CALL bar(1, 5) USING goo AS too),
-tar (*) AS (CALL tar(3) USING soo AS woo, goo AS too)
+  WITH
+  bar (*) AS (CALL bar(1, 5) USING goo AS too),
+  tar (*) AS (CALL tar(3) USING soo AS woo, goo AS too)
 SELECT *
   FROM bar,
-tar;
+  tar;
 
 SELECT *
   FROM (CALL foo() USING stuff AS source);
@@ -1763,8 +1780,9 @@ BEGIN
   DECLARE R CURSOR LIKE V;
   FETCH R FROM VALUES(FROM C LIKE T, FROM D);
   UPDATE CURSOR R FROM VALUES(FROM C LIKE T, FROM D);
-  DECLARE S CURSOR FOR WITH
-  cte (l, m, n, o) AS (VALUES(FROM C LIKE T, FROM D))
+  DECLARE S CURSOR FOR   WITH
+    cte (l, m, n, o) AS (
+      VALUES(FROM C LIKE T, FROM D))
   SELECT *
     FROM cte;
   FETCH S;
@@ -1984,65 +2002,80 @@ END;
 
 SELECT *
   FROM (xx AS T1
-  INNER JOIN yy AS T2 ON T1.x = T2.y)
-  INNER JOIN yy;
+    INNER JOIN yy AS T2 ON T1.x = T2.y)
+    INNER JOIN yy;
 
 SELECT *
   FROM (xx AS T1
-  INNER JOIN yy AS T2 ON T1.x = T2.y) AS T1;
+    INNER JOIN yy AS T2 ON T1.x = T2.y) AS T1;
 
 SELECT x
   FROM (xx AS T1
-  INNER JOIN yy AS T2 ON T1.x = T2.y) AS Q;
+    INNER JOIN yy AS T2 ON T1.x = T2.y) AS Q;
 
 SELECT *
   FROM (xx AS T1
-  INNER JOIN yy AS T2 ON T1.x = T2.y) AS T1;
+    INNER JOIN yy AS T2 ON T1.x = T2.y) AS T1;
 
 @MACRO(CTE_TABLES) cte!()
 BEGIN
-  foo (*) AS (SELECT 1 AS x, 2 AS y),
-  bar (*) AS (SELECT 3 AS u, 4 AS v)
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v)
 END;
 
-WITH
-vv (*) AS (SELECT 1 AS x, 2 AS y),
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v),
-uu (*) AS (SELECT 1 AS x, 2 AS y)
+  WITH
+  vv (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v),
+  uu (*) AS (
+    SELECT 1 AS x, 2 AS y)
 SELECT *
   FROM foo;
 
-WITH
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v),
-uu (*) AS (SELECT 1 AS x, 2 AS y)
+  WITH
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v),
+  uu (*) AS (
+    SELECT 1 AS x, 2 AS y)
 SELECT *
   FROM foo;
 
-WITH
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v)
+  WITH
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v)
 SELECT *
   FROM foo;
 
-WITH
-vv (*) AS (SELECT 1 AS x, 2 AS y),
-foo (*) AS (SELECT 1 AS x, 2 AS y),
-bar (*) AS (SELECT 3 AS u, 4 AS v)
+  WITH
+  vv (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  foo (*) AS (
+    SELECT 1 AS x, 2 AS y),
+  bar (*) AS (
+    SELECT 3 AS u, 4 AS v)
 SELECT *
   FROM foo;
 
 @MACRO(STMT_LIST) query!(u! CTE_TABLES)
 BEGIN
-  WITH
-  u!
+    WITH
+    u!
   SELECT *
     FROM foo;
 END;
 
-WITH
-foo (*) AS (SELECT 100 AS x, 200 AS y)
+  WITH
+  foo (*) AS (
+    SELECT 100 AS x, 200 AS y)
 SELECT *
   FROM foo;
 
@@ -2130,11 +2163,11 @@ LET z := x * (y + 5 + (y + 5) + 1);
 
 SET z := 151;
 
-LET zz := "(SELECT 1 AS x, 2 AS y) AS T";
+LET zz := "(\n  SELECT 1 AS x, 2 AS y) AS T";
 
 SET zz := "T1\n  INNER JOIN T2 ON T1.id = T2.id";
 
-SET zz := "x (*) AS (SELECT 1 AS x, 2 AS y)\n";
+SET zz := "x (*) AS (\n  SELECT 1 AS x, 2 AS y)\n";
 
 SET zz := "SELECT 1 AS x\n  FROM foo";
 
@@ -2167,7 +2200,7 @@ BEGIN
   END);
 END;
 
-SET zz := "1 + 2x\n  INNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS xxf (*) AS (SELECT 99\n  FROM yy)\nLET qq := 201;\n";
+SET zz := "1 + 2x\n  INNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS xxf (*) AS (\n  SELECT 99\n    FROM yy)\nLET qq := 201;\n";
 
 LET expr := 1;
 

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -169,7 +169,7 @@ SELECT a, b
   FROM c
   LEFT OUTER JOIN d ON e.f = g.h;
 
-SELECT 
+SELECT
     P.thread_key,
     P.contact_id,
     P.is_admin,
@@ -184,7 +184,7 @@ SELECT
   FROM participants AS P
   LEFT OUTER JOIN contacts AS C ON C.id = P.contact_id;
 
-SELECT 
+SELECT
     T.thread_key,
     T.thread_type,
     UTN.thread_name AS thread_name,
@@ -199,7 +199,7 @@ SELECT *
 SELECT a
   FROM b;
 
-SELECT 
+SELECT
     T.thread_key,
     T.thread_type,
     UTN.thread_name AS thread_name,
@@ -222,7 +222,7 @@ SELECT a, b
   FROM c
 ORDER BY f;
 
-SELECT 
+SELECT
     C.id AS contact_id,
     C.contact_type,
     C.profile_picture_url,
@@ -293,7 +293,7 @@ SELECT DISTINCT a, b AS c, d
 ORDER BY o.p DESC;
 
 CREATE VIEW thread_messages AS
-SELECT DISTINCT 
+SELECT DISTINCT
     M.message_id,
     M.thread_key,
     M.offline_threading_id,
@@ -2031,6 +2031,8 @@ foo(q).r;
 foo::bar().baz;
 
 column := 1;
+
+DECLARE foo int;
 
 @MACRO(EXPR) foo!(x! EXPR, z! EXPR)
 BEGIN


### PR DESCRIPTION
The code in `gen_sql.c` which echos the AST back is the oldest except for `cql.y` and `ast.c`. As such many of the features like character buffers didn't even exist when it was first written and were sort of retrofitted.  When writing to stdout directly there was little we could do to get enough context to properly indent so only a modest effort was made to do something reasonable.

I've made a pass over some of the most popular constructs to try to better.  As a result insert, update, and select statements are hugely improved.  Some day we can turn it into a CQL auto-formatter but for now at least the echo is more readable.

Unfortunately this broke a lot of tests.  But fortunately having to look at the all the failures found lots of bugs and so my confidence that I haven't broken anything is very high.