### PR TITLE
Type getters only -- the "smaller/faster" path doesn't actually work in all cases

### DIFF
--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -7549,77 +7549,6 @@ typedef struct function_info {
   CSTR value_suffix;
 } function_info;
 
-// Using the information above we emit a column getter.  The essence of this
-// is to reach into the data field of the result set and index the requested row
-// then fetch the column.  There's two parts to this:
-// * First we need to compute the name of the getter, it's fairly simple coming
-//   from the name of the procedure that had the select and the field name that we
-//   are getting.
-// * Second we emit the body of the getter there's a few cases here
-//   * for fragments, we don't do our own getting, the master assembled query knows
-//     all the pieces so we delegate to it;  but we need to emit a declaration for
-//     the getter in the master query
-//   * for normal rowsets it's foo->data[i].column
-//   * for single row result sets it's just foo->data->column; there is only the one row
-static void cg_proc_result_set_getter(function_info *info) {
-  charbuf *h = info->headers;
-  charbuf *d = info->defs;
-
-  CG_CHARBUF_OPEN_SYM_WITH_PREFIX(
-    col_getter_sym,
-    "",
-    info->name,
-    "_get_",
-    info->col,
-    info->sym_suffix);
-
-  CHARBUF_OPEN(func_decl);
-  cg_col_reader_type(&func_decl, info->ret_type, info->ret_kind, col_getter_sym.ptr);
-  bprintf(&func_decl, "(%s _Nonnull result_set", info->result_set_ref_type);
-
-  // a procedure that uses OUT gives exactly one row, so no index in the API
-  if (!info->uses_out) {
-    bprintf(&func_decl, ", %s row", rt->cql_int32);
-  }
-
-  bprintf(&func_decl, ")");
-  bprintf(h, "%s%s;\n", rt->symbol_visibility, func_decl.ptr);
-  bprintf(d, "\n%s {\n", func_decl.ptr);
-
-  bprintf(d,
-    "  %s *data = (%s *)%s((cql_result_set_ref)result_set);\n",
-    info->row_struct_type,
-    info->row_struct_type,
-    rt->cql_result_set_get_data);
-
-  CHARBUF_OPEN(cast_tmp);
-
-  // cast the data type in the buffer to the correct result type
-  if (is_result_set_type(info->ret_type, info->ret_kind)) {
-    bprintf(&cast_tmp, "(");
-    cg_result_set_type_from_kind(&cast_tmp, info->ret_type, info->ret_kind);
-    bprintf(&cast_tmp, ")");
-  }
-
-  // Single row result set is always data[0]
-  // And data->field looks nicer than data[0].field
-  if (info->uses_out) {
-    bprintf(d, "  return %sdata->%s%s;\n",
-      cast_tmp.ptr, info->col, info->value_suffix ? info->value_suffix : "");
-  }
-  else {
-    bprintf(d, "  return %sdata[row].%s%s;\n",
-    cast_tmp.ptr, info->col, info->value_suffix ? info->value_suffix : "");
-  }
-
-  CHARBUF_CLOSE(cast_tmp);
-
-  bprintf(d, "}\n");
-
-  CHARBUF_CLOSE(func_decl);
-  CHARBUF_CLOSE(col_getter_sym);
-}
-
 // The inlineable version of the getter can be generated instead of the opened coded version as above
 // This type inlines well because it uses a small number of standard helpers to do the fetching.
 // The situation is not so different from the original open coded case above.
@@ -7663,6 +7592,8 @@ static void cg_proc_result_set_type_based_getter(function_info *_Nonnull info)
 
   // The inline body will all go into the header file in the normal case.
   // Note it's ok for these to be static inline because they have a different name
+  bprintf(h, "#ifndef _%s_inline_\n", col_getter_sym.ptr);
+  bprintf(h, "#define _%s_inline_\n\n", col_getter_sym.ptr);
   bprintf(h, "\nstatic inline %s {\n", func_decl.ptr);
   out = h;
 
@@ -7717,6 +7648,7 @@ static void cg_proc_result_set_type_based_getter(function_info *_Nonnull info)
   }
   bprintf(out, "((cql_result_set_ref)result_set, %s, %d)%s;\n", row, info->col_index, trailing_string);
   bprintf(out, "}\n");
+  bprintf(h, "\n#endif\n\n");
 
   CHARBUF_CLOSE(func_decl);
   CHARBUF_CLOSE(col_getter_sym);
@@ -7775,11 +7707,10 @@ static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_i
   }
 
   CHARBUF_OPEN(func_decl);
-  if (use_inline) {
-    bprintf(&func_decl, "static inline void %s", col_getter_sym.ptr);
-  } else {
-    bprintf(&func_decl, "%svoid %s", rt->symbol_visibility, col_getter_sym.ptr);
-  }
+
+  bprintf(&func_decl, "#ifndef _%s_inline_\n", col_getter_sym.ptr);
+  bprintf(&func_decl, "#define _%s_inline_\n\n", col_getter_sym.ptr);
+  bprintf(&func_decl, "static inline void %s", col_getter_sym.ptr);
   bprintf(&func_decl, "(%s _Nonnull result_set", info->result_set_ref_type);
 
   // a procedure that uses OUT gives exactly one row, so no index in the API
@@ -7787,16 +7718,7 @@ static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_i
     bprintf(&func_decl, ", %s row", rt->cql_int32);
   }
 
-  if (use_inline) {
-    out = h;
-  } else {
-    if (is_set_null) {
-      bprintf(h, "%s);\n", func_decl.ptr);
-    } else {
-      bprintf(h, "%s, %s);\n", func_decl.ptr, var_decl.ptr);
-    }
-    out = d;
-  }
+  out = h;
 
   if (is_set_null) {
     bprintf(out, "\n%s) {\n", func_decl.ptr);
@@ -7853,6 +7775,10 @@ static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_i
   }
 
   bprintf(out, "}\n");
+
+  if (use_inline) {
+    bprintf(out, "\n#endif\n");
+  }
 
   CHARBUF_CLOSE(func_decl);
   CHARBUF_CLOSE(var_decl);
@@ -8048,14 +7974,12 @@ static void cg_proc_result_set(ast_node *ast) {
           data_types_sym.ptr,
           data_types_count_sym.ptr);
 
-  // If we are generating the typed getters, setup the function tables.
-  if (options.generate_type_getters) {
-    bprintf(h,
-      "\n%suint8_t %s[%s];\n",
-      rt->symbol_visibility,
-      data_types_sym.ptr,
-      data_types_count_sym.ptr);
-  }
+  // we always use typed getters, setup the function tables.
+  bprintf(h,
+    "\n%suint8_t %s[%s];\n",
+    rt->symbol_visibility,
+    data_types_sym.ptr,
+    data_types_count_sym.ptr);
 
   bprintf(h, "\n");
 
@@ -8109,66 +8033,33 @@ static void cg_proc_result_set(ast_node *ast) {
       .ret_kind = kind,
     };
 
-    if (options.generate_type_getters) {
-      if (col_is_nullable && !is_ref_type(sem_type)) {
-        info.ret_type = SEM_TYPE_BOOL | SEM_TYPE_NOTNULL;
-        info.name_type = SEM_TYPE_NULL;
-        info.sym_suffix = "_is_null";
-        cg_proc_result_set_type_based_getter(&info);
-
-        info.ret_type = core_type | SEM_TYPE_NOTNULL;
-        info.name_type = core_type;
-        info.sym_suffix = "_value";
-        cg_proc_result_set_type_based_getter(&info);
-
-        if (emit_setters) {
-          info.name_type = core_type;
-          cg_proc_result_set_setter(&info, DO_USE_INLINE, DONT_EMIT_SET_NULL);
-
-          // set null setter
-          info.sym_suffix = "_to_null";
-          cg_proc_result_set_setter(&info, DO_USE_INLINE, DO_EMIT_SET_NULL);
-        }
-      }
-      else {
-        info.ret_type = sem_type;
-        info.name_type = core_type;
-        info.sym_suffix = NULL;
-        cg_proc_result_set_type_based_getter(&info);
-        if (emit_setters) {
-          cg_proc_result_set_setter(&info, DO_USE_INLINE, DONT_EMIT_SET_NULL);
-        }
-      }
-    }
-    else if (col_is_nullable && is_numeric(sem_type)) {
+    if (col_is_nullable && !is_ref_type(sem_type)) {
       info.ret_type = SEM_TYPE_BOOL | SEM_TYPE_NOTNULL;
+      info.name_type = SEM_TYPE_NULL;
       info.sym_suffix = "_is_null";
-      info.value_suffix = ".is_null";
-      cg_proc_result_set_getter(&info);
+      cg_proc_result_set_type_based_getter(&info);
 
-      info.ret_type = core_type | SEM_TYPE_NOTNULL,
+      info.ret_type = core_type | SEM_TYPE_NOTNULL;
+      info.name_type = core_type;
       info.sym_suffix = "_value";
-      info.value_suffix = ".value";
-      cg_proc_result_set_getter(&info);
+      cg_proc_result_set_type_based_getter(&info);
 
       if (emit_setters) {
         info.name_type = core_type;
-        cg_proc_result_set_setter(&info, DONT_USE_INLINE, DONT_EMIT_SET_NULL);
+        cg_proc_result_set_setter(&info, DO_USE_INLINE, DONT_EMIT_SET_NULL);
 
         // set null setter
         info.sym_suffix = "_to_null";
-        cg_proc_result_set_setter(&info, DONT_USE_INLINE, DO_EMIT_SET_NULL);
+        cg_proc_result_set_setter(&info, DO_USE_INLINE, DO_EMIT_SET_NULL);
       }
     }
     else {
       info.ret_type = sem_type;
+      info.name_type = core_type;
       info.sym_suffix = NULL;
-      info.value_suffix = NULL;
-      cg_proc_result_set_getter(&info);
-
+      cg_proc_result_set_type_based_getter(&info);
       if (emit_setters) {
-        info.name_type = core_type;
-        cg_proc_result_set_setter(&info, DONT_USE_INLINE, DONT_EMIT_SET_NULL);
+        cg_proc_result_set_setter(&info, DO_USE_INLINE, DONT_EMIT_SET_NULL);
       }
     }
 
@@ -8193,9 +8084,7 @@ static void cg_proc_result_set(ast_node *ast) {
     }
   }
 
-  if (options.generate_type_getters) {
-    bprintf(h, "\n");
-  }
+  bprintf(h, "\n");
 
   CHARBUF_OPEN(is_null_getter);
 

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -7688,8 +7688,7 @@ static void cg_proc_result_set_type_based_getter(function_info *_Nonnull info)
 // vs a extern function on false
 static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_inline, bool_t is_set_null)
 {
-  charbuf *h = info->headers;
-  charbuf *out = NULL;
+  charbuf *out = info->headers;
 
   CG_CHARBUF_OPEN_SYM_WITH_PREFIX(
     col_getter_sym,
@@ -7716,8 +7715,6 @@ static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_i
   if (!info->uses_out) {
     bprintf(&func_decl, ", %s row", rt->cql_int32);
   }
-
-  out = h;
 
   if (is_set_null) {
     bprintf(out, "\n%s) {\n", func_decl.ptr);

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -7656,8 +7656,6 @@ static void cg_proc_result_set_type_based_getter(function_info *_Nonnull info)
 
 #define DO_EMIT_SET_NULL true
 #define DONT_EMIT_SET_NULL false
-#define DO_USE_INLINE true
-#define DONT_USE_INLINE false
 
 // This function generate a inline or export version of a setter by using the function_info
 // passed in
@@ -7684,9 +7682,7 @@ static void cg_proc_result_set_type_based_getter(function_info *_Nonnull info)
 //  cql_set_null(new_value_);
 //  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value_);
 // }
-// use_inline arg is about the function visibility, on true will generate a static inline function
-// vs a extern function on false
-static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_inline, bool_t is_set_null)
+static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t is_set_null)
 {
   charbuf *out = info->headers;
 
@@ -7771,10 +7767,7 @@ static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_i
   }
 
   bprintf(out, "}\n");
-
-  if (use_inline) {
-    bprintf(out, "\n#endif\n");
-  }
+  bprintf(out, "\n#endif\n");
 
   CHARBUF_CLOSE(func_decl);
   CHARBUF_CLOSE(var_decl);
@@ -8042,11 +8035,11 @@ static void cg_proc_result_set(ast_node *ast) {
 
       if (emit_setters) {
         info.name_type = core_type;
-        cg_proc_result_set_setter(&info, DO_USE_INLINE, DONT_EMIT_SET_NULL);
+        cg_proc_result_set_setter(&info, DONT_EMIT_SET_NULL);
 
         // set null setter
         info.sym_suffix = "_to_null";
-        cg_proc_result_set_setter(&info, DO_USE_INLINE, DO_EMIT_SET_NULL);
+        cg_proc_result_set_setter(&info, DO_EMIT_SET_NULL);
       }
     }
     else {
@@ -8055,7 +8048,7 @@ static void cg_proc_result_set(ast_node *ast) {
       info.sym_suffix = NULL;
       cg_proc_result_set_type_based_getter(&info);
       if (emit_setters) {
-        cg_proc_result_set_setter(&info, DO_USE_INLINE, DONT_EMIT_SET_NULL);
+        cg_proc_result_set_setter(&info, DONT_EMIT_SET_NULL);
       }
     }
 

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -7689,7 +7689,6 @@ static void cg_proc_result_set_type_based_getter(function_info *_Nonnull info)
 static void cg_proc_result_set_setter(function_info *_Nonnull info, bool_t use_inline, bool_t is_set_null)
 {
   charbuf *h = info->headers;
-  charbuf *d = info->defs;
   charbuf *out = NULL;
 
   CG_CHARBUF_OPEN_SYM_WITH_PREFIX(

--- a/sources/cql.h
+++ b/sources/cql.h
@@ -84,7 +84,6 @@ typedef struct cmd_options {
   bool_t semantic;
   bool_t codegen;
   bool_t compress;
-  bool_t generate_type_getters;
   bool_t generate_exports;
   bool_t run_unit_tests;
   bool_t nolines;
@@ -174,10 +173,6 @@ typedef struct rtdata {
 
   // The case to use for symbols.
   cg_symbol_case symbol_case;
-
-  // If enabled, generic type-based getters are used by the generated code, registering the callback function
-  // pointers when creating the result set objects.
-  bool_t generate_type_getters;
 
   // If enabled, macros will be generated to test equality between 2 list/index pairs.
   bool_t generate_equality_macros;
@@ -379,7 +374,7 @@ typedef struct rtdata {
   //   refOffsets:  unsigned short *refOffsets (offsets to all of the references in a row)
   //   rowsize:     size_t rowsize  (the size of each row in bytes)
   //
-  // The following getter callbacks are only used when generate_type_getters is true.
+  // The following getter callbacks are used to fetch values in the typed getters
   //   getBoolean:  Boolean (*_Nullable)(cql_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 col)
   //   getDouble:   double (*_Nullable)(cql_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 col)
   //   getInt32:    int32_t (*_Nullable)(cql_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 col)
@@ -427,7 +422,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_data;
 
   // Generic bool value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -437,7 +432,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_bool;
 
   // Generic double value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -447,7 +442,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_double;
 
   // Generic int32 value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -457,7 +452,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_int32;
 
   // Generic int64 value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -467,7 +462,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_int64;
 
   // Generic string value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -477,7 +472,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_string;
 
   // Generic object value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -487,7 +482,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_object;
 
   // Generic blob value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -497,7 +492,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_blob;
 
   // Generic is_null value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param row The row number to fetch the value for.
@@ -507,7 +502,7 @@ typedef struct rtdata {
   const char *cql_result_set_get_is_null;
 
   // Generic is_encoded value getter on base result set object.
-  // NOTE: This is only used when generate_type_getters is true.  This function should call through to the
+  // NOTE: This function should call through to the
   // inline type getters that are passed into the ctor for the result set.
   // @param result_set The cql result_set object.
   // @param col The column to fetch the value for.

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -2858,8 +2858,6 @@ static void parse_cmd(int argc, char **argv) {
       options.run_unit_tests = 1;
     } else if (strcmp(arg, "--generate_exports") == 0) {
       options.generate_exports = 1;
-    } else if (strcmp(arg, "--generate_type_getters") == 0) {
-      options.generate_type_getters = 1;
     } else if (strcmp(arg, "--cg") == 0) {
       a = gather_arg_params(a, argc, argv, &options.file_names_count, &options.file_names);
       options.codegen = 1;
@@ -3323,10 +3321,6 @@ static void cql_usage() {
     "  emits foo.h into the C output instead of cqlrt.h\n"
     "--generate_exports\n"
     "  requires another output file to --cg; it contains the procedure declarations for the input\n"
-    "  used with --rt c\n"
-    "--generate_type_getters\n"
-    "  emits rowset accessors using shared type getters instead of individual functions\n"
-    "  this makes them more interoperable if they share columns\n"
     "  used with --rt c\n"
     );
 }

--- a/sources/cqlrt_common.h
+++ b/sources/cqlrt_common.h
@@ -84,7 +84,7 @@ typedef struct cql_nullable_bool {
 
 typedef long long llint_t;
 
-// These macros are only used when generate_type_getters is enabled.
+// These macros are used for the typed getters
 #define CQL_DATA_TYPE_INT32     1       // note these are array offsets, do not reorder them!
 #define CQL_DATA_TYPE_INT64     2       // note these are array offsets, do not reorder them!
 #define CQL_DATA_TYPE_DOUBLE    3       // note these are array offsets, do not reorder them!

--- a/sources/rt_common.c
+++ b/sources/rt_common.c
@@ -45,7 +45,6 @@ static rtdata rt_c = {
     RT_IP_NOTICE("--")
     RT_AUTOGEN("--") "\n",
   .symbol_case = cg_symbol_case_snake,
-  .generate_type_getters = 0,
   .generate_equality_macros = 1,
   .symbol_prefix = "",
   .symbol_visibility = "extern ",
@@ -120,7 +119,6 @@ static rtdata rt_lua = {
   .source_wrapper_end = "",
   .exports_prefix = "",
   .symbol_case = cg_symbol_case_snake,
-  .generate_type_getters = 0,
   .generate_equality_macros = 1,
   .symbol_prefix = ""
 };
@@ -138,7 +136,6 @@ static rtdata rt_objc = {
   .header_wrapper_begin = "\nNS_ASSUME_NONNULL_BEGIN\n",
   .header_wrapper_end = "\nNS_ASSUME_NONNULL_END\n",
   .symbol_case = RT_OBJC_CASE,
-  .generate_type_getters = 1,
   .generate_equality_macros = 1,
   .symbol_prefix = RT_SYM_PREFIX,
   .impl_symbol_prefix = RT_IMPL_SYMBOL_PREFIX,
@@ -167,7 +164,6 @@ static rtdata rt_objc_mit = {
   .header_wrapper_begin = "\nNS_ASSUME_NONNULL_BEGIN\n",
   .header_wrapper_end = "\nNS_ASSUME_NONNULL_END\n",
   .symbol_case = cg_symbol_case_snake,
-  .generate_type_getters = 1,
   .generate_equality_macros = 1,
   .symbol_prefix = "CGS_",
   .impl_symbol_prefix = "",
@@ -272,11 +268,6 @@ cql_noexport rtdata *find_rtdata(CSTR name) {
        break;
     }
     i++;
-  }
-
-  // the result type can override this, we don't want to check both places so normalize to the option.
-  if (rt_) {
-    options.generate_type_getters |= rt_->generate_type_getters;
   }
 
   return rt_;

--- a/sources/test.sh
+++ b/sources/test.sh
@@ -371,7 +371,7 @@ code_gen_c_test() {
   cql_verify "$T/cg_test_c_globals.sql" "$O/cg_test_c_globals.h"
 
   echo running codegen test with type getters enabled
-  if ! ${CQL} --test --cg "$O/cg_test_c_with_type_getters.h" "$O/cg_test_c_with_type_getters.c" --in "$T/cg_test_c_type_getters.sql" --global_proc cql_startup --generate_type_getters  2>"$O/cg_test_c.err"
+  if ! ${CQL} --test --cg "$O/cg_test_c_with_type_getters.h" "$O/cg_test_c_with_type_getters.c" --in "$T/cg_test_c_type_getters.sql" --global_proc cql_startup 2>"$O/cg_test_c.err"
   then
     echo "ERROR:"
     cat "$O/cg_test_c.err"

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -740,14 +740,6 @@ set b0_nullable := 'b' not between null and 'c';
 
 -- TEST: this procedure will have a structured semantic type
 -- + cql_string_proc_name(with_result_set_stored_procedure_name, "with_result_set");
--- + cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
 -- + uint8_t with_result_set_data_types[with_result_set_data_types_count] = {
 -- + #define with_result_set_refs_offset cql_offsetof(with_result_set_row, name) // count = 1
 -- + static cql_uint16 with_result_set_col_offsets[] = { 5,
@@ -763,10 +755,7 @@ end;
 -- TEST: grabs values from a view that is backed by a table
 -- - .refs_count = 0,
 -- - .refs_offset = 0,
--- + cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_int32 select_from_view_result_count(select_from_view_result_set_ref _Nonnull result_set) {
+ -- + cql_int32 select_from_view_result_count(select_from_view_result_set_ref _Nonnull result_set) {
 -- + CQL_WARN_UNUSED cql_code select_from_view_fetch_results(sqlite3 *_Nonnull _db_, select_from_view_result_set_ref _Nullable *_Nonnull result_set) {
 -- + cql_code select_from_view(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt) {
 create proc select_from_view()
@@ -2896,26 +2885,9 @@ begin
 end;
 
 -- TEST: emit an object result set with setters with not null values
--- + extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
--- +   cql_contract_argument_notnull((void *)new_value, 2);
--- +   cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
--- + extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
--- +   cql_contract_argument_notnull((void *)new_value, 2);
--- +   cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
--- + extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
--- +   cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
--- + extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
--- +   cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
--- + extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
--- +   cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
--- + extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
--- +   cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
--- + extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
--- +   cql_contract_argument_notnull((void *)new_value, 2);
--- +   cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
--- + extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
--- +   cql_contract_argument_notnull((void *)new_value, 2);
--- +   cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+-- all this stuff goes in the header file so it's no longer present here
+-- - emit_object_with_setters_get_o
+-- - emit_object_with_setters_set_o
 @attribute(cql:emit_setters)
 create proc emit_object_with_setters(
   o object not null,
@@ -2933,30 +2905,9 @@ begin
 end;
 
 -- TEST: emit an object result set with setters with nullable values
--- + extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
--- +   cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
--- + extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
--- +   cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
--- + extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
--- +   cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
--- + extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
--- +  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
--- + extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
--- +   cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
--- + extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
--- +   cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
--- + extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
--- +   cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
--- + extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
--- +   cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
--- + extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
--- +   cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
--- + extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
--- +   cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
--- + extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
--- +   cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
--- + extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
--- +  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+-- all this stuff goes in the header file so it's no longer present here
+-- - emit_setters_with_nullables_get_o
+-- - emit_setters_with_nullables_set_o
 @attribute(cql:emit_setters)
 create proc emit_setters_with_nullables(
   o object,
@@ -2975,17 +2926,14 @@ end;
 
 
 -- TEST: emit an object result set not out and setters
--- + extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value)
--- + extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value)
--- + extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value)
--- + extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value)
--- + extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value)
+-- all this stuff goes in the header file so it's no longer present here
+-- - no_out_with_setters_get_id
+-- - no_out_with_setters_set_id
 @attribute(cql:emit_setters)
 create proc no_out_with_setters()
 begin
   select * from bar;
 end;
-
 
 -- TEST: no result set items should be generated at all
 -- - CQL_DATA_TYPE
@@ -5316,22 +5264,9 @@ begin
 end;
 
 -- TEST: emit getters and setters for a simple result set set type
--- + cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + return data[row].a.is_null;
--- + cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + return data[row].a.value;
--- + extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
--- + cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
--- + extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
--- + cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + return data[row].b;
--- + void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
--- + cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
--- + simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
--- + return (simple_child_proc_result_set_ref _Nullable )data[row].c;
--- + extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
--- + cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
+-- this stuff all goes in the header now, should be nothing here
+-- - simple_container_proc_get_a_is_null
+-- - simple_container_proc_get_a_value
 @attribute(cql:emit_setters)
 create proc simple_container_proc()
 begin

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -964,46 +964,6 @@ typedef struct with_result_set_row {
   cql_string_ref _Nullable name;
 } with_result_set_row;
 
-cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t with_result_set_data_types[with_result_set_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -1087,21 +1047,6 @@ typedef struct select_from_view_row {
   cql_int32 id;
   cql_nullable_int32 type;
 } select_from_view_row;
-
-cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t select_from_view_data_types[select_from_view_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -1240,46 +1185,6 @@ typedef struct get_data_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } get_data_row;
-
-cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t get_data_data_types[get_data_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -1589,41 +1494,6 @@ typedef struct complex_return_row {
   cql_string_ref _Nonnull _text;
 } complex_return_row;
 
-cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._bool;
-}
-
-cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._integer;
-}
-
-cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._longint;
-}
-
-cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._real;
-}
-
-cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._text;
-}
-
-cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._nullable_bool.is_null;
-}
-
-cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._nullable_bool.value;
-}
-
 uint8_t complex_return_data_types[complex_return_data_types_count] = {
   CQL_DATA_TYPE_BOOL | CQL_DATA_TYPE_NOT_NULL, // _bool
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // _integer
@@ -1721,11 +1591,6 @@ typedef struct hierarchical_query_row {
   cql_int32 id;
 } hierarchical_query_row;
 
-cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row) {
-  hierarchical_query_row *data = (hierarchical_query_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t hierarchical_query_data_types[hierarchical_query_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -1815,11 +1680,6 @@ typedef struct hierarchical_unmatched_query_row {
   cql_int32 id;
 } hierarchical_unmatched_query_row;
 
-cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row) {
-  hierarchical_unmatched_query_row *data = (hierarchical_unmatched_query_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t hierarchical_unmatched_query_data_types[hierarchical_unmatched_query_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -1903,11 +1763,6 @@ typedef struct union_select_row {
   cql_int32 A;
 } union_select_row;
 
-cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_select_row *data = (union_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].A;
-}
-
 uint8_t union_select_data_types[union_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
 };
@@ -1980,11 +1835,6 @@ cql_string_proc_name(union_all_select_stored_procedure_name, "union_all_select")
 typedef struct union_all_select_row {
   cql_int32 A;
 } union_all_select_row;
-
-cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_all_select_row *data = (union_all_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].A;
-}
 
 uint8_t union_all_select_data_types[union_all_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -2059,11 +1909,6 @@ cql_string_proc_name(union_all_with_nullable_stored_procedure_name, "union_all_w
 typedef struct union_all_with_nullable_row {
   cql_string_ref _Nullable name;
 } union_all_with_nullable_row;
-
-cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_all_with_nullable_row *data = (union_all_with_nullable_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
 
 uint8_t union_all_with_nullable_data_types[union_all_with_nullable_data_types_count] = {
   CQL_DATA_TYPE_STRING, // name
@@ -2208,21 +2053,6 @@ typedef struct with_stmt_row {
   cql_int32 c;
 } with_stmt_row;
 
-cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].c;
-}
-
 uint8_t with_stmt_data_types[with_stmt_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -2310,21 +2140,6 @@ typedef struct with_recursive_stmt_row {
   cql_int32 c;
 } with_recursive_stmt_row;
 
-cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].c;
-}
-
 uint8_t with_recursive_stmt_data_types[with_recursive_stmt_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -2407,21 +2222,6 @@ typedef struct parent_proc_row {
   cql_int32 three;
 } parent_proc_row;
 
-cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].one;
-}
-
-cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].two;
-}
-
-cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].three;
-}
-
 uint8_t parent_proc_data_types[parent_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // one
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // two
@@ -2496,21 +2296,6 @@ typedef struct parent_proc_child_row {
   cql_int32 five;
   cql_int32 six;
 } parent_proc_child_row;
-
-cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].four;
-}
-
-cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].five;
-}
-
-cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].six;
-}
 
 uint8_t parent_proc_child_data_types[parent_proc_child_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // four
@@ -2721,11 +2506,6 @@ END;
 static int32_t cursor_with_object_perf_index;
 
 cql_string_proc_name(cursor_with_object_stored_procedure_name, "cursor_with_object");
-
-cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set) {
-  cursor_with_object_row *data = (cursor_with_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->object_;
-}
 
 uint8_t cursor_with_object_data_types[cursor_with_object_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // object_
@@ -2975,46 +2755,6 @@ typedef struct uses_proc_for_result_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } uses_proc_for_result_row;
-
-cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t uses_proc_for_result_data_types[uses_proc_for_result_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -3324,21 +3064,6 @@ typedef struct blob_returner_row {
   cql_blob_ref _Nullable b_nullable;
 } blob_returner_row;
 
-cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].blob_id;
-}
-
-cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b_notnull;
-}
-
-cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b_nullable;
-}
-
 uint8_t blob_returner_data_types[blob_returner_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // blob_id
   CQL_DATA_TYPE_BLOB | CQL_DATA_TYPE_NOT_NULL, // b_notnull
@@ -3439,56 +3164,6 @@ END;
 static int32_t out_cursor_proc_perf_index;
 
 cql_string_proc_name(out_cursor_proc_stored_procedure_name, "out_cursor_proc");
-
-cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
-
-cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->extra1;
-}
-
-cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->extra2;
-}
 
 uint8_t out_cursor_proc_data_types[out_cursor_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -3762,11 +3437,6 @@ cql_string_proc_name(thread_theme_info_list_stored_procedure_name, "thread_theme
 typedef struct thread_theme_info_list_row {
   cql_int64 thread_key;
 } thread_theme_info_list_row;
-
-cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row) {
-  thread_theme_info_list_row *data = (thread_theme_info_list_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].thread_key;
-}
 
 uint8_t thread_theme_info_list_data_types[thread_theme_info_list_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // thread_key
@@ -4076,16 +3746,6 @@ static int32_t out_no_db_perf_index;
 
 cql_string_proc_name(out_no_db_stored_procedure_name, "out_no_db");
 
-cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set) {
-  out_no_db_row *data = (out_no_db_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set) {
-  out_no_db_row *data = (out_no_db_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
-
 uint8_t out_no_db_data_types[out_no_db_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
   CQL_DATA_TYPE_DOUBLE | CQL_DATA_TYPE_NOT_NULL, // B
@@ -4159,16 +3819,6 @@ END;
 static int32_t declare_cursor_like_cursor_perf_index;
 
 cql_string_proc_name(declare_cursor_like_cursor_stored_procedure_name, "declare_cursor_like_cursor");
-
-cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_cursor_row *data = (declare_cursor_like_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_cursor_row *data = (declare_cursor_like_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
 
 uint8_t declare_cursor_like_cursor_data_types[declare_cursor_like_cursor_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -4253,21 +3903,6 @@ static int32_t declare_cursor_like_proc_perf_index;
 
 cql_string_proc_name(declare_cursor_like_proc_stored_procedure_name, "declare_cursor_like_proc");
 
-cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->a.is_null;
-}
-
-cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->a.value;
-}
-
-cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b;
-}
-
 uint8_t declare_cursor_like_proc_data_types[declare_cursor_like_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // a
   CQL_DATA_TYPE_STRING, // b
@@ -4345,46 +3980,6 @@ END;
 static int32_t declare_cursor_like_table_perf_index;
 
 cql_string_proc_name(declare_cursor_like_table_stored_procedure_name, "declare_cursor_like_table");
-
-cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
 
 uint8_t declare_cursor_like_table_data_types[declare_cursor_like_table_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -4473,21 +4068,6 @@ END;
 static int32_t declare_cursor_like_view_perf_index;
 
 cql_string_proc_name(declare_cursor_like_view_stored_procedure_name, "declare_cursor_like_view");
-
-cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f1;
-}
-
-cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f2;
-}
-
-cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f3;
-}
 
 uint8_t declare_cursor_like_view_data_types[declare_cursor_like_view_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // f1
@@ -4823,16 +4403,6 @@ END;
 static int32_t fetch_to_cursor_from_cursor_perf_index;
 
 cql_string_proc_name(fetch_to_cursor_from_cursor_stored_procedure_name, "fetch_to_cursor_from_cursor");
-
-cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
-  fetch_to_cursor_from_cursor_row *data = (fetch_to_cursor_from_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
-  fetch_to_cursor_from_cursor_row *data = (fetch_to_cursor_from_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
 
 uint8_t fetch_to_cursor_from_cursor_data_types[fetch_to_cursor_from_cursor_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -5252,11 +4822,6 @@ static int32_t out_union_helper_perf_index;
 
 cql_string_proc_name(out_union_helper_stored_procedure_name, "out_union_helper");
 
-cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_helper_row *data = (out_union_helper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t out_union_helper_data_types[out_union_helper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5320,11 +4885,6 @@ END;
 static int32_t out_union_dml_helper_perf_index;
 
 cql_string_proc_name(out_union_dml_helper_stored_procedure_name, "out_union_dml_helper");
-
-cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_helper_row *data = (out_union_dml_helper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t out_union_dml_helper_data_types[out_union_dml_helper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -5462,11 +5022,6 @@ static int32_t forward_out_union_perf_index;
 
 cql_string_proc_name(forward_out_union_stored_procedure_name, "forward_out_union");
 
-cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_row *data = (forward_out_union_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t forward_out_union_data_types[forward_out_union_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5521,11 +5076,6 @@ static int32_t forward_out_union_extern_perf_index;
 
 cql_string_proc_name(forward_out_union_extern_stored_procedure_name, "forward_out_union_extern");
 
-cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_extern_row *data = (forward_out_union_extern_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t forward_out_union_extern_data_types[forward_out_union_extern_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5573,11 +5123,6 @@ END;
 static int32_t forward_out_union_dml_perf_index;
 
 cql_string_proc_name(forward_out_union_dml_stored_procedure_name, "forward_out_union_dml");
-
-cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_dml_row *data = (forward_out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t forward_out_union_dml_data_types[forward_out_union_dml_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -5867,16 +5412,6 @@ typedef struct simple_identity_row {
   cql_int32 data;
 } simple_identity_row;
 
-cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_identity_row *data = (simple_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_identity_row *data = (simple_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
-
 uint8_t simple_identity_data_types[simple_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // data
@@ -5956,21 +5491,6 @@ typedef struct complex_identity_row {
   cql_int32 data;
 } complex_identity_row;
 
-cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].col1;
-}
-
-cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].col2;
-}
-
-cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
-
 uint8_t complex_identity_data_types[complex_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // col1
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // col2
@@ -6049,16 +5569,6 @@ END;
 static int32_t out_cursor_identity_perf_index;
 
 cql_string_proc_name(out_cursor_identity_stored_procedure_name, "out_cursor_identity");
-
-cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set) {
-  out_cursor_identity_row *data = (out_cursor_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set) {
-  out_cursor_identity_row *data = (out_cursor_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->data;
-}
 
 uint8_t out_cursor_identity_data_types[out_cursor_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6157,16 +5667,6 @@ typedef struct radioactive_proc_row {
   cql_int32 id;
   cql_string_ref _Nullable data;
 } radioactive_proc_row;
-
-cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  radioactive_proc_row *data = (radioactive_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  radioactive_proc_row *data = (radioactive_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
 
 uint8_t radioactive_proc_data_types[radioactive_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6332,16 +5832,6 @@ typedef struct autodropper_row {
   cql_int32 b;
 } autodropper_row;
 
-cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  autodropper_row *data = (autodropper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  autodropper_row *data = (autodropper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
 uint8_t autodropper_data_types[autodropper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -6411,11 +5901,6 @@ END;
 static int32_t simple_cursor_proc_perf_index;
 
 cql_string_proc_name(simple_cursor_proc_stored_procedure_name, "simple_cursor_proc");
-
-cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set) {
-  simple_cursor_proc_row *data = (simple_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
 
 uint8_t simple_cursor_proc_data_types[simple_cursor_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6488,16 +5973,6 @@ typedef struct redundant_cast_row {
   cql_int32 plugh;
   cql_int32 five;
 } redundant_cast_row;
-
-cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
-  redundant_cast_row *data = (redundant_cast_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].plugh;
-}
-
-cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
-  redundant_cast_row *data = (redundant_cast_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].five;
-}
 
 uint8_t redundant_cast_data_types[redundant_cast_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // plugh
@@ -6650,16 +6125,6 @@ typedef struct top_level_select_alias_unused_row {
   cql_int32 x;
 } top_level_select_alias_unused_row;
 
-cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_unused_row *data = (top_level_select_alias_unused_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_unused_row *data = (top_level_select_alias_unused_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t top_level_select_alias_unused_data_types[top_level_select_alias_unused_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -6738,16 +6203,6 @@ typedef struct top_level_select_alias_used_in_orderby_row {
   cql_int32 id;
   cql_int32 x;
 } top_level_select_alias_used_in_orderby_row;
-
-cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_used_in_orderby_row *data = (top_level_select_alias_used_in_orderby_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_used_in_orderby_row *data = (top_level_select_alias_used_in_orderby_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t top_level_select_alias_used_in_orderby_data_types[top_level_select_alias_used_in_orderby_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -7173,16 +6628,6 @@ static int32_t out_union_two_perf_index;
 
 cql_string_proc_name(out_union_two_stored_procedure_name, "out_union_two");
 
-cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_two_row *data = (out_union_two_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_two_row *data = (out_union_two_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t out_union_two_data_types[out_union_two_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // y
@@ -7322,16 +6767,6 @@ END;
 static int32_t out_union_from_select_perf_index;
 
 cql_string_proc_name(out_union_from_select_stored_procedure_name, "out_union_from_select");
-
-cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_from_select_row *data = (out_union_from_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_from_select_row *data = (out_union_from_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
 
 uint8_t out_union_from_select_data_types[out_union_from_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -7487,16 +6922,6 @@ static int32_t out_union_values_perf_index;
 
 cql_string_proc_name(out_union_values_stored_procedure_name, "out_union_values");
 
-cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_values_row *data = (out_union_values_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_values_row *data = (out_union_values_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t out_union_values_data_types[out_union_values_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // y
@@ -7616,16 +7041,6 @@ END;
 static int32_t out_union_dml_perf_index;
 
 cql_string_proc_name(out_union_dml_stored_procedure_name, "out_union_dml");
-
-cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_row *data = (out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_row *data = (out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
 
 uint8_t out_union_dml_data_types[out_union_dml_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -7828,16 +7243,6 @@ typedef struct window_function_invocation_row {
   cql_int32 row_num;
 } window_function_invocation_row;
 
-cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window_function_invocation_row *data = (window_function_invocation_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window_function_invocation_row *data = (window_function_invocation_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].row_num;
-}
-
 uint8_t window_function_invocation_data_types[window_function_invocation_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // row_num
@@ -7965,11 +7370,6 @@ cql_string_proc_name(use_return_stored_procedure_name, "use_return");
 typedef struct use_return_row {
   cql_int32 x;
 } use_return_row;
-
-cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_return_row *data = (use_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t use_return_data_types[use_return_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -8386,46 +7786,6 @@ typedef struct sproc_with_copy_row {
   cql_string_ref _Nullable name;
 } sproc_with_copy_row;
 
-cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t sproc_with_copy_data_types[sproc_with_copy_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -8508,82 +7868,6 @@ END;
 static int32_t emit_object_with_setters_perf_index;
 
 cql_string_proc_name(emit_object_with_setters_stored_procedure_name, "emit_object_with_setters");
-
-cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
-extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
-}
-
-cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x;
-}
-
-extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
-}
-
-cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i;
-}
-
-extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
-}
-
-cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l;
-}
-
-extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
-}
-
-cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b;
-}
-
-extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
-  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
-}
-
-cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d;
-}
-
-extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
-}
-
-cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->t;
-}
-
-extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
-}
-
-cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->bl;
-}
-
-extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
-}
 
 uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data_types_count] = {
   CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
@@ -8703,114 +7987,6 @@ static int32_t emit_setters_with_nullables_perf_index;
 
 cql_string_proc_name(emit_setters_with_nullables_stored_procedure_name, "emit_setters_with_nullables");
 
-cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
-extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
-}
-
-cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x;
-}
-
-extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
-}
-
-cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i.is_null;
-}
-
-cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i.value;
-}
-
-extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
-}
-
-extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
-}
-
-cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l.is_null;
-}
-
-cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l.value;
-}
-
-extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
-}
-
-extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
-}
-
-cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b.is_null;
-}
-
-cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b.value;
-}
-
-extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
-  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
-}
-
-extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
-}
-
-cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d.is_null;
-}
-
-cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d.value;
-}
-
-extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
-}
-
-extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
-}
-
-cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->t;
-}
-
-extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
-}
-
-cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->bl;
-}
-
-extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
-  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
-}
-
 uint8_t emit_setters_with_nullables_data_types[emit_setters_with_nullables_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // o
   CQL_DATA_TYPE_OBJECT, // x
@@ -8928,78 +8104,6 @@ typedef struct no_out_with_setters_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } no_out_with_setters_row;
-
-cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
-}
-
-cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value) {
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, row, 1, new_value);
-}
-
-cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, row, 2, new_value);
-}
-
-extern void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 2);
-}
-
-cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 3, new_value);
-}
-
-extern void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 3);
-}
-
-cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
-extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, row, 4, new_value);
-}
-
-extern void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 4);
-}
 
 uint8_t no_out_with_setters_data_types[no_out_with_setters_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -9179,31 +8283,6 @@ typedef struct vault_sensitive_with_values_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_values_proc_row;
 
-cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_values_proc_data_types[vault_sensitive_with_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9294,26 +8373,6 @@ typedef struct vault_not_nullable_sensitive_with_values_proc_row {
   cql_string_ref _Nonnull title;
 } vault_not_nullable_sensitive_with_values_proc_row;
 
-cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type;
-}
-
 uint8_t vault_not_nullable_sensitive_with_values_proc_data_types[vault_not_nullable_sensitive_with_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_ENCODED, // name
@@ -9402,31 +8461,6 @@ typedef struct vault_sensitive_with_no_values_proc_row {
   cql_string_ref _Nullable name;
   cql_string_ref _Nullable title;
 } vault_sensitive_with_no_values_proc_row;
-
-cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t vault_sensitive_with_no_values_proc_data_types[vault_sensitive_with_no_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -9520,31 +8554,6 @@ typedef struct vault_union_all_table_proc_row {
   cql_string_ref _Nullable title;
 } vault_union_all_table_proc_row;
 
-cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_union_all_table_proc_data_types[vault_union_all_table_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9634,11 +8643,6 @@ typedef struct vault_alias_column_proc_row {
   cql_string_ref _Nullable alias_name;
 } vault_alias_column_proc_row;
 
-cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_alias_column_proc_row *data = (vault_alias_column_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].alias_name;
-}
-
 uint8_t vault_alias_column_proc_data_types[vault_alias_column_proc_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // alias_name
 };
@@ -9718,11 +8722,6 @@ cql_string_proc_name(vault_alias_column_name_proc_stored_procedure_name, "vault_
 typedef struct vault_alias_column_name_proc_row {
   cql_string_ref _Nullable alias_name;
 } vault_alias_column_name_proc_row;
-
-cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_alias_column_name_proc_row *data = (vault_alias_column_name_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].alias_name;
-}
 
 uint8_t vault_alias_column_name_proc_data_types[vault_alias_column_name_proc_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // alias_name
@@ -9859,31 +8858,6 @@ typedef struct vault_sensitive_with_context_and_sensitive_columns_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_context_and_sensitive_columns_proc_row;
 
-cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9973,31 +8947,6 @@ typedef struct vault_sensitive_with_no_context_and_sensitive_columns_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_no_context_and_sensitive_columns_proc_row;
 
-cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -10086,31 +9035,6 @@ typedef struct vault_sensitive_with_context_and_no_sensitive_columns_proc_row {
   cql_string_ref _Nullable name;
   cql_string_ref _Nullable title;
 } vault_sensitive_with_context_and_no_sensitive_columns_proc_row;
-
-cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -10788,36 +9712,6 @@ typedef struct window1_row {
   cql_nullable_double SalesMovingAverage;
 } window1_row;
 
-cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window1_data_types[window1_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -10896,36 +9790,6 @@ typedef struct window2_row {
   cql_nullable_double amount;
   cql_nullable_double RunningTotal;
 } window2_row;
-
-cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].RunningTotal.is_null;
-}
-
-cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].RunningTotal.value;
-}
 
 uint8_t window2_data_types[window2_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11006,36 +9870,6 @@ typedef struct window3_row {
   cql_nullable_double SalesMovingAverage;
 } window3_row;
 
-cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window3_data_types[window3_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11114,36 +9948,6 @@ typedef struct window4_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window4_row;
-
-cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window4_data_types[window4_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11224,36 +10028,6 @@ typedef struct window5_row {
   cql_nullable_double SalesMovingAverage;
 } window5_row;
 
-cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window5_data_types[window5_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11332,36 +10106,6 @@ typedef struct window6_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window6_row;
-
-cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window6_data_types[window6_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11442,36 +10186,6 @@ typedef struct window7_row {
   cql_nullable_double SalesMovingAverage;
 } window7_row;
 
-cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window7_data_types[window7_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11550,36 +10264,6 @@ typedef struct window8_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window8_row;
-
-cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window8_data_types[window8_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11660,36 +10344,6 @@ typedef struct window9_row {
   cql_nullable_double SalesMovingAverage;
 } window9_row;
 
-cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window9_data_types[window9_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11768,36 +10422,6 @@ typedef struct window10_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window10_row;
-
-cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window10_data_types[window10_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11878,36 +10502,6 @@ typedef struct window11_row {
   cql_nullable_double SalesMovingAverage;
 } window11_row;
 
-cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window11_data_types[window11_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11986,36 +10580,6 @@ typedef struct window12_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window12_row;
-
-cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window12_data_types[window12_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12096,36 +10660,6 @@ typedef struct window13_row {
   cql_nullable_double SalesMovingAverage;
 } window13_row;
 
-cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window13_data_types[window13_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -12204,36 +10738,6 @@ typedef struct window14_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window14_row;
-
-cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window14_data_types[window14_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12314,36 +10818,6 @@ typedef struct window15_row {
   cql_nullable_double SalesMovingAverage;
 } window15_row;
 
-cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window15_data_types[window15_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -12422,36 +10896,6 @@ typedef struct window16_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window16_row;
-
-cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window16_data_types[window16_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12920,26 +11364,6 @@ typedef struct virtual1_row {
   cql_int32 vz;
 } virtual1_row;
 
-cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vx;
-}
-
-cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.is_null;
-}
-
-cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.value;
-}
-
-cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vz;
-}
-
 uint8_t virtual1_data_types[virtual1_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // vx
   CQL_DATA_TYPE_INT32, // vy
@@ -13017,26 +11441,6 @@ typedef struct virtual2_row {
   cql_nullable_int32 vy;
   cql_int32 vz;
 } virtual2_row;
-
-cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vx;
-}
-
-cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.is_null;
-}
-
-cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.value;
-}
-
-cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vz;
-}
 
 uint8_t virtual2_data_types[virtual2_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // vx
@@ -13997,11 +12401,6 @@ static int32_t out_object_perf_index;
 
 cql_string_proc_name(out_object_stored_procedure_name, "out_object");
 
-cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
-  out_object_row *data = (out_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
 uint8_t out_object_data_types[out_object_data_types_count] = {
   CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
 };
@@ -14161,46 +12560,6 @@ typedef struct result_set_proc_with_contract_in_fetch_results_row {
   cql_string_ref _Nullable name;
 } result_set_proc_with_contract_in_fetch_results_row;
 
-cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t result_set_proc_with_contract_in_fetch_results_data_types[result_set_proc_with_contract_in_fetch_results_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -14283,46 +12642,6 @@ END;
 static int32_t out_proc_with_contract_in_fetch_results_perf_index;
 
 cql_string_proc_name(out_proc_with_contract_in_fetch_results_stored_procedure_name, "out_proc_with_contract_in_fetch_results");
-
-cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
 
 uint8_t out_proc_with_contract_in_fetch_results_data_types[out_proc_with_contract_in_fetch_results_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -14419,11 +12738,6 @@ cql_string_proc_name(nullability_improvements_are_erased_for_sql_stored_procedur
 typedef struct nullability_improvements_are_erased_for_sql_row {
   cql_int32 b;
 } nullability_improvements_are_erased_for_sql_row;
-
-cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row) {
-  nullability_improvements_are_erased_for_sql_row *data = (nullability_improvements_are_erased_for_sql_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
 
 uint8_t nullability_improvements_are_erased_for_sql_data_types[nullability_improvements_are_erased_for_sql_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -15283,11 +13597,6 @@ typedef struct sensitive_function_is_a_no_op_row {
   cql_string_ref _Nonnull y;
 } sensitive_function_is_a_no_op_row;
 
-cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sensitive_function_is_a_no_op_row *data = (sensitive_function_is_a_no_op_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t sensitive_function_is_a_no_op_data_types[sensitive_function_is_a_no_op_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // y
 };
@@ -15485,11 +13794,6 @@ typedef struct foo_row {
   cql_int32 shared_something;
 } foo_row;
 
-cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row) {
-  foo_row *data = (foo_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].shared_something;
-}
-
 uint8_t foo_data_types[foo_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // shared_something
 };
@@ -15592,46 +13896,6 @@ typedef struct shared_conditional_user_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } shared_conditional_user_row;
-
-cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t shared_conditional_user_data_types[shared_conditional_user_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -15784,11 +14048,6 @@ typedef struct nested_shared_stuff_row {
   cql_int32 x;
 } nested_shared_stuff_row;
 
-cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row) {
-  nested_shared_stuff_row *data = (nested_shared_stuff_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t nested_shared_stuff_data_types[nested_shared_stuff_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -15919,11 +14178,6 @@ cql_string_proc_name(use_nested_select_shared_frag_form_stored_procedure_name, "
 typedef struct use_nested_select_shared_frag_form_row {
   cql_int32 x;
 } use_nested_select_shared_frag_form_row;
-
-cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_nested_select_shared_frag_form_row *data = (use_nested_select_shared_frag_form_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t use_nested_select_shared_frag_form_data_types[use_nested_select_shared_frag_form_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -16114,11 +14368,6 @@ typedef struct shared_frag_else_nothing_test_row {
   cql_int32 id;
 } shared_frag_else_nothing_test_row;
 
-cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_test_row *data = (shared_frag_else_nothing_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t shared_frag_else_nothing_test_data_types[shared_frag_else_nothing_test_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -16216,21 +14465,6 @@ typedef struct shared_frag_else_nothing_in_from_clause_test_row {
   cql_nullable_int32 id1;
   cql_string_ref _Nonnull text1;
 } shared_frag_else_nothing_in_from_clause_test_row;
-
-cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id1.is_null;
-}
-
-cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id1.value;
-}
-
-cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].text1;
-}
 
 uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count] = {
   CQL_DATA_TYPE_INT32, // id1
@@ -16683,16 +14917,6 @@ static int32_t some_redeclared_out_proc_perf_index;
 
 cql_string_proc_name(some_redeclared_out_proc_stored_procedure_name, "some_redeclared_out_proc");
 
-cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
-  some_redeclared_out_proc_row *data = (some_redeclared_out_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x.is_null;
-}
-
-cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
-  some_redeclared_out_proc_row *data = (some_redeclared_out_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x.value;
-}
-
 uint8_t some_redeclared_out_proc_data_types[some_redeclared_out_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // x
 };
@@ -16788,16 +15012,6 @@ END;
 static int32_t some_redeclared_out_union_proc_perf_index;
 
 cql_string_proc_name(some_redeclared_out_union_proc_stored_procedure_name, "some_redeclared_out_union_proc");
-
-cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  some_redeclared_out_union_proc_row *data = (some_redeclared_out_union_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x.is_null;
-}
-
-cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  some_redeclared_out_union_proc_row *data = (some_redeclared_out_union_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x.value;
-}
 
 uint8_t some_redeclared_out_union_proc_data_types[some_redeclared_out_union_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // x
@@ -17098,16 +15312,6 @@ static int32_t a_proc_that_needs_dependents_perf_index;
 
 cql_string_proc_name(a_proc_that_needs_dependents_stored_procedure_name, "a_proc_that_needs_dependents");
 
-a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
-  a_proc_that_needs_dependents_row *data = (a_proc_that_needs_dependents_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (a_proc_we_need_result_set_ref _Nullable )data[row].a_foo;
-}
-
-a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
-  a_proc_that_needs_dependents_row *data = (a_proc_that_needs_dependents_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (a_proc_we_need_result_set_ref _Nullable )data[row].another_foo;
-}
-
 uint8_t a_proc_that_needs_dependents_data_types[a_proc_that_needs_dependents_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // a_foo
   CQL_DATA_TYPE_OBJECT, // another_foo
@@ -17226,16 +15430,6 @@ typedef struct simple_child_proc_row {
   cql_int32 y;
 } simple_child_proc_row;
 
-cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_child_proc_row *data = (simple_child_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_child_proc_row *data = (simple_child_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // y
@@ -17307,42 +15501,6 @@ END;
 static int32_t simple_container_proc_perf_index;
 
 cql_string_proc_name(simple_container_proc_stored_procedure_name, "simple_container_proc");
-
-cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a.is_null;
-}
-
-cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a.value;
-}
-
-extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
-}
-
-extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
-}
-
-cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-extern void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
-}
-
-simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (simple_child_proc_result_set_ref _Nullable )data[row].c;
-}
-
-extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
-}
 
 uint8_t simple_container_proc_data_types[simple_container_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // a
@@ -17633,51 +15791,6 @@ typedef struct use_generated_fragment_row {
   cql_blob_ref _Nullable storage;
 } use_generated_fragment_row;
 
-cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
-
 uint8_t use_generated_fragment_data_types[use_generated_fragment_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid
   CQL_DATA_TYPE_BOOL | CQL_DATA_TYPE_NOT_NULL, // flag
@@ -17787,51 +15900,6 @@ typedef struct use_backed_table_directly_row {
   cql_string_ref _Nullable name;
   cql_blob_ref _Nullable storage;
 } use_backed_table_directly_row;
-
-cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
 
 uint8_t use_backed_table_directly_data_types[use_backed_table_directly_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid
@@ -17999,51 +16067,6 @@ typedef struct use_backed_table_directly_in_with_select_row {
   cql_string_ref _Nullable name;
   cql_blob_ref _Nullable storage;
 } use_backed_table_directly_in_with_select_row;
-
-cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
 
 uint8_t use_backed_table_directly_in_with_select_data_types[use_backed_table_directly_in_with_select_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -282,18 +282,93 @@ extern cql_string_ref _Nonnull with_result_set_stored_procedure_name;
 
 #define with_result_set_data_types_count 5
 
+extern uint8_t with_result_set_data_types[with_result_set_data_types_count];
+
 #ifndef result_set_type_decl_with_result_set_result_set
 #define result_set_type_decl_with_result_set_result_set 1
 cql_result_set_type_decl(with_result_set_result_set, with_result_set_result_set_ref);
 #endif
-extern cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_result_set_get_id_inline_
+#define _with_result_set_get_id_inline_
+
+
+static inline cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_result_set_get_name_inline_
+#define _with_result_set_get_name_inline_
+
+
+static inline cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_result_set_get_rate_is_null_inline_
+#define _with_result_set_get_rate_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _with_result_set_get_rate_value_inline_
+#define _with_result_set_get_rate_value_inline_
+
+
+static inline cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _with_result_set_get_type_is_null_inline_
+#define _with_result_set_get_type_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _with_result_set_get_type_value_inline_
+#define _with_result_set_get_type_value_inline_
+
+
+static inline cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _with_result_set_get_size_is_null_inline_
+#define _with_result_set_get_size_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _with_result_set_get_size_value_inline_
+#define _with_result_set_get_size_value_inline_
+
+
+static inline cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 with_result_set_result_count(with_result_set_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_result_set_fetch_results(sqlite3 *_Nonnull _db_, with_result_set_result_set_ref _Nullable *_Nonnull result_set);
 #define with_result_set_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -311,13 +386,43 @@ extern cql_string_ref _Nonnull select_from_view_stored_procedure_name;
 
 #define select_from_view_data_types_count 2
 
+extern uint8_t select_from_view_data_types[select_from_view_data_types_count];
+
 #ifndef result_set_type_decl_select_from_view_result_set
 #define result_set_type_decl_select_from_view_result_set 1
 cql_result_set_type_decl(select_from_view_result_set, select_from_view_result_set_ref);
 #endif
-extern cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _select_from_view_get_id_inline_
+#define _select_from_view_get_id_inline_
+
+
+static inline cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _select_from_view_get_type_is_null_inline_
+#define _select_from_view_get_type_is_null_inline_
+
+
+static inline cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _select_from_view_get_type_value_inline_
+#define _select_from_view_get_type_value_inline_
+
+
+static inline cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 select_from_view_result_count(select_from_view_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code select_from_view_fetch_results(sqlite3 *_Nonnull _db_, select_from_view_result_set_ref _Nullable *_Nonnull result_set);
 #define select_from_view_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -341,18 +446,93 @@ extern cql_string_ref _Nonnull get_data_stored_procedure_name;
 
 #define get_data_data_types_count 5
 
+extern uint8_t get_data_data_types[get_data_data_types_count];
+
 #ifndef result_set_type_decl_get_data_result_set
 #define result_set_type_decl_get_data_result_set 1
 cql_result_set_type_decl(get_data_result_set, get_data_result_set_ref);
 #endif
-extern cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _get_data_get_id_inline_
+#define _get_data_get_id_inline_
+
+
+static inline cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _get_data_get_name_inline_
+#define _get_data_get_name_inline_
+
+
+static inline cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _get_data_get_rate_is_null_inline_
+#define _get_data_get_rate_is_null_inline_
+
+
+static inline cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _get_data_get_rate_value_inline_
+#define _get_data_get_rate_value_inline_
+
+
+static inline cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _get_data_get_type_is_null_inline_
+#define _get_data_get_type_is_null_inline_
+
+
+static inline cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _get_data_get_type_value_inline_
+#define _get_data_get_type_value_inline_
+
+
+static inline cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _get_data_get_size_is_null_inline_
+#define _get_data_get_size_is_null_inline_
+
+
+static inline cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _get_data_get_size_value_inline_
+#define _get_data_get_size_value_inline_
+
+
+static inline cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 get_data_result_count(get_data_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code get_data_fetch_results(sqlite3 *_Nonnull _db_, get_data_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull name_, cql_int32 id_);
 #define get_data_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -412,17 +592,83 @@ extern cql_string_ref _Nonnull complex_return_stored_procedure_name;
 
 #define complex_return_data_types_count 6
 
+extern uint8_t complex_return_data_types[complex_return_data_types_count];
+
 #ifndef result_set_type_decl_complex_return_result_set
 #define result_set_type_decl_complex_return_result_set 1
 cql_result_set_type_decl(complex_return_result_set, complex_return_result_set_ref);
 #endif
-extern cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _complex_return_get__bool_inline_
+#define _complex_return_get__bool_inline_
+
+
+static inline cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _complex_return_get__integer_inline_
+#define _complex_return_get__integer_inline_
+
+
+static inline cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _complex_return_get__longint_inline_
+#define _complex_return_get__longint_inline_
+
+
+static inline cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _complex_return_get__real_inline_
+#define _complex_return_get__real_inline_
+
+
+static inline cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _complex_return_get__text_inline_
+#define _complex_return_get__text_inline_
+
+
+static inline cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _complex_return_get__nullable_bool_is_null_inline_
+#define _complex_return_get__nullable_bool_is_null_inline_
+
+
+static inline cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _complex_return_get__nullable_bool_value_inline_
+#define _complex_return_get__nullable_bool_value_inline_
+
+
+static inline cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+
 extern cql_int32 complex_return_result_count(complex_return_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code complex_return_fetch_results(sqlite3 *_Nonnull _db_, complex_return_result_set_ref _Nullable *_Nonnull result_set);
 #define complex_return_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -440,11 +686,23 @@ extern cql_string_ref _Nonnull hierarchical_query_stored_procedure_name;
 
 #define hierarchical_query_data_types_count 1
 
+extern uint8_t hierarchical_query_data_types[hierarchical_query_data_types_count];
+
 #ifndef result_set_type_decl_hierarchical_query_result_set
 #define result_set_type_decl_hierarchical_query_result_set 1
 cql_result_set_type_decl(hierarchical_query_result_set, hierarchical_query_result_set_ref);
 #endif
-extern cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _hierarchical_query_get_id_inline_
+#define _hierarchical_query_get_id_inline_
+
+
+static inline cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 hierarchical_query_result_count(hierarchical_query_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code hierarchical_query_fetch_results(sqlite3 *_Nonnull _db_, hierarchical_query_result_set_ref _Nullable *_Nonnull result_set, cql_int64 rate_, cql_int32 limit_, cql_int32 offset_);
 #define hierarchical_query_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -462,11 +720,23 @@ extern cql_string_ref _Nonnull hierarchical_unmatched_query_stored_procedure_nam
 
 #define hierarchical_unmatched_query_data_types_count 1
 
+extern uint8_t hierarchical_unmatched_query_data_types[hierarchical_unmatched_query_data_types_count];
+
 #ifndef result_set_type_decl_hierarchical_unmatched_query_result_set
 #define result_set_type_decl_hierarchical_unmatched_query_result_set 1
 cql_result_set_type_decl(hierarchical_unmatched_query_result_set, hierarchical_unmatched_query_result_set_ref);
 #endif
-extern cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _hierarchical_unmatched_query_get_id_inline_
+#define _hierarchical_unmatched_query_get_id_inline_
+
+
+static inline cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 hierarchical_unmatched_query_result_count(hierarchical_unmatched_query_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code hierarchical_unmatched_query_fetch_results(sqlite3 *_Nonnull _db_, hierarchical_unmatched_query_result_set_ref _Nullable *_Nonnull result_set, cql_int64 rate_, cql_int32 limit_, cql_int32 offset_);
 #define hierarchical_unmatched_query_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -484,11 +754,23 @@ extern cql_string_ref _Nonnull union_select_stored_procedure_name;
 
 #define union_select_data_types_count 1
 
+extern uint8_t union_select_data_types[union_select_data_types_count];
+
 #ifndef result_set_type_decl_union_select_result_set
 #define result_set_type_decl_union_select_result_set 1
 cql_result_set_type_decl(union_select_result_set, union_select_result_set_ref);
 #endif
-extern cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_select_get_A_inline_
+#define _union_select_get_A_inline_
+
+
+static inline cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_select_result_count(union_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_select_fetch_results(sqlite3 *_Nonnull _db_, union_select_result_set_ref _Nullable *_Nonnull result_set);
 #define union_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -506,11 +788,23 @@ extern cql_string_ref _Nonnull union_all_select_stored_procedure_name;
 
 #define union_all_select_data_types_count 1
 
+extern uint8_t union_all_select_data_types[union_all_select_data_types_count];
+
 #ifndef result_set_type_decl_union_all_select_result_set
 #define result_set_type_decl_union_all_select_result_set 1
 cql_result_set_type_decl(union_all_select_result_set, union_all_select_result_set_ref);
 #endif
-extern cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_all_select_get_A_inline_
+#define _union_all_select_get_A_inline_
+
+
+static inline cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_all_select_result_count(union_all_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_all_select_fetch_results(sqlite3 *_Nonnull _db_, union_all_select_result_set_ref _Nullable *_Nonnull result_set);
 #define union_all_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -528,11 +822,23 @@ extern cql_string_ref _Nonnull union_all_with_nullable_stored_procedure_name;
 
 #define union_all_with_nullable_data_types_count 1
 
+extern uint8_t union_all_with_nullable_data_types[union_all_with_nullable_data_types_count];
+
 #ifndef result_set_type_decl_union_all_with_nullable_result_set
 #define result_set_type_decl_union_all_with_nullable_result_set 1
 cql_result_set_type_decl(union_all_with_nullable_result_set, union_all_with_nullable_result_set_ref);
 #endif
-extern cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_all_with_nullable_get_name_inline_
+#define _union_all_with_nullable_get_name_inline_
+
+
+static inline cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_all_with_nullable_result_count(union_all_with_nullable_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_all_with_nullable_fetch_results(sqlite3 *_Nonnull _db_, union_all_with_nullable_result_set_ref _Nullable *_Nonnull result_set);
 #define union_all_with_nullable_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -553,13 +859,43 @@ extern cql_string_ref _Nonnull with_stmt_stored_procedure_name;
 
 #define with_stmt_data_types_count 3
 
+extern uint8_t with_stmt_data_types[with_stmt_data_types_count];
+
 #ifndef result_set_type_decl_with_stmt_result_set
 #define result_set_type_decl_with_stmt_result_set 1
 cql_result_set_type_decl(with_stmt_result_set, with_stmt_result_set_ref);
 #endif
-extern cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_stmt_get_a_inline_
+#define _with_stmt_get_a_inline_
+
+
+static inline cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_stmt_get_b_inline_
+#define _with_stmt_get_b_inline_
+
+
+static inline cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_stmt_get_c_inline_
+#define _with_stmt_get_c_inline_
+
+
+static inline cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 with_stmt_result_count(with_stmt_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_stmt_fetch_results(sqlite3 *_Nonnull _db_, with_stmt_result_set_ref _Nullable *_Nonnull result_set);
 #define with_stmt_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -577,13 +913,43 @@ extern cql_string_ref _Nonnull with_recursive_stmt_stored_procedure_name;
 
 #define with_recursive_stmt_data_types_count 3
 
+extern uint8_t with_recursive_stmt_data_types[with_recursive_stmt_data_types_count];
+
 #ifndef result_set_type_decl_with_recursive_stmt_result_set
 #define result_set_type_decl_with_recursive_stmt_result_set 1
 cql_result_set_type_decl(with_recursive_stmt_result_set, with_recursive_stmt_result_set_ref);
 #endif
-extern cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_recursive_stmt_get_a_inline_
+#define _with_recursive_stmt_get_a_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_recursive_stmt_get_b_inline_
+#define _with_recursive_stmt_get_b_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_recursive_stmt_get_c_inline_
+#define _with_recursive_stmt_get_c_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 with_recursive_stmt_result_count(with_recursive_stmt_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_recursive_stmt_fetch_results(sqlite3 *_Nonnull _db_, with_recursive_stmt_result_set_ref _Nullable *_Nonnull result_set);
 #define with_recursive_stmt_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -601,13 +967,43 @@ extern cql_string_ref _Nonnull parent_proc_stored_procedure_name;
 
 #define parent_proc_data_types_count 3
 
+extern uint8_t parent_proc_data_types[parent_proc_data_types_count];
+
 #ifndef result_set_type_decl_parent_proc_result_set
 #define result_set_type_decl_parent_proc_result_set 1
 cql_result_set_type_decl(parent_proc_result_set, parent_proc_result_set_ref);
 #endif
-extern cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _parent_proc_get_one_inline_
+#define _parent_proc_get_one_inline_
+
+
+static inline cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _parent_proc_get_two_inline_
+#define _parent_proc_get_two_inline_
+
+
+static inline cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _parent_proc_get_three_inline_
+#define _parent_proc_get_three_inline_
+
+
+static inline cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 parent_proc_result_count(parent_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code parent_proc_fetch_results(sqlite3 *_Nonnull _db_, parent_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define parent_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -625,13 +1021,43 @@ extern cql_string_ref _Nonnull parent_proc_child_stored_procedure_name;
 
 #define parent_proc_child_data_types_count 3
 
+extern uint8_t parent_proc_child_data_types[parent_proc_child_data_types_count];
+
 #ifndef result_set_type_decl_parent_proc_child_result_set
 #define result_set_type_decl_parent_proc_child_result_set 1
 cql_result_set_type_decl(parent_proc_child_result_set, parent_proc_child_result_set_ref);
 #endif
-extern cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _parent_proc_child_get_four_inline_
+#define _parent_proc_child_get_four_inline_
+
+
+static inline cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _parent_proc_child_get_five_inline_
+#define _parent_proc_child_get_five_inline_
+
+
+static inline cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _parent_proc_child_get_six_inline_
+#define _parent_proc_child_get_six_inline_
+
+
+static inline cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 parent_proc_child_result_count(parent_proc_child_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code parent_proc_child_fetch_results(sqlite3 *_Nonnull _db_, parent_proc_child_result_set_ref _Nullable *_Nonnull result_set);
 #define parent_proc_child_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -698,11 +1124,23 @@ extern cql_string_ref _Nonnull cursor_with_object_stored_procedure_name;
 
 #define cursor_with_object_data_types_count 1
 
+extern uint8_t cursor_with_object_data_types[cursor_with_object_data_types_count];
+
 #ifndef result_set_type_decl_cursor_with_object_result_set
 #define result_set_type_decl_cursor_with_object_result_set 1
 cql_result_set_type_decl(cursor_with_object_result_set, cursor_with_object_result_set_ref);
 #endif
-extern cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set);
+#ifndef _cursor_with_object_get_object__inline_
+#define _cursor_with_object_get_object__inline_
+
+
+static inline cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 cursor_with_object_result_count(cursor_with_object_result_set_ref _Nonnull result_set);
 extern void cursor_with_object_fetch_results( cursor_with_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nullable object_);
 #define cursor_with_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -771,18 +1209,93 @@ extern cql_string_ref _Nonnull uses_proc_for_result_stored_procedure_name;
 
 #define uses_proc_for_result_data_types_count 5
 
+extern uint8_t uses_proc_for_result_data_types[uses_proc_for_result_data_types_count];
+
 #ifndef result_set_type_decl_uses_proc_for_result_result_set
 #define result_set_type_decl_uses_proc_for_result_result_set 1
 cql_result_set_type_decl(uses_proc_for_result_result_set, uses_proc_for_result_result_set_ref);
 #endif
-extern cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _uses_proc_for_result_get_id_inline_
+#define _uses_proc_for_result_get_id_inline_
+
+
+static inline cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_name_inline_
+#define _uses_proc_for_result_get_name_inline_
+
+
+static inline cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_rate_is_null_inline_
+#define _uses_proc_for_result_get_rate_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_rate_value_inline_
+#define _uses_proc_for_result_get_rate_value_inline_
+
+
+static inline cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_type_is_null_inline_
+#define _uses_proc_for_result_get_type_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_type_value_inline_
+#define _uses_proc_for_result_get_type_value_inline_
+
+
+static inline cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_size_is_null_inline_
+#define _uses_proc_for_result_get_size_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_size_value_inline_
+#define _uses_proc_for_result_get_size_value_inline_
+
+
+static inline cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 uses_proc_for_result_result_count(uses_proc_for_result_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code uses_proc_for_result_fetch_results(sqlite3 *_Nonnull _db_, uses_proc_for_result_result_set_ref _Nullable *_Nonnull result_set);
 #define uses_proc_for_result_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -889,13 +1402,43 @@ extern cql_string_ref _Nonnull blob_returner_stored_procedure_name;
 
 #define blob_returner_data_types_count 3
 
+extern uint8_t blob_returner_data_types[blob_returner_data_types_count];
+
 #ifndef result_set_type_decl_blob_returner_result_set
 #define result_set_type_decl_blob_returner_result_set 1
 cql_result_set_type_decl(blob_returner_result_set, blob_returner_result_set_ref);
 #endif
-extern cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _blob_returner_get_blob_id_inline_
+#define _blob_returner_get_blob_id_inline_
+
+
+static inline cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _blob_returner_get_b_notnull_inline_
+#define _blob_returner_get_b_notnull_inline_
+
+
+static inline cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _blob_returner_get_b_nullable_inline_
+#define _blob_returner_get_b_nullable_inline_
+
+
+static inline cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 blob_returner_result_count(blob_returner_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code blob_returner_fetch_results(sqlite3 *_Nonnull _db_, blob_returner_result_set_ref _Nullable *_Nonnull result_set);
 #define blob_returner_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -918,20 +1461,113 @@ extern cql_string_ref _Nonnull out_cursor_proc_stored_procedure_name;
 
 #define out_cursor_proc_data_types_count 7
 
+extern uint8_t out_cursor_proc_data_types[out_cursor_proc_data_types_count];
+
 #ifndef result_set_type_decl_out_cursor_proc_result_set
 #define result_set_type_decl_out_cursor_proc_result_set 1
 cql_result_set_type_decl(out_cursor_proc_result_set, out_cursor_proc_result_set_ref);
 #endif
-extern cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set);
+#ifndef _out_cursor_proc_get_id_inline_
+#define _out_cursor_proc_get_id_inline_
+
+
+static inline cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_name_inline_
+#define _out_cursor_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_rate_is_null_inline_
+#define _out_cursor_proc_get_rate_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_rate_value_inline_
+#define _out_cursor_proc_get_rate_value_inline_
+
+
+static inline cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_type_is_null_inline_
+#define _out_cursor_proc_get_type_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_type_value_inline_
+#define _out_cursor_proc_get_type_value_inline_
+
+
+static inline cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_size_is_null_inline_
+#define _out_cursor_proc_get_size_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_size_value_inline_
+#define _out_cursor_proc_get_size_value_inline_
+
+
+static inline cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_extra1_inline_
+#define _out_cursor_proc_get_extra1_inline_
+
+
+static inline cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_extra2_inline_
+#define _out_cursor_proc_get_extra2_inline_
+
+
+static inline cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
 extern cql_int32 out_cursor_proc_result_count(out_cursor_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code out_cursor_proc_fetch_results(sqlite3 *_Nonnull _db_, out_cursor_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define out_cursor_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -976,11 +1612,23 @@ extern cql_string_ref _Nonnull thread_theme_info_list_stored_procedure_name;
 
 #define thread_theme_info_list_data_types_count 1
 
+extern uint8_t thread_theme_info_list_data_types[thread_theme_info_list_data_types_count];
+
 #ifndef result_set_type_decl_thread_theme_info_list_result_set
 #define result_set_type_decl_thread_theme_info_list_result_set 1
 cql_result_set_type_decl(thread_theme_info_list_result_set, thread_theme_info_list_result_set_ref);
 #endif
-extern cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _thread_theme_info_list_get_thread_key_inline_
+#define _thread_theme_info_list_get_thread_key_inline_
+
+
+static inline cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 thread_theme_info_list_result_count(thread_theme_info_list_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code thread_theme_info_list_fetch_results(sqlite3 *_Nonnull _db_, thread_theme_info_list_result_set_ref _Nullable *_Nonnull result_set, cql_int64 thread_key_);
 #define thread_theme_info_list_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1013,12 +1661,33 @@ extern cql_string_ref _Nonnull out_no_db_stored_procedure_name;
 
 #define out_no_db_data_types_count 2
 
+extern uint8_t out_no_db_data_types[out_no_db_data_types_count];
+
 #ifndef result_set_type_decl_out_no_db_result_set
 #define result_set_type_decl_out_no_db_result_set 1
 cql_result_set_type_decl(out_no_db_result_set, out_no_db_result_set_ref);
 #endif
-extern cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set);
-extern cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set);
+#ifndef _out_no_db_get_A_inline_
+#define _out_no_db_get_A_inline_
+
+
+static inline cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_no_db_get_B_inline_
+#define _out_no_db_get_B_inline_
+
+
+static inline cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_no_db_result_count(out_no_db_result_set_ref _Nonnull result_set);
 extern void out_no_db_fetch_results( out_no_db_result_set_ref _Nullable *_Nonnull result_set);
 #define out_no_db_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1036,12 +1705,33 @@ extern cql_string_ref _Nonnull declare_cursor_like_cursor_stored_procedure_name;
 
 #define declare_cursor_like_cursor_data_types_count 2
 
+extern uint8_t declare_cursor_like_cursor_data_types[declare_cursor_like_cursor_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_cursor_result_set
 #define result_set_type_decl_declare_cursor_like_cursor_result_set 1
 cql_result_set_type_decl(declare_cursor_like_cursor_result_set, declare_cursor_like_cursor_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
-extern cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_cursor_get_A_inline_
+#define _declare_cursor_like_cursor_get_A_inline_
+
+
+static inline cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_cursor_get_B_inline_
+#define _declare_cursor_like_cursor_get_B_inline_
+
+
+static inline cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_cursor_result_count(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_cursor_fetch_results( declare_cursor_like_cursor_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_cursor_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1059,13 +1749,43 @@ extern cql_string_ref _Nonnull declare_cursor_like_proc_stored_procedure_name;
 
 #define declare_cursor_like_proc_data_types_count 2
 
+extern uint8_t declare_cursor_like_proc_data_types[declare_cursor_like_proc_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_proc_result_set
 #define result_set_type_decl_declare_cursor_like_proc_result_set 1
 cql_result_set_type_decl(declare_cursor_like_proc_result_set, declare_cursor_like_proc_result_set_ref);
 #endif
-extern cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_proc_get_a_is_null_inline_
+#define _declare_cursor_like_proc_get_a_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_proc_get_a_value_inline_
+#define _declare_cursor_like_proc_get_a_value_inline_
+
+
+static inline cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_proc_get_b_inline_
+#define _declare_cursor_like_proc_get_b_inline_
+
+
+static inline cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_proc_result_count(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_proc_fetch_results( declare_cursor_like_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1083,18 +1803,93 @@ extern cql_string_ref _Nonnull declare_cursor_like_table_stored_procedure_name;
 
 #define declare_cursor_like_table_data_types_count 5
 
+extern uint8_t declare_cursor_like_table_data_types[declare_cursor_like_table_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_table_result_set
 #define result_set_type_decl_declare_cursor_like_table_result_set 1
 cql_result_set_type_decl(declare_cursor_like_table_result_set, declare_cursor_like_table_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_table_get_id_inline_
+#define _declare_cursor_like_table_get_id_inline_
+
+
+static inline cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_name_inline_
+#define _declare_cursor_like_table_get_name_inline_
+
+
+static inline cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_rate_is_null_inline_
+#define _declare_cursor_like_table_get_rate_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_rate_value_inline_
+#define _declare_cursor_like_table_get_rate_value_inline_
+
+
+static inline cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_type_is_null_inline_
+#define _declare_cursor_like_table_get_type_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_type_value_inline_
+#define _declare_cursor_like_table_get_type_value_inline_
+
+
+static inline cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_size_is_null_inline_
+#define _declare_cursor_like_table_get_size_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_size_value_inline_
+#define _declare_cursor_like_table_get_size_value_inline_
+
+
+static inline cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_table_result_count(declare_cursor_like_table_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_table_fetch_results( declare_cursor_like_table_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_table_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1112,13 +1907,43 @@ extern cql_string_ref _Nonnull declare_cursor_like_view_stored_procedure_name;
 
 #define declare_cursor_like_view_data_types_count 3
 
+extern uint8_t declare_cursor_like_view_data_types[declare_cursor_like_view_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_view_result_set
 #define result_set_type_decl_declare_cursor_like_view_result_set 1
 cql_result_set_type_decl(declare_cursor_like_view_result_set, declare_cursor_like_view_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_view_get_f1_inline_
+#define _declare_cursor_like_view_get_f1_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_view_get_f2_inline_
+#define _declare_cursor_like_view_get_f2_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_view_get_f3_inline_
+#define _declare_cursor_like_view_get_f3_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_view_result_count(declare_cursor_like_view_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_view_fetch_results( declare_cursor_like_view_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_view_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1165,12 +1990,33 @@ extern cql_string_ref _Nonnull fetch_to_cursor_from_cursor_stored_procedure_name
 
 #define fetch_to_cursor_from_cursor_data_types_count 2
 
+extern uint8_t fetch_to_cursor_from_cursor_data_types[fetch_to_cursor_from_cursor_data_types_count];
+
 #ifndef result_set_type_decl_fetch_to_cursor_from_cursor_result_set
 #define result_set_type_decl_fetch_to_cursor_from_cursor_result_set 1
 cql_result_set_type_decl(fetch_to_cursor_from_cursor_result_set, fetch_to_cursor_from_cursor_result_set_ref);
 #endif
-extern cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
+#ifndef _fetch_to_cursor_from_cursor_get_A_inline_
+#define _fetch_to_cursor_from_cursor_get_A_inline_
+
+
+static inline cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _fetch_to_cursor_from_cursor_get_B_inline_
+#define _fetch_to_cursor_from_cursor_get_B_inline_
+
+
+static inline cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 fetch_to_cursor_from_cursor_result_count(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
 extern void fetch_to_cursor_from_cursor_fetch_results( fetch_to_cursor_from_cursor_result_set_ref _Nullable *_Nonnull result_set);
 #define fetch_to_cursor_from_cursor_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1205,11 +2051,23 @@ extern cql_string_ref _Nonnull out_union_helper_stored_procedure_name;
 
 #define out_union_helper_data_types_count 1
 
+extern uint8_t out_union_helper_data_types[out_union_helper_data_types_count];
+
 #ifndef result_set_type_decl_out_union_helper_result_set
 #define result_set_type_decl_out_union_helper_result_set 1
 cql_result_set_type_decl(out_union_helper_result_set, out_union_helper_result_set_ref);
 #endif
-extern cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_helper_get_x_inline_
+#define _out_union_helper_get_x_inline_
+
+
+static inline cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_union_helper_result_count(out_union_helper_result_set_ref _Nonnull result_set);
 #define out_union_helper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_helper_row_equal(rs1, row1, rs2, row2) \
@@ -1227,11 +2085,23 @@ extern cql_string_ref _Nonnull out_union_dml_helper_stored_procedure_name;
 
 #define out_union_dml_helper_data_types_count 1
 
+extern uint8_t out_union_dml_helper_data_types[out_union_dml_helper_data_types_count];
+
 #ifndef result_set_type_decl_out_union_dml_helper_result_set
 #define result_set_type_decl_out_union_dml_helper_result_set 1
 cql_result_set_type_decl(out_union_dml_helper_result_set, out_union_dml_helper_result_set_ref);
 #endif
-extern cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_dml_helper_get_x_inline_
+#define _out_union_dml_helper_get_x_inline_
+
+
+static inline cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_union_dml_helper_result_count(out_union_dml_helper_result_set_ref _Nonnull result_set);
 #define out_union_dml_helper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_dml_helper_row_equal(rs1, row1, rs2, row2) \
@@ -1252,11 +2122,23 @@ extern cql_string_ref _Nonnull forward_out_union_stored_procedure_name;
 
 #define forward_out_union_data_types_count 1
 
+extern uint8_t forward_out_union_data_types[forward_out_union_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_result_set
 #define result_set_type_decl_forward_out_union_result_set 1
 cql_result_set_type_decl(forward_out_union_result_set, forward_out_union_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_get_x_inline_
+#define _forward_out_union_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_result_count(forward_out_union_result_set_ref _Nonnull result_set);
 #define forward_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -1280,11 +2162,23 @@ extern cql_string_ref _Nonnull forward_out_union_extern_stored_procedure_name;
 
 #define forward_out_union_extern_data_types_count 1
 
+extern uint8_t forward_out_union_extern_data_types[forward_out_union_extern_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_extern_result_set
 #define result_set_type_decl_forward_out_union_extern_result_set 1
 cql_result_set_type_decl(forward_out_union_extern_result_set, forward_out_union_extern_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_extern_get_x_inline_
+#define _forward_out_union_extern_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_extern_result_count(forward_out_union_extern_result_set_ref _Nonnull result_set);
 #define forward_out_union_extern_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_extern_row_equal(rs1, row1, rs2, row2) \
@@ -1302,11 +2196,23 @@ extern cql_string_ref _Nonnull forward_out_union_dml_stored_procedure_name;
 
 #define forward_out_union_dml_data_types_count 1
 
+extern uint8_t forward_out_union_dml_data_types[forward_out_union_dml_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_dml_result_set
 #define result_set_type_decl_forward_out_union_dml_result_set 1
 cql_result_set_type_decl(forward_out_union_dml_result_set, forward_out_union_dml_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_dml_get_x_inline_
+#define _forward_out_union_dml_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_dml_result_count(forward_out_union_dml_result_set_ref _Nonnull result_set);
 #define forward_out_union_dml_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_dml_row_equal(rs1, row1, rs2, row2) \
@@ -1369,12 +2275,33 @@ extern cql_string_ref _Nonnull simple_identity_stored_procedure_name;
 
 #define simple_identity_data_types_count 2
 
+extern uint8_t simple_identity_data_types[simple_identity_data_types_count];
+
 #ifndef result_set_type_decl_simple_identity_result_set
 #define result_set_type_decl_simple_identity_result_set 1
 cql_result_set_type_decl(simple_identity_result_set, simple_identity_result_set_ref);
 #endif
-extern cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _simple_identity_get_id_inline_
+#define _simple_identity_get_id_inline_
+
+
+static inline cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_identity_get_data_inline_
+#define _simple_identity_get_data_inline_
+
+
+static inline cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_uint16 simple_identity_identity_columns[];
 
 extern cql_int32 simple_identity_result_count(simple_identity_result_set_ref _Nonnull result_set);
@@ -1400,13 +2327,43 @@ extern cql_string_ref _Nonnull complex_identity_stored_procedure_name;
 
 #define complex_identity_data_types_count 3
 
+extern uint8_t complex_identity_data_types[complex_identity_data_types_count];
+
 #ifndef result_set_type_decl_complex_identity_result_set
 #define result_set_type_decl_complex_identity_result_set 1
 cql_result_set_type_decl(complex_identity_result_set, complex_identity_result_set_ref);
 #endif
-extern cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _complex_identity_get_col1_inline_
+#define _complex_identity_get_col1_inline_
+
+
+static inline cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _complex_identity_get_col2_inline_
+#define _complex_identity_get_col2_inline_
+
+
+static inline cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _complex_identity_get_data_inline_
+#define _complex_identity_get_data_inline_
+
+
+static inline cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_uint16 complex_identity_identity_columns[];
 
 extern cql_int32 complex_identity_result_count(complex_identity_result_set_ref _Nonnull result_set);
@@ -1432,12 +2389,33 @@ extern cql_string_ref _Nonnull out_cursor_identity_stored_procedure_name;
 
 #define out_cursor_identity_data_types_count 2
 
+extern uint8_t out_cursor_identity_data_types[out_cursor_identity_data_types_count];
+
 #ifndef result_set_type_decl_out_cursor_identity_result_set
 #define result_set_type_decl_out_cursor_identity_result_set 1
 cql_result_set_type_decl(out_cursor_identity_result_set, out_cursor_identity_result_set_ref);
 #endif
-extern cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set);
-extern cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set);
+#ifndef _out_cursor_identity_get_id_inline_
+#define _out_cursor_identity_get_id_inline_
+
+
+static inline cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_cursor_identity_get_data_inline_
+#define _out_cursor_identity_get_data_inline_
+
+
+static inline cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_uint16 out_cursor_identity_identity_columns[];
 
 extern cql_int32 out_cursor_identity_result_count(out_cursor_identity_result_set_ref _Nonnull result_set);
@@ -1463,15 +2441,36 @@ extern cql_string_ref _Nonnull radioactive_proc_stored_procedure_name;
 
 #define radioactive_proc_data_types_count 2
 
+extern uint8_t radioactive_proc_data_types[radioactive_proc_data_types_count];
+
 #ifndef result_set_type_decl_radioactive_proc_result_set
 #define result_set_type_decl_radioactive_proc_result_set 1
 cql_result_set_type_decl(radioactive_proc_result_set, radioactive_proc_result_set_ref);
 #endif
-extern cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _radioactive_proc_get_id_inline_
+#define _radioactive_proc_get_id_inline_
+
+
+static inline cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _radioactive_proc_get_data_inline_
+#define _radioactive_proc_get_data_inline_
+
+
+static inline cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define radioactive_proc_get_data_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
+
 extern cql_int32 radioactive_proc_result_count(radioactive_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code radioactive_proc_fetch_results(sqlite3 *_Nonnull _db_, radioactive_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define radioactive_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1497,12 +2496,33 @@ extern cql_string_ref _Nonnull autodropper_stored_procedure_name;
 
 #define autodropper_data_types_count 2
 
+extern uint8_t autodropper_data_types[autodropper_data_types_count];
+
 #ifndef result_set_type_decl_autodropper_result_set
 #define result_set_type_decl_autodropper_result_set 1
 cql_result_set_type_decl(autodropper_result_set, autodropper_result_set_ref);
 #endif
-extern cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _autodropper_get_a_inline_
+#define _autodropper_get_a_inline_
+
+
+static inline cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _autodropper_get_b_inline_
+#define _autodropper_get_b_inline_
+
+
+static inline cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 autodropper_result_count(autodropper_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code autodropper_fetch_results(sqlite3 *_Nonnull _db_, autodropper_result_set_ref _Nullable *_Nonnull result_set);
 #define autodropper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1520,11 +2540,23 @@ extern cql_string_ref _Nonnull simple_cursor_proc_stored_procedure_name;
 
 #define simple_cursor_proc_data_types_count 1
 
+extern uint8_t simple_cursor_proc_data_types[simple_cursor_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_cursor_proc_result_set
 #define result_set_type_decl_simple_cursor_proc_result_set 1
 cql_result_set_type_decl(simple_cursor_proc_result_set, simple_cursor_proc_result_set_ref);
 #endif
-extern cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set);
+#ifndef _simple_cursor_proc_get_id_inline_
+#define _simple_cursor_proc_get_id_inline_
+
+
+static inline cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 simple_cursor_proc_result_count(simple_cursor_proc_result_set_ref _Nonnull result_set);
 extern void simple_cursor_proc_fetch_results( simple_cursor_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define simple_cursor_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1554,12 +2586,33 @@ extern cql_string_ref _Nonnull redundant_cast_stored_procedure_name;
 
 #define redundant_cast_data_types_count 2
 
+extern uint8_t redundant_cast_data_types[redundant_cast_data_types_count];
+
 #ifndef result_set_type_decl_redundant_cast_result_set
 #define result_set_type_decl_redundant_cast_result_set 1
 cql_result_set_type_decl(redundant_cast_result_set, redundant_cast_result_set_ref);
 #endif
-extern cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _redundant_cast_get_plugh_inline_
+#define _redundant_cast_get_plugh_inline_
+
+
+static inline cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _redundant_cast_get_five_inline_
+#define _redundant_cast_get_five_inline_
+
+
+static inline cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 redundant_cast_result_count(redundant_cast_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code redundant_cast_fetch_results(sqlite3 *_Nonnull _db_, redundant_cast_result_set_ref _Nullable *_Nonnull result_set);
 #define redundant_cast_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1585,12 +2638,33 @@ extern cql_string_ref _Nonnull top_level_select_alias_unused_stored_procedure_na
 
 #define top_level_select_alias_unused_data_types_count 2
 
+extern uint8_t top_level_select_alias_unused_data_types[top_level_select_alias_unused_data_types_count];
+
 #ifndef result_set_type_decl_top_level_select_alias_unused_result_set
 #define result_set_type_decl_top_level_select_alias_unused_result_set 1
 cql_result_set_type_decl(top_level_select_alias_unused_result_set, top_level_select_alias_unused_result_set_ref);
 #endif
-extern cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _top_level_select_alias_unused_get_id_inline_
+#define _top_level_select_alias_unused_get_id_inline_
+
+
+static inline cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _top_level_select_alias_unused_get_x_inline_
+#define _top_level_select_alias_unused_get_x_inline_
+
+
+static inline cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 top_level_select_alias_unused_result_count(top_level_select_alias_unused_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code top_level_select_alias_unused_fetch_results(sqlite3 *_Nonnull _db_, top_level_select_alias_unused_result_set_ref _Nullable *_Nonnull result_set);
 #define top_level_select_alias_unused_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1608,12 +2682,33 @@ extern cql_string_ref _Nonnull top_level_select_alias_used_in_orderby_stored_pro
 
 #define top_level_select_alias_used_in_orderby_data_types_count 2
 
+extern uint8_t top_level_select_alias_used_in_orderby_data_types[top_level_select_alias_used_in_orderby_data_types_count];
+
 #ifndef result_set_type_decl_top_level_select_alias_used_in_orderby_result_set
 #define result_set_type_decl_top_level_select_alias_used_in_orderby_result_set 1
 cql_result_set_type_decl(top_level_select_alias_used_in_orderby_result_set, top_level_select_alias_used_in_orderby_result_set_ref);
 #endif
-extern cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _top_level_select_alias_used_in_orderby_get_id_inline_
+#define _top_level_select_alias_used_in_orderby_get_id_inline_
+
+
+static inline cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _top_level_select_alias_used_in_orderby_get_x_inline_
+#define _top_level_select_alias_used_in_orderby_get_x_inline_
+
+
+static inline cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 top_level_select_alias_used_in_orderby_result_count(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code top_level_select_alias_used_in_orderby_fetch_results(sqlite3 *_Nonnull _db_, top_level_select_alias_used_in_orderby_result_set_ref _Nullable *_Nonnull result_set);
 #define top_level_select_alias_used_in_orderby_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1670,12 +2765,33 @@ extern cql_string_ref _Nonnull out_union_two_stored_procedure_name;
 
 #define out_union_two_data_types_count 2
 
+extern uint8_t out_union_two_data_types[out_union_two_data_types_count];
+
 #ifndef result_set_type_decl_out_union_two_result_set
 #define result_set_type_decl_out_union_two_result_set 1
 cql_result_set_type_decl(out_union_two_result_set, out_union_two_result_set_ref);
 #endif
-extern cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_two_get_x_inline_
+#define _out_union_two_get_x_inline_
+
+
+static inline cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_two_get_y_inline_
+#define _out_union_two_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_two_result_count(out_union_two_result_set_ref _Nonnull result_set);
 #define out_union_two_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_two_row_equal(rs1, row1, rs2, row2) \
@@ -1696,12 +2812,33 @@ extern cql_string_ref _Nonnull out_union_from_select_stored_procedure_name;
 
 #define out_union_from_select_data_types_count 2
 
+extern uint8_t out_union_from_select_data_types[out_union_from_select_data_types_count];
+
 #ifndef result_set_type_decl_out_union_from_select_result_set
 #define result_set_type_decl_out_union_from_select_result_set 1
 cql_result_set_type_decl(out_union_from_select_result_set, out_union_from_select_result_set_ref);
 #endif
-extern cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_from_select_get_x_inline_
+#define _out_union_from_select_get_x_inline_
+
+
+static inline cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_from_select_get_y_inline_
+#define _out_union_from_select_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_from_select_result_count(out_union_from_select_result_set_ref _Nonnull result_set);
 #define out_union_from_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_from_select_row_equal(rs1, row1, rs2, row2) \
@@ -1722,12 +2859,33 @@ extern cql_string_ref _Nonnull out_union_values_stored_procedure_name;
 
 #define out_union_values_data_types_count 2
 
+extern uint8_t out_union_values_data_types[out_union_values_data_types_count];
+
 #ifndef result_set_type_decl_out_union_values_result_set
 #define result_set_type_decl_out_union_values_result_set 1
 cql_result_set_type_decl(out_union_values_result_set, out_union_values_result_set_ref);
 #endif
-extern cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_values_get_x_inline_
+#define _out_union_values_get_x_inline_
+
+
+static inline cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_values_get_y_inline_
+#define _out_union_values_get_y_inline_
+
+
+static inline cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_values_result_count(out_union_values_result_set_ref _Nonnull result_set);
 #define out_union_values_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_values_row_equal(rs1, row1, rs2, row2) \
@@ -1748,15 +2906,36 @@ extern cql_string_ref _Nonnull out_union_dml_stored_procedure_name;
 
 #define out_union_dml_data_types_count 2
 
+extern uint8_t out_union_dml_data_types[out_union_dml_data_types_count];
+
 #ifndef result_set_type_decl_out_union_dml_result_set
 #define result_set_type_decl_out_union_dml_result_set 1
 cql_result_set_type_decl(out_union_dml_result_set, out_union_dml_result_set_ref);
 #endif
-extern cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_dml_get_id_inline_
+#define _out_union_dml_get_id_inline_
+
+
+static inline cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_dml_get_data_inline_
+#define _out_union_dml_get_data_inline_
+
+
+static inline cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define out_union_dml_get_data_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
+
 extern cql_int32 out_union_dml_result_count(out_union_dml_result_set_ref _Nonnull result_set);
 #define out_union_dml_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_dml_row_equal(rs1, row1, rs2, row2) \
@@ -1782,12 +2961,33 @@ extern cql_string_ref _Nonnull window_function_invocation_stored_procedure_name;
 
 #define window_function_invocation_data_types_count 2
 
+extern uint8_t window_function_invocation_data_types[window_function_invocation_data_types_count];
+
 #ifndef result_set_type_decl_window_function_invocation_result_set
 #define result_set_type_decl_window_function_invocation_result_set 1
 cql_result_set_type_decl(window_function_invocation_result_set, window_function_invocation_result_set_ref);
 #endif
-extern cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window_function_invocation_get_id_inline_
+#define _window_function_invocation_get_id_inline_
+
+
+static inline cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window_function_invocation_get_row_num_inline_
+#define _window_function_invocation_get_row_num_inline_
+
+
+static inline cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 window_function_invocation_result_count(window_function_invocation_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window_function_invocation_fetch_results(sqlite3 *_Nonnull _db_, window_function_invocation_result_set_ref _Nullable *_Nonnull result_set);
 #define window_function_invocation_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1820,11 +3020,23 @@ extern cql_string_ref _Nonnull use_return_stored_procedure_name;
 
 #define use_return_data_types_count 1
 
+extern uint8_t use_return_data_types[use_return_data_types_count];
+
 #ifndef result_set_type_decl_use_return_result_set
 #define result_set_type_decl_use_return_result_set 1
 cql_result_set_type_decl(use_return_result_set, use_return_result_set_ref);
 #endif
-extern cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_return_get_x_inline_
+#define _use_return_get_x_inline_
+
+
+static inline cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 use_return_result_count(use_return_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_return_fetch_results(sqlite3 *_Nonnull _db_, use_return_result_set_ref _Nullable *_Nonnull result_set);
 #define use_return_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1860,10 +3072,13 @@ extern cql_string_ref _Nonnull lotsa_columns_no_getters_stored_procedure_name;
 
 #define lotsa_columns_no_getters_data_types_count 5
 
+extern uint8_t lotsa_columns_no_getters_data_types[lotsa_columns_no_getters_data_types_count];
+
 #ifndef result_set_type_decl_lotsa_columns_no_getters_result_set
 #define result_set_type_decl_lotsa_columns_no_getters_result_set 1
 cql_result_set_type_decl(lotsa_columns_no_getters_result_set, lotsa_columns_no_getters_result_set_ref);
 #endif
+
 extern cql_int32 lotsa_columns_no_getters_result_count(lotsa_columns_no_getters_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code lotsa_columns_no_getters_fetch_results(sqlite3 *_Nonnull _db_, lotsa_columns_no_getters_result_set_ref _Nullable *_Nonnull result_set);
 #define lotsa_columns_no_getters_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1881,18 +3096,93 @@ extern cql_string_ref _Nonnull sproc_with_copy_stored_procedure_name;
 
 #define sproc_with_copy_data_types_count 5
 
+extern uint8_t sproc_with_copy_data_types[sproc_with_copy_data_types_count];
+
 #ifndef result_set_type_decl_sproc_with_copy_result_set
 #define result_set_type_decl_sproc_with_copy_result_set 1
 cql_result_set_type_decl(sproc_with_copy_result_set, sproc_with_copy_result_set_ref);
 #endif
-extern cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _sproc_with_copy_get_id_inline_
+#define _sproc_with_copy_get_id_inline_
+
+
+static inline cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_name_inline_
+#define _sproc_with_copy_get_name_inline_
+
+
+static inline cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_rate_is_null_inline_
+#define _sproc_with_copy_get_rate_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_rate_value_inline_
+#define _sproc_with_copy_get_rate_value_inline_
+
+
+static inline cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_type_is_null_inline_
+#define _sproc_with_copy_get_type_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_type_value_inline_
+#define _sproc_with_copy_get_type_value_inline_
+
+
+static inline cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_size_is_null_inline_
+#define _sproc_with_copy_get_size_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_size_value_inline_
+#define _sproc_with_copy_get_size_value_inline_
+
+
+static inline cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 sproc_with_copy_result_count(sproc_with_copy_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sproc_with_copy_fetch_results(sqlite3 *_Nonnull _db_, sproc_with_copy_result_set_ref _Nullable *_Nonnull result_set);
 #define sproc_with_copy_copy(result_set, result_set_to, from, count) \
@@ -1916,26 +3206,169 @@ extern cql_string_ref _Nonnull emit_object_with_setters_stored_procedure_name;
 
 #define emit_object_with_setters_data_types_count 8
 
+extern uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data_types_count];
+
 #ifndef result_set_type_decl_emit_object_with_setters_result_set
 #define result_set_type_decl_emit_object_with_setters_result_set 1
 cql_result_set_type_decl(emit_object_with_setters_result_set, emit_object_with_setters_result_set_ref);
 #endif
-extern cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value);
-extern cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value);
-extern cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value);
-extern cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value);
-extern cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value);
-extern cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value);
-extern cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value);
-extern cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value);
+#ifndef _emit_object_with_setters_get_o_inline_
+#define _emit_object_with_setters_get_o_inline_
+
+
+static inline cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_o_inline_
+#define _emit_object_with_setters_set_o_inline_
+
+static inline void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_x_inline_
+#define _emit_object_with_setters_get_x_inline_
+
+
+static inline cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_x_inline_
+#define _emit_object_with_setters_set_x_inline_
+
+static inline void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_i_inline_
+#define _emit_object_with_setters_get_i_inline_
+
+
+static inline cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_i_inline_
+#define _emit_object_with_setters_set_i_inline_
+
+static inline void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_l_inline_
+#define _emit_object_with_setters_get_l_inline_
+
+
+static inline cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_l_inline_
+#define _emit_object_with_setters_set_l_inline_
+
+static inline void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_b_inline_
+#define _emit_object_with_setters_get_b_inline_
+
+
+static inline cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_b_inline_
+#define _emit_object_with_setters_set_b_inline_
+
+static inline void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
+  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_d_inline_
+#define _emit_object_with_setters_get_d_inline_
+
+
+static inline cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_d_inline_
+#define _emit_object_with_setters_set_d_inline_
+
+static inline void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_t_inline_
+#define _emit_object_with_setters_get_t_inline_
+
+
+static inline cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_t_inline_
+#define _emit_object_with_setters_set_t_inline_
+
+static inline void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_bl_inline_
+#define _emit_object_with_setters_get_bl_inline_
+
+
+static inline cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_blob_col((cql_result_set_ref)result_set, 0, 7);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_bl_inline_
+#define _emit_object_with_setters_set_bl_inline_
+
+static inline void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+}
+
+#endif
+
 extern cql_int32 emit_object_with_setters_result_count(emit_object_with_setters_result_set_ref _Nonnull result_set);
 extern void emit_object_with_setters_fetch_results( emit_object_with_setters_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o, cql_object_ref _Nonnull x, cql_int32 i, cql_int64 l, cql_bool b, cql_double d, cql_string_ref _Nonnull t, cql_blob_ref _Nonnull bl);
 #define emit_object_with_setters_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1953,34 +3386,241 @@ extern cql_string_ref _Nonnull emit_setters_with_nullables_stored_procedure_name
 
 #define emit_setters_with_nullables_data_types_count 8
 
+extern uint8_t emit_setters_with_nullables_data_types[emit_setters_with_nullables_data_types_count];
+
 #ifndef result_set_type_decl_emit_setters_with_nullables_result_set
 #define result_set_type_decl_emit_setters_with_nullables_result_set 1
 cql_result_set_type_decl(emit_setters_with_nullables_result_set, emit_setters_with_nullables_result_set_ref);
 #endif
-extern cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value);
-extern cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value);
-extern cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value);
-extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value);
-extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value);
-extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value);
-extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value);
-extern cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value);
+#ifndef _emit_setters_with_nullables_get_o_inline_
+#define _emit_setters_with_nullables_get_o_inline_
+
+
+static inline cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_o_inline_
+#define _emit_setters_with_nullables_set_o_inline_
+
+static inline void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_x_inline_
+#define _emit_setters_with_nullables_get_x_inline_
+
+
+static inline cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_x_inline_
+#define _emit_setters_with_nullables_set_x_inline_
+
+static inline void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_i_is_null_inline_
+#define _emit_setters_with_nullables_get_i_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_i_value_inline_
+#define _emit_setters_with_nullables_get_i_value_inline_
+
+
+static inline cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_i_value_inline_
+#define _emit_setters_with_nullables_set_i_value_inline_
+
+static inline void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_i_to_null_inline_
+#define _emit_setters_with_nullables_set_i_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_l_is_null_inline_
+#define _emit_setters_with_nullables_get_l_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_l_value_inline_
+#define _emit_setters_with_nullables_get_l_value_inline_
+
+
+static inline cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_l_value_inline_
+#define _emit_setters_with_nullables_set_l_value_inline_
+
+static inline void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_l_to_null_inline_
+#define _emit_setters_with_nullables_set_l_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_b_is_null_inline_
+#define _emit_setters_with_nullables_get_b_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_b_value_inline_
+#define _emit_setters_with_nullables_get_b_value_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_b_value_inline_
+#define _emit_setters_with_nullables_set_b_value_inline_
+
+static inline void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
+  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_b_to_null_inline_
+#define _emit_setters_with_nullables_set_b_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_d_is_null_inline_
+#define _emit_setters_with_nullables_get_d_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_d_value_inline_
+#define _emit_setters_with_nullables_get_d_value_inline_
+
+
+static inline cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_d_value_inline_
+#define _emit_setters_with_nullables_set_d_value_inline_
+
+static inline void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_d_to_null_inline_
+#define _emit_setters_with_nullables_set_d_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_t_inline_
+#define _emit_setters_with_nullables_get_t_inline_
+
+
+static inline cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 6) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_t_inline_
+#define _emit_setters_with_nullables_set_t_inline_
+
+static inline void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_bl_inline_
+#define _emit_setters_with_nullables_get_bl_inline_
+
+
+static inline cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 7) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, 0, 7);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_bl_inline_
+#define _emit_setters_with_nullables_set_bl_inline_
+
+static inline void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
+  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+}
+
+#endif
+
 extern cql_int32 emit_setters_with_nullables_result_count(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
 extern void emit_setters_with_nullables_fetch_results( emit_setters_with_nullables_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nullable o, cql_object_ref _Nullable x, cql_nullable_int32 i, cql_nullable_int64 l, cql_nullable_bool b, cql_nullable_double d, cql_string_ref _Nullable t, cql_blob_ref _Nullable bl);
 #define emit_setters_with_nullables_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1998,26 +3638,165 @@ extern cql_string_ref _Nonnull no_out_with_setters_stored_procedure_name;
 
 #define no_out_with_setters_data_types_count 5
 
+extern uint8_t no_out_with_setters_data_types[no_out_with_setters_data_types_count];
+
 #ifndef result_set_type_decl_no_out_with_setters_result_set
 #define result_set_type_decl_no_out_with_setters_result_set 1
 cql_result_set_type_decl(no_out_with_setters_result_set, no_out_with_setters_result_set_ref);
 #endif
-extern cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value);
-extern cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value);
-extern void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value);
-extern void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _no_out_with_setters_get_id_inline_
+#define _no_out_with_setters_get_id_inline_
+
+
+static inline cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_id_inline_
+#define _no_out_with_setters_set_id_inline_
+
+static inline void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_name_inline_
+#define _no_out_with_setters_get_name_inline_
+
+
+static inline cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_name_inline_
+#define _no_out_with_setters_set_name_inline_
+
+static inline void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value) {
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, row, 1, new_value);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_rate_is_null_inline_
+#define _no_out_with_setters_get_rate_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_rate_value_inline_
+#define _no_out_with_setters_get_rate_value_inline_
+
+
+static inline cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_rate_value_inline_
+#define _no_out_with_setters_set_rate_value_inline_
+
+static inline void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, row, 2, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_rate_to_null_inline_
+#define _no_out_with_setters_set_rate_to_null_inline_
+
+static inline void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_type_is_null_inline_
+#define _no_out_with_setters_get_type_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_type_value_inline_
+#define _no_out_with_setters_get_type_value_inline_
+
+
+static inline cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_type_value_inline_
+#define _no_out_with_setters_set_type_value_inline_
+
+static inline void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 3, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_type_to_null_inline_
+#define _no_out_with_setters_set_type_to_null_inline_
+
+static inline void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_size_is_null_inline_
+#define _no_out_with_setters_get_size_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_size_value_inline_
+#define _no_out_with_setters_get_size_value_inline_
+
+
+static inline cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_size_value_inline_
+#define _no_out_with_setters_set_size_value_inline_
+
+static inline void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, row, 4, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_size_to_null_inline_
+#define _no_out_with_setters_set_size_to_null_inline_
+
+static inline void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
 extern cql_int32 no_out_with_setters_result_count(no_out_with_setters_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code no_out_with_setters_fetch_results(sqlite3 *_Nonnull _db_, no_out_with_setters_result_set_ref _Nullable *_Nonnull result_set);
 #define no_out_with_setters_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2040,21 +3819,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_values_proc_stored_procedure
 
 #define vault_sensitive_with_values_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_values_proc_data_types[vault_sensitive_with_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_values_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_values_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_values_proc_result_set, vault_sensitive_with_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_values_proc_get_id_inline_
+#define _vault_sensitive_with_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_name_inline_
+#define _vault_sensitive_with_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_values_proc_get_title_inline_
+#define _vault_sensitive_with_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_values_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_type_value_inline_
+#define _vault_sensitive_with_values_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_values_proc_result_count(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2074,20 +3901,59 @@ extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_sto
 
 #define vault_not_nullable_sensitive_with_values_proc_data_types_count 4
 
+extern uint8_t vault_not_nullable_sensitive_with_values_proc_data_types[vault_not_nullable_sensitive_with_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_not_nullable_sensitive_with_values_proc_result_set
 #define result_set_type_decl_vault_not_nullable_sensitive_with_values_proc_result_set 1
 cql_result_set_type_decl(vault_not_nullable_sensitive_with_values_proc_result_set, vault_not_nullable_sensitive_with_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_id_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_name_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_not_nullable_sensitive_with_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_title_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_type_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_type_inline_
+
+
+static inline cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_not_nullable_sensitive_with_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_not_nullable_sensitive_with_values_proc_result_count(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_not_nullable_sensitive_with_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_not_nullable_sensitive_with_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2107,21 +3973,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_no_values_proc_stored_proced
 
 #define vault_sensitive_with_no_values_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_no_values_proc_data_types[vault_sensitive_with_no_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_no_values_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_no_values_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_no_values_proc_result_set, vault_sensitive_with_no_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_values_proc_get_id_inline_
+#define _vault_sensitive_with_no_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_name_inline_
+#define _vault_sensitive_with_no_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_values_proc_get_title_inline_
+#define _vault_sensitive_with_no_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_no_values_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_type_value_inline_
+#define _vault_sensitive_with_no_values_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_no_values_proc_result_count(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_no_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_no_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_no_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2141,21 +4055,69 @@ extern cql_string_ref _Nonnull vault_union_all_table_proc_stored_procedure_name;
 
 #define vault_union_all_table_proc_data_types_count 4
 
+extern uint8_t vault_union_all_table_proc_data_types[vault_union_all_table_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_union_all_table_proc_result_set
 #define result_set_type_decl_vault_union_all_table_proc_result_set 1
 cql_result_set_type_decl(vault_union_all_table_proc_result_set, vault_union_all_table_proc_result_set_ref);
 #endif
-extern cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_union_all_table_proc_get_id_inline_
+#define _vault_union_all_table_proc_get_id_inline_
+
+
+static inline cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_name_inline_
+#define _vault_union_all_table_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_union_all_table_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_union_all_table_proc_get_title_inline_
+#define _vault_union_all_table_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_type_is_null_inline_
+#define _vault_union_all_table_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_type_value_inline_
+#define _vault_union_all_table_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_union_all_table_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_union_all_table_proc_result_count(vault_union_all_table_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_union_all_table_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_union_all_table_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_union_all_table_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2175,14 +4137,26 @@ extern cql_string_ref _Nonnull vault_alias_column_proc_stored_procedure_name;
 
 #define vault_alias_column_proc_data_types_count 1
 
+extern uint8_t vault_alias_column_proc_data_types[vault_alias_column_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_alias_column_proc_result_set
 #define result_set_type_decl_vault_alias_column_proc_result_set 1
 cql_result_set_type_decl(vault_alias_column_proc_result_set, vault_alias_column_proc_result_set_ref);
 #endif
-extern cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_alias_column_proc_get_alias_name_inline_
+#define _vault_alias_column_proc_get_alias_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
 
 #define vault_alias_column_proc_get_alias_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 0)
+
 extern cql_int32 vault_alias_column_proc_result_count(vault_alias_column_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_alias_column_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_alias_column_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_alias_column_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2202,14 +4176,26 @@ extern cql_string_ref _Nonnull vault_alias_column_name_proc_stored_procedure_nam
 
 #define vault_alias_column_name_proc_data_types_count 1
 
+extern uint8_t vault_alias_column_name_proc_data_types[vault_alias_column_name_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_alias_column_name_proc_result_set
 #define result_set_type_decl_vault_alias_column_name_proc_result_set 1
 cql_result_set_type_decl(vault_alias_column_name_proc_result_set, vault_alias_column_name_proc_result_set_ref);
 #endif
-extern cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_alias_column_name_proc_get_alias_name_inline_
+#define _vault_alias_column_name_proc_get_alias_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
 
 #define vault_alias_column_name_proc_get_alias_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 0)
+
 extern cql_int32 vault_alias_column_name_proc_result_count(vault_alias_column_name_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_alias_column_name_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_alias_column_name_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_alias_column_name_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2232,21 +4218,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_context_and_sensitive_column
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_context_and_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_context_and_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_context_and_sensitive_columns_proc_result_set, vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_result_count(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_context_and_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_context_and_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2266,21 +4300,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_no_context_and_sensitive_col
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set, vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_result_count(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_no_context_and_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2300,15 +4382,63 @@ extern cql_string_ref _Nonnull vault_sensitive_with_context_and_no_sensitive_col
 
 #define vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set, vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+
 extern cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_result_count(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_context_and_no_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_context_and_no_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2456,16 +4586,73 @@ extern cql_string_ref _Nonnull window1_stored_procedure_name;
 
 #define window1_data_types_count 3
 
+extern uint8_t window1_data_types[window1_data_types_count];
+
 #ifndef result_set_type_decl_window1_result_set
 #define result_set_type_decl_window1_result_set 1
 cql_result_set_type_decl(window1_result_set, window1_result_set_ref);
 #endif
-extern cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window1_get_month_is_null_inline_
+#define _window1_get_month_is_null_inline_
+
+
+static inline cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window1_get_month_value_inline_
+#define _window1_get_month_value_inline_
+
+
+static inline cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window1_get_amount_is_null_inline_
+#define _window1_get_amount_is_null_inline_
+
+
+static inline cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window1_get_amount_value_inline_
+#define _window1_get_amount_value_inline_
+
+
+static inline cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window1_get_SalesMovingAverage_is_null_inline_
+#define _window1_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window1_get_SalesMovingAverage_value_inline_
+#define _window1_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window1_result_count(window1_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window1_fetch_results(sqlite3 *_Nonnull _db_, window1_result_set_ref _Nullable *_Nonnull result_set);
 #define window1_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2483,16 +4670,73 @@ extern cql_string_ref _Nonnull window2_stored_procedure_name;
 
 #define window2_data_types_count 3
 
+extern uint8_t window2_data_types[window2_data_types_count];
+
 #ifndef result_set_type_decl_window2_result_set
 #define result_set_type_decl_window2_result_set 1
 cql_result_set_type_decl(window2_result_set, window2_result_set_ref);
 #endif
-extern cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window2_get_month_is_null_inline_
+#define _window2_get_month_is_null_inline_
+
+
+static inline cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window2_get_month_value_inline_
+#define _window2_get_month_value_inline_
+
+
+static inline cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window2_get_amount_is_null_inline_
+#define _window2_get_amount_is_null_inline_
+
+
+static inline cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window2_get_amount_value_inline_
+#define _window2_get_amount_value_inline_
+
+
+static inline cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window2_get_RunningTotal_is_null_inline_
+#define _window2_get_RunningTotal_is_null_inline_
+
+
+static inline cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window2_get_RunningTotal_value_inline_
+#define _window2_get_RunningTotal_value_inline_
+
+
+static inline cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window2_result_count(window2_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window2_fetch_results(sqlite3 *_Nonnull _db_, window2_result_set_ref _Nullable *_Nonnull result_set);
 #define window2_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2510,16 +4754,73 @@ extern cql_string_ref _Nonnull window3_stored_procedure_name;
 
 #define window3_data_types_count 3
 
+extern uint8_t window3_data_types[window3_data_types_count];
+
 #ifndef result_set_type_decl_window3_result_set
 #define result_set_type_decl_window3_result_set 1
 cql_result_set_type_decl(window3_result_set, window3_result_set_ref);
 #endif
-extern cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window3_get_month_is_null_inline_
+#define _window3_get_month_is_null_inline_
+
+
+static inline cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window3_get_month_value_inline_
+#define _window3_get_month_value_inline_
+
+
+static inline cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window3_get_amount_is_null_inline_
+#define _window3_get_amount_is_null_inline_
+
+
+static inline cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window3_get_amount_value_inline_
+#define _window3_get_amount_value_inline_
+
+
+static inline cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window3_get_SalesMovingAverage_is_null_inline_
+#define _window3_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window3_get_SalesMovingAverage_value_inline_
+#define _window3_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window3_result_count(window3_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window3_fetch_results(sqlite3 *_Nonnull _db_, window3_result_set_ref _Nullable *_Nonnull result_set);
 #define window3_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2537,16 +4838,73 @@ extern cql_string_ref _Nonnull window4_stored_procedure_name;
 
 #define window4_data_types_count 3
 
+extern uint8_t window4_data_types[window4_data_types_count];
+
 #ifndef result_set_type_decl_window4_result_set
 #define result_set_type_decl_window4_result_set 1
 cql_result_set_type_decl(window4_result_set, window4_result_set_ref);
 #endif
-extern cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window4_get_month_is_null_inline_
+#define _window4_get_month_is_null_inline_
+
+
+static inline cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window4_get_month_value_inline_
+#define _window4_get_month_value_inline_
+
+
+static inline cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window4_get_amount_is_null_inline_
+#define _window4_get_amount_is_null_inline_
+
+
+static inline cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window4_get_amount_value_inline_
+#define _window4_get_amount_value_inline_
+
+
+static inline cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window4_get_SalesMovingAverage_is_null_inline_
+#define _window4_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window4_get_SalesMovingAverage_value_inline_
+#define _window4_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window4_result_count(window4_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window4_fetch_results(sqlite3 *_Nonnull _db_, window4_result_set_ref _Nullable *_Nonnull result_set);
 #define window4_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2564,16 +4922,73 @@ extern cql_string_ref _Nonnull window5_stored_procedure_name;
 
 #define window5_data_types_count 3
 
+extern uint8_t window5_data_types[window5_data_types_count];
+
 #ifndef result_set_type_decl_window5_result_set
 #define result_set_type_decl_window5_result_set 1
 cql_result_set_type_decl(window5_result_set, window5_result_set_ref);
 #endif
-extern cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window5_get_month_is_null_inline_
+#define _window5_get_month_is_null_inline_
+
+
+static inline cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window5_get_month_value_inline_
+#define _window5_get_month_value_inline_
+
+
+static inline cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window5_get_amount_is_null_inline_
+#define _window5_get_amount_is_null_inline_
+
+
+static inline cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window5_get_amount_value_inline_
+#define _window5_get_amount_value_inline_
+
+
+static inline cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window5_get_SalesMovingAverage_is_null_inline_
+#define _window5_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window5_get_SalesMovingAverage_value_inline_
+#define _window5_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window5_result_count(window5_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window5_fetch_results(sqlite3 *_Nonnull _db_, window5_result_set_ref _Nullable *_Nonnull result_set);
 #define window5_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2591,16 +5006,73 @@ extern cql_string_ref _Nonnull window6_stored_procedure_name;
 
 #define window6_data_types_count 3
 
+extern uint8_t window6_data_types[window6_data_types_count];
+
 #ifndef result_set_type_decl_window6_result_set
 #define result_set_type_decl_window6_result_set 1
 cql_result_set_type_decl(window6_result_set, window6_result_set_ref);
 #endif
-extern cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window6_get_month_is_null_inline_
+#define _window6_get_month_is_null_inline_
+
+
+static inline cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window6_get_month_value_inline_
+#define _window6_get_month_value_inline_
+
+
+static inline cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window6_get_amount_is_null_inline_
+#define _window6_get_amount_is_null_inline_
+
+
+static inline cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window6_get_amount_value_inline_
+#define _window6_get_amount_value_inline_
+
+
+static inline cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window6_get_SalesMovingAverage_is_null_inline_
+#define _window6_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window6_get_SalesMovingAverage_value_inline_
+#define _window6_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window6_result_count(window6_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window6_fetch_results(sqlite3 *_Nonnull _db_, window6_result_set_ref _Nullable *_Nonnull result_set);
 #define window6_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2618,16 +5090,73 @@ extern cql_string_ref _Nonnull window7_stored_procedure_name;
 
 #define window7_data_types_count 3
 
+extern uint8_t window7_data_types[window7_data_types_count];
+
 #ifndef result_set_type_decl_window7_result_set
 #define result_set_type_decl_window7_result_set 1
 cql_result_set_type_decl(window7_result_set, window7_result_set_ref);
 #endif
-extern cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window7_get_month_is_null_inline_
+#define _window7_get_month_is_null_inline_
+
+
+static inline cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window7_get_month_value_inline_
+#define _window7_get_month_value_inline_
+
+
+static inline cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window7_get_amount_is_null_inline_
+#define _window7_get_amount_is_null_inline_
+
+
+static inline cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window7_get_amount_value_inline_
+#define _window7_get_amount_value_inline_
+
+
+static inline cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window7_get_SalesMovingAverage_is_null_inline_
+#define _window7_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window7_get_SalesMovingAverage_value_inline_
+#define _window7_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window7_result_count(window7_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window7_fetch_results(sqlite3 *_Nonnull _db_, window7_result_set_ref _Nullable *_Nonnull result_set);
 #define window7_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2645,16 +5174,73 @@ extern cql_string_ref _Nonnull window8_stored_procedure_name;
 
 #define window8_data_types_count 3
 
+extern uint8_t window8_data_types[window8_data_types_count];
+
 #ifndef result_set_type_decl_window8_result_set
 #define result_set_type_decl_window8_result_set 1
 cql_result_set_type_decl(window8_result_set, window8_result_set_ref);
 #endif
-extern cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window8_get_month_is_null_inline_
+#define _window8_get_month_is_null_inline_
+
+
+static inline cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window8_get_month_value_inline_
+#define _window8_get_month_value_inline_
+
+
+static inline cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window8_get_amount_is_null_inline_
+#define _window8_get_amount_is_null_inline_
+
+
+static inline cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window8_get_amount_value_inline_
+#define _window8_get_amount_value_inline_
+
+
+static inline cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window8_get_SalesMovingAverage_is_null_inline_
+#define _window8_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window8_get_SalesMovingAverage_value_inline_
+#define _window8_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window8_result_count(window8_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window8_fetch_results(sqlite3 *_Nonnull _db_, window8_result_set_ref _Nullable *_Nonnull result_set);
 #define window8_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2672,16 +5258,73 @@ extern cql_string_ref _Nonnull window9_stored_procedure_name;
 
 #define window9_data_types_count 3
 
+extern uint8_t window9_data_types[window9_data_types_count];
+
 #ifndef result_set_type_decl_window9_result_set
 #define result_set_type_decl_window9_result_set 1
 cql_result_set_type_decl(window9_result_set, window9_result_set_ref);
 #endif
-extern cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window9_get_month_is_null_inline_
+#define _window9_get_month_is_null_inline_
+
+
+static inline cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window9_get_month_value_inline_
+#define _window9_get_month_value_inline_
+
+
+static inline cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window9_get_amount_is_null_inline_
+#define _window9_get_amount_is_null_inline_
+
+
+static inline cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window9_get_amount_value_inline_
+#define _window9_get_amount_value_inline_
+
+
+static inline cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window9_get_SalesMovingAverage_is_null_inline_
+#define _window9_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window9_get_SalesMovingAverage_value_inline_
+#define _window9_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window9_result_count(window9_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window9_fetch_results(sqlite3 *_Nonnull _db_, window9_result_set_ref _Nullable *_Nonnull result_set);
 #define window9_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2699,16 +5342,73 @@ extern cql_string_ref _Nonnull window10_stored_procedure_name;
 
 #define window10_data_types_count 3
 
+extern uint8_t window10_data_types[window10_data_types_count];
+
 #ifndef result_set_type_decl_window10_result_set
 #define result_set_type_decl_window10_result_set 1
 cql_result_set_type_decl(window10_result_set, window10_result_set_ref);
 #endif
-extern cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window10_get_month_is_null_inline_
+#define _window10_get_month_is_null_inline_
+
+
+static inline cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window10_get_month_value_inline_
+#define _window10_get_month_value_inline_
+
+
+static inline cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window10_get_amount_is_null_inline_
+#define _window10_get_amount_is_null_inline_
+
+
+static inline cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window10_get_amount_value_inline_
+#define _window10_get_amount_value_inline_
+
+
+static inline cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window10_get_SalesMovingAverage_is_null_inline_
+#define _window10_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window10_get_SalesMovingAverage_value_inline_
+#define _window10_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window10_result_count(window10_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window10_fetch_results(sqlite3 *_Nonnull _db_, window10_result_set_ref _Nullable *_Nonnull result_set);
 #define window10_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2726,16 +5426,73 @@ extern cql_string_ref _Nonnull window11_stored_procedure_name;
 
 #define window11_data_types_count 3
 
+extern uint8_t window11_data_types[window11_data_types_count];
+
 #ifndef result_set_type_decl_window11_result_set
 #define result_set_type_decl_window11_result_set 1
 cql_result_set_type_decl(window11_result_set, window11_result_set_ref);
 #endif
-extern cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window11_get_month_is_null_inline_
+#define _window11_get_month_is_null_inline_
+
+
+static inline cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window11_get_month_value_inline_
+#define _window11_get_month_value_inline_
+
+
+static inline cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window11_get_amount_is_null_inline_
+#define _window11_get_amount_is_null_inline_
+
+
+static inline cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window11_get_amount_value_inline_
+#define _window11_get_amount_value_inline_
+
+
+static inline cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window11_get_SalesMovingAverage_is_null_inline_
+#define _window11_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window11_get_SalesMovingAverage_value_inline_
+#define _window11_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window11_result_count(window11_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window11_fetch_results(sqlite3 *_Nonnull _db_, window11_result_set_ref _Nullable *_Nonnull result_set);
 #define window11_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2753,16 +5510,73 @@ extern cql_string_ref _Nonnull window12_stored_procedure_name;
 
 #define window12_data_types_count 3
 
+extern uint8_t window12_data_types[window12_data_types_count];
+
 #ifndef result_set_type_decl_window12_result_set
 #define result_set_type_decl_window12_result_set 1
 cql_result_set_type_decl(window12_result_set, window12_result_set_ref);
 #endif
-extern cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window12_get_month_is_null_inline_
+#define _window12_get_month_is_null_inline_
+
+
+static inline cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window12_get_month_value_inline_
+#define _window12_get_month_value_inline_
+
+
+static inline cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window12_get_amount_is_null_inline_
+#define _window12_get_amount_is_null_inline_
+
+
+static inline cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window12_get_amount_value_inline_
+#define _window12_get_amount_value_inline_
+
+
+static inline cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window12_get_SalesMovingAverage_is_null_inline_
+#define _window12_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window12_get_SalesMovingAverage_value_inline_
+#define _window12_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window12_result_count(window12_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window12_fetch_results(sqlite3 *_Nonnull _db_, window12_result_set_ref _Nullable *_Nonnull result_set);
 #define window12_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2780,16 +5594,73 @@ extern cql_string_ref _Nonnull window13_stored_procedure_name;
 
 #define window13_data_types_count 3
 
+extern uint8_t window13_data_types[window13_data_types_count];
+
 #ifndef result_set_type_decl_window13_result_set
 #define result_set_type_decl_window13_result_set 1
 cql_result_set_type_decl(window13_result_set, window13_result_set_ref);
 #endif
-extern cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window13_get_month_is_null_inline_
+#define _window13_get_month_is_null_inline_
+
+
+static inline cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window13_get_month_value_inline_
+#define _window13_get_month_value_inline_
+
+
+static inline cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window13_get_amount_is_null_inline_
+#define _window13_get_amount_is_null_inline_
+
+
+static inline cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window13_get_amount_value_inline_
+#define _window13_get_amount_value_inline_
+
+
+static inline cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window13_get_SalesMovingAverage_is_null_inline_
+#define _window13_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window13_get_SalesMovingAverage_value_inline_
+#define _window13_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window13_result_count(window13_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window13_fetch_results(sqlite3 *_Nonnull _db_, window13_result_set_ref _Nullable *_Nonnull result_set);
 #define window13_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2807,16 +5678,73 @@ extern cql_string_ref _Nonnull window14_stored_procedure_name;
 
 #define window14_data_types_count 3
 
+extern uint8_t window14_data_types[window14_data_types_count];
+
 #ifndef result_set_type_decl_window14_result_set
 #define result_set_type_decl_window14_result_set 1
 cql_result_set_type_decl(window14_result_set, window14_result_set_ref);
 #endif
-extern cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window14_get_month_is_null_inline_
+#define _window14_get_month_is_null_inline_
+
+
+static inline cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window14_get_month_value_inline_
+#define _window14_get_month_value_inline_
+
+
+static inline cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window14_get_amount_is_null_inline_
+#define _window14_get_amount_is_null_inline_
+
+
+static inline cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window14_get_amount_value_inline_
+#define _window14_get_amount_value_inline_
+
+
+static inline cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window14_get_SalesMovingAverage_is_null_inline_
+#define _window14_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window14_get_SalesMovingAverage_value_inline_
+#define _window14_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window14_result_count(window14_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window14_fetch_results(sqlite3 *_Nonnull _db_, window14_result_set_ref _Nullable *_Nonnull result_set);
 #define window14_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2834,16 +5762,73 @@ extern cql_string_ref _Nonnull window15_stored_procedure_name;
 
 #define window15_data_types_count 3
 
+extern uint8_t window15_data_types[window15_data_types_count];
+
 #ifndef result_set_type_decl_window15_result_set
 #define result_set_type_decl_window15_result_set 1
 cql_result_set_type_decl(window15_result_set, window15_result_set_ref);
 #endif
-extern cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window15_get_month_is_null_inline_
+#define _window15_get_month_is_null_inline_
+
+
+static inline cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window15_get_month_value_inline_
+#define _window15_get_month_value_inline_
+
+
+static inline cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window15_get_amount_is_null_inline_
+#define _window15_get_amount_is_null_inline_
+
+
+static inline cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window15_get_amount_value_inline_
+#define _window15_get_amount_value_inline_
+
+
+static inline cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window15_get_SalesMovingAverage_is_null_inline_
+#define _window15_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window15_get_SalesMovingAverage_value_inline_
+#define _window15_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window15_result_count(window15_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window15_fetch_results(sqlite3 *_Nonnull _db_, window15_result_set_ref _Nullable *_Nonnull result_set);
 #define window15_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2861,16 +5846,73 @@ extern cql_string_ref _Nonnull window16_stored_procedure_name;
 
 #define window16_data_types_count 3
 
+extern uint8_t window16_data_types[window16_data_types_count];
+
 #ifndef result_set_type_decl_window16_result_set
 #define result_set_type_decl_window16_result_set 1
 cql_result_set_type_decl(window16_result_set, window16_result_set_ref);
 #endif
-extern cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window16_get_month_is_null_inline_
+#define _window16_get_month_is_null_inline_
+
+
+static inline cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window16_get_month_value_inline_
+#define _window16_get_month_value_inline_
+
+
+static inline cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window16_get_amount_is_null_inline_
+#define _window16_get_amount_is_null_inline_
+
+
+static inline cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window16_get_amount_value_inline_
+#define _window16_get_amount_value_inline_
+
+
+static inline cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window16_get_SalesMovingAverage_is_null_inline_
+#define _window16_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window16_get_SalesMovingAverage_value_inline_
+#define _window16_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window16_result_count(window16_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window16_fetch_results(sqlite3 *_Nonnull _db_, window16_result_set_ref _Nullable *_Nonnull result_set);
 #define window16_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2971,14 +6013,53 @@ extern cql_string_ref _Nonnull virtual1_stored_procedure_name;
 
 #define virtual1_data_types_count 3
 
+extern uint8_t virtual1_data_types[virtual1_data_types_count];
+
 #ifndef result_set_type_decl_virtual1_result_set
 #define result_set_type_decl_virtual1_result_set 1
 cql_result_set_type_decl(virtual1_result_set, virtual1_result_set_ref);
 #endif
-extern cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _virtual1_get_vx_inline_
+#define _virtual1_get_vx_inline_
+
+
+static inline cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _virtual1_get_vy_is_null_inline_
+#define _virtual1_get_vy_is_null_inline_
+
+
+static inline cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual1_get_vy_value_inline_
+#define _virtual1_get_vy_value_inline_
+
+
+static inline cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual1_get_vz_inline_
+#define _virtual1_get_vz_inline_
+
+
+static inline cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 virtual1_result_count(virtual1_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code virtual1_fetch_results(sqlite3 *_Nonnull _db_, virtual1_result_set_ref _Nullable *_Nonnull result_set);
 #define virtual1_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2996,14 +6077,53 @@ extern cql_string_ref _Nonnull virtual2_stored_procedure_name;
 
 #define virtual2_data_types_count 3
 
+extern uint8_t virtual2_data_types[virtual2_data_types_count];
+
 #ifndef result_set_type_decl_virtual2_result_set
 #define result_set_type_decl_virtual2_result_set 1
 cql_result_set_type_decl(virtual2_result_set, virtual2_result_set_ref);
 #endif
-extern cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _virtual2_get_vx_inline_
+#define _virtual2_get_vx_inline_
+
+
+static inline cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _virtual2_get_vy_is_null_inline_
+#define _virtual2_get_vy_is_null_inline_
+
+
+static inline cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual2_get_vy_value_inline_
+#define _virtual2_get_vy_value_inline_
+
+
+static inline cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual2_get_vz_inline_
+#define _virtual2_get_vz_inline_
+
+
+static inline cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 virtual2_result_count(virtual2_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code virtual2_fetch_results(sqlite3 *_Nonnull _db_, virtual2_result_set_ref _Nullable *_Nonnull result_set);
 #define virtual2_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3038,10 +6158,13 @@ extern cql_string_ref _Nonnull private_out_union_stored_procedure_name;
 
 #define private_out_union_data_types_count 1
 
+extern uint8_t private_out_union_data_types[private_out_union_data_types_count];
+
 #ifndef result_set_type_decl_private_out_union_result_set
 #define result_set_type_decl_private_out_union_result_set 1
 cql_result_set_type_decl(private_out_union_result_set, private_out_union_result_set_ref);
 #endif
+
 extern cql_int32 private_out_union_result_count(private_out_union_result_set_ref _Nonnull result_set);
 #define private_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define private_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3065,10 +6188,13 @@ extern cql_string_ref _Nonnull no_getters_out_union_stored_procedure_name;
 
 #define no_getters_out_union_data_types_count 1
 
+extern uint8_t no_getters_out_union_data_types[no_getters_out_union_data_types_count];
+
 #ifndef result_set_type_decl_no_getters_out_union_result_set
 #define result_set_type_decl_no_getters_out_union_result_set 1
 cql_result_set_type_decl(no_getters_out_union_result_set, no_getters_out_union_result_set_ref);
 #endif
+
 extern cql_int32 no_getters_out_union_result_count(no_getters_out_union_result_set_ref _Nonnull result_set);
 #define no_getters_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define no_getters_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3089,10 +6215,13 @@ extern cql_string_ref _Nonnull suppress_results_out_union_stored_procedure_name;
 
 #define suppress_results_out_union_data_types_count 1
 
+extern uint8_t suppress_results_out_union_data_types[suppress_results_out_union_data_types_count];
+
 #ifndef result_set_type_decl_suppress_results_out_union_result_set
 #define result_set_type_decl_suppress_results_out_union_result_set 1
 cql_result_set_type_decl(suppress_results_out_union_result_set, suppress_results_out_union_result_set_ref);
 #endif
+
 extern cql_int32 suppress_results_out_union_result_count(suppress_results_out_union_result_set_ref _Nonnull result_set);
 #define suppress_results_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define suppress_results_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3164,11 +6293,23 @@ extern cql_string_ref _Nonnull out_object_stored_procedure_name;
 
 #define out_object_data_types_count 1
 
+extern uint8_t out_object_data_types[out_object_data_types_count];
+
 #ifndef result_set_type_decl_out_object_result_set
 #define result_set_type_decl_out_object_result_set 1
 cql_result_set_type_decl(out_object_result_set, out_object_result_set_ref);
 #endif
-extern cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set);
+#ifndef _out_object_get_o_inline_
+#define _out_object_get_o_inline_
+
+
+static inline cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set);
 extern void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o);
 #define out_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3195,18 +6336,93 @@ extern cql_string_ref _Nonnull result_set_proc_with_contract_in_fetch_results_st
 
 #define result_set_proc_with_contract_in_fetch_results_data_types_count 5
 
+extern uint8_t result_set_proc_with_contract_in_fetch_results_data_types[result_set_proc_with_contract_in_fetch_results_data_types_count];
+
 #ifndef result_set_type_decl_result_set_proc_with_contract_in_fetch_results_result_set
 #define result_set_type_decl_result_set_proc_with_contract_in_fetch_results_result_set 1
 cql_result_set_type_decl(result_set_proc_with_contract_in_fetch_results_result_set, result_set_proc_with_contract_in_fetch_results_result_set_ref);
 #endif
-extern cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_id_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_id_inline_
+
+
+static inline cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_name_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_name_inline_
+
+
+static inline cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_rate_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_rate_value_inline_
+
+
+static inline cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_type_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_type_value_inline_
+
+
+static inline cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_size_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_size_value_inline_
+
+
+static inline cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 result_set_proc_with_contract_in_fetch_results_result_count(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code result_set_proc_with_contract_in_fetch_results_fetch_results(sqlite3 *_Nonnull _db_, result_set_proc_with_contract_in_fetch_results_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull t);
 #define result_set_proc_with_contract_in_fetch_results_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3224,18 +6440,93 @@ extern cql_string_ref _Nonnull out_proc_with_contract_in_fetch_results_stored_pr
 
 #define out_proc_with_contract_in_fetch_results_data_types_count 5
 
+extern uint8_t out_proc_with_contract_in_fetch_results_data_types[out_proc_with_contract_in_fetch_results_data_types_count];
+
 #ifndef result_set_type_decl_out_proc_with_contract_in_fetch_results_result_set
 #define result_set_type_decl_out_proc_with_contract_in_fetch_results_result_set 1
 cql_result_set_type_decl(out_proc_with_contract_in_fetch_results_result_set, out_proc_with_contract_in_fetch_results_result_set_ref);
 #endif
-extern cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
+#ifndef _out_proc_with_contract_in_fetch_results_get_id_inline_
+#define _out_proc_with_contract_in_fetch_results_get_id_inline_
+
+
+static inline cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_name_inline_
+#define _out_proc_with_contract_in_fetch_results_get_name_inline_
+
+
+static inline cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_rate_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_rate_value_inline_
+
+
+static inline cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_type_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_type_value_inline_
+
+
+static inline cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_size_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_size_value_inline_
+
+
+static inline cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
 extern cql_int32 out_proc_with_contract_in_fetch_results_result_count(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
 extern void out_proc_with_contract_in_fetch_results_fetch_results( out_proc_with_contract_in_fetch_results_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull t);
 #define out_proc_with_contract_in_fetch_results_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3253,11 +6544,23 @@ extern cql_string_ref _Nonnull nullability_improvements_are_erased_for_sql_store
 
 #define nullability_improvements_are_erased_for_sql_data_types_count 1
 
+extern uint8_t nullability_improvements_are_erased_for_sql_data_types[nullability_improvements_are_erased_for_sql_data_types_count];
+
 #ifndef result_set_type_decl_nullability_improvements_are_erased_for_sql_result_set
 #define result_set_type_decl_nullability_improvements_are_erased_for_sql_result_set 1
 cql_result_set_type_decl(nullability_improvements_are_erased_for_sql_result_set, nullability_improvements_are_erased_for_sql_result_set_ref);
 #endif
-extern cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _nullability_improvements_are_erased_for_sql_get_b_inline_
+#define _nullability_improvements_are_erased_for_sql_get_b_inline_
+
+
+static inline cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 nullability_improvements_are_erased_for_sql_result_count(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code nullability_improvements_are_erased_for_sql_fetch_results(sqlite3 *_Nonnull _db_, nullability_improvements_are_erased_for_sql_result_set_ref _Nullable *_Nonnull result_set);
 #define nullability_improvements_are_erased_for_sql_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3357,11 +6660,23 @@ extern cql_string_ref _Nonnull sensitive_function_is_a_no_op_stored_procedure_na
 
 #define sensitive_function_is_a_no_op_data_types_count 1
 
+extern uint8_t sensitive_function_is_a_no_op_data_types[sensitive_function_is_a_no_op_data_types_count];
+
 #ifndef result_set_type_decl_sensitive_function_is_a_no_op_result_set
 #define result_set_type_decl_sensitive_function_is_a_no_op_result_set 1
 cql_result_set_type_decl(sensitive_function_is_a_no_op_result_set, sensitive_function_is_a_no_op_result_set_ref);
 #endif
-extern cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _sensitive_function_is_a_no_op_get_y_inline_
+#define _sensitive_function_is_a_no_op_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 sensitive_function_is_a_no_op_result_count(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sensitive_function_is_a_no_op_fetch_results(sqlite3 *_Nonnull _db_, sensitive_function_is_a_no_op_result_set_ref _Nullable *_Nonnull result_set);
 #define sensitive_function_is_a_no_op_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3390,11 +6705,23 @@ extern cql_string_ref _Nonnull foo_stored_procedure_name;
 
 #define foo_data_types_count 1
 
+extern uint8_t foo_data_types[foo_data_types_count];
+
 #ifndef result_set_type_decl_foo_result_set
 #define result_set_type_decl_foo_result_set 1
 cql_result_set_type_decl(foo_result_set, foo_result_set_ref);
 #endif
-extern cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _foo_get_shared_something_inline_
+#define _foo_get_shared_something_inline_
+
+
+static inline cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 foo_result_count(foo_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code foo_fetch_results(sqlite3 *_Nonnull _db_, foo_result_set_ref _Nullable *_Nonnull result_set);
 #define foo_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3417,18 +6744,93 @@ extern cql_string_ref _Nonnull shared_conditional_user_stored_procedure_name;
 
 #define shared_conditional_user_data_types_count 5
 
+extern uint8_t shared_conditional_user_data_types[shared_conditional_user_data_types_count];
+
 #ifndef result_set_type_decl_shared_conditional_user_result_set
 #define result_set_type_decl_shared_conditional_user_result_set 1
 cql_result_set_type_decl(shared_conditional_user_result_set, shared_conditional_user_result_set_ref);
 #endif
-extern cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_conditional_user_get_id_inline_
+#define _shared_conditional_user_get_id_inline_
+
+
+static inline cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_name_inline_
+#define _shared_conditional_user_get_name_inline_
+
+
+static inline cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_rate_is_null_inline_
+#define _shared_conditional_user_get_rate_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_rate_value_inline_
+#define _shared_conditional_user_get_rate_value_inline_
+
+
+static inline cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_type_is_null_inline_
+#define _shared_conditional_user_get_type_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_type_value_inline_
+#define _shared_conditional_user_get_type_value_inline_
+
+
+static inline cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_size_is_null_inline_
+#define _shared_conditional_user_get_size_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_size_value_inline_
+#define _shared_conditional_user_get_size_value_inline_
+
+
+static inline cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 shared_conditional_user_result_count(shared_conditional_user_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_conditional_user_fetch_results(sqlite3 *_Nonnull _db_, shared_conditional_user_result_set_ref _Nullable *_Nonnull result_set, cql_int32 x);
 #define shared_conditional_user_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3451,11 +6853,23 @@ extern cql_string_ref _Nonnull nested_shared_stuff_stored_procedure_name;
 
 #define nested_shared_stuff_data_types_count 1
 
+extern uint8_t nested_shared_stuff_data_types[nested_shared_stuff_data_types_count];
+
 #ifndef result_set_type_decl_nested_shared_stuff_result_set
 #define result_set_type_decl_nested_shared_stuff_result_set 1
 cql_result_set_type_decl(nested_shared_stuff_result_set, nested_shared_stuff_result_set_ref);
 #endif
-extern cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _nested_shared_stuff_get_x_inline_
+#define _nested_shared_stuff_get_x_inline_
+
+
+static inline cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 nested_shared_stuff_result_count(nested_shared_stuff_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code nested_shared_stuff_fetch_results(sqlite3 *_Nonnull _db_, nested_shared_stuff_result_set_ref _Nullable *_Nonnull result_set);
 #define nested_shared_stuff_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3473,11 +6887,23 @@ extern cql_string_ref _Nonnull use_nested_select_shared_frag_form_stored_procedu
 
 #define use_nested_select_shared_frag_form_data_types_count 1
 
+extern uint8_t use_nested_select_shared_frag_form_data_types[use_nested_select_shared_frag_form_data_types_count];
+
 #ifndef result_set_type_decl_use_nested_select_shared_frag_form_result_set
 #define result_set_type_decl_use_nested_select_shared_frag_form_result_set 1
 cql_result_set_type_decl(use_nested_select_shared_frag_form_result_set, use_nested_select_shared_frag_form_result_set_ref);
 #endif
-extern cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_nested_select_shared_frag_form_get_x_inline_
+#define _use_nested_select_shared_frag_form_get_x_inline_
+
+
+static inline cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 use_nested_select_shared_frag_form_result_count(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form_fetch_results(sqlite3 *_Nonnull _db_, use_nested_select_shared_frag_form_result_set_ref _Nullable *_Nonnull result_set);
 #define use_nested_select_shared_frag_form_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3502,11 +6928,23 @@ extern cql_string_ref _Nonnull shared_frag_else_nothing_test_stored_procedure_na
 
 #define shared_frag_else_nothing_test_data_types_count 1
 
+extern uint8_t shared_frag_else_nothing_test_data_types[shared_frag_else_nothing_test_data_types_count];
+
 #ifndef result_set_type_decl_shared_frag_else_nothing_test_result_set
 #define result_set_type_decl_shared_frag_else_nothing_test_result_set 1
 cql_result_set_type_decl(shared_frag_else_nothing_test_result_set, shared_frag_else_nothing_test_result_set_ref);
 #endif
-extern cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_frag_else_nothing_test_get_id_inline_
+#define _shared_frag_else_nothing_test_get_id_inline_
+
+
+static inline cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 shared_frag_else_nothing_test_result_count(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_test_result_set_ref _Nullable *_Nonnull result_set);
 #define shared_frag_else_nothing_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3524,13 +6962,43 @@ extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_stor
 
 #define shared_frag_else_nothing_in_from_clause_test_data_types_count 2
 
+extern uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count];
+
 #ifndef result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set
 #define result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set 1
 cql_result_set_type_decl(shared_frag_else_nothing_in_from_clause_test_result_set, shared_frag_else_nothing_in_from_clause_test_result_set_ref);
 #endif
-extern cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_id1_is_null_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_id1_is_null_inline_
+
+
+static inline cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_id1_value_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_id1_value_inline_
+
+
+static inline cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_text1_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_text1_inline_
+
+
+static inline cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set);
 #define shared_frag_else_nothing_in_from_clause_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3635,12 +7103,33 @@ extern cql_string_ref _Nonnull some_redeclared_out_proc_stored_procedure_name;
 
 #define some_redeclared_out_proc_data_types_count 1
 
+extern uint8_t some_redeclared_out_proc_data_types[some_redeclared_out_proc_data_types_count];
+
 #ifndef result_set_type_decl_some_redeclared_out_proc_result_set
 #define result_set_type_decl_some_redeclared_out_proc_result_set 1
 cql_result_set_type_decl(some_redeclared_out_proc_result_set, some_redeclared_out_proc_result_set_ref);
 #endif
-extern cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
+#ifndef _some_redeclared_out_proc_get_x_is_null_inline_
+#define _some_redeclared_out_proc_get_x_is_null_inline_
+
+
+static inline cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _some_redeclared_out_proc_get_x_value_inline_
+#define _some_redeclared_out_proc_get_x_value_inline_
+
+
+static inline cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 some_redeclared_out_proc_result_count(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code some_redeclared_out_proc_fetch_results(sqlite3 *_Nonnull _db_, some_redeclared_out_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define some_redeclared_out_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3670,12 +7159,33 @@ extern cql_string_ref _Nonnull some_redeclared_out_union_proc_stored_procedure_n
 
 #define some_redeclared_out_union_proc_data_types_count 1
 
+extern uint8_t some_redeclared_out_union_proc_data_types[some_redeclared_out_union_proc_data_types_count];
+
 #ifndef result_set_type_decl_some_redeclared_out_union_proc_result_set
 #define result_set_type_decl_some_redeclared_out_union_proc_result_set 1
 cql_result_set_type_decl(some_redeclared_out_union_proc_result_set, some_redeclared_out_union_proc_result_set_ref);
 #endif
-extern cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _some_redeclared_out_union_proc_get_x_is_null_inline_
+#define _some_redeclared_out_union_proc_get_x_is_null_inline_
+
+
+static inline cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _some_redeclared_out_union_proc_get_x_value_inline_
+#define _some_redeclared_out_union_proc_get_x_value_inline_
+
+
+static inline cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 some_redeclared_out_union_proc_result_count(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set);
 #define some_redeclared_out_union_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define some_redeclared_out_union_proc_row_equal(rs1, row1, rs2, row2) \
@@ -3726,12 +7236,33 @@ extern cql_string_ref _Nonnull a_proc_that_needs_dependents_stored_procedure_nam
 
 #define a_proc_that_needs_dependents_data_types_count 2
 
+extern uint8_t a_proc_that_needs_dependents_data_types[a_proc_that_needs_dependents_data_types_count];
+
 #ifndef result_set_type_decl_a_proc_that_needs_dependents_result_set
 #define result_set_type_decl_a_proc_that_needs_dependents_result_set 1
 cql_result_set_type_decl(a_proc_that_needs_dependents_result_set, a_proc_that_needs_dependents_result_set_ref);
 #endif
-extern a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row);
-extern a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _a_proc_that_needs_dependents_get_a_foo_inline_
+#define _a_proc_that_needs_dependents_get_a_foo_inline_
+
+
+static inline a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (a_proc_we_need_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 0));
+}
+
+#endif
+
+#ifndef _a_proc_that_needs_dependents_get_another_foo_inline_
+#define _a_proc_that_needs_dependents_get_another_foo_inline_
+
+
+static inline a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (a_proc_we_need_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 1));
+}
+
+#endif
+
+
 extern cql_int32 a_proc_that_needs_dependents_result_count(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set);
 #define a_proc_that_needs_dependents_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define a_proc_that_needs_dependents_row_equal(rs1, row1, rs2, row2) \
@@ -3752,12 +7283,33 @@ extern cql_string_ref _Nonnull simple_child_proc_stored_procedure_name;
 
 #define simple_child_proc_data_types_count 2
 
+extern uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_child_proc_result_set
 #define result_set_type_decl_simple_child_proc_result_set 1
 cql_result_set_type_decl(simple_child_proc_result_set, simple_child_proc_result_set_ref);
 #endif
-extern cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _simple_child_proc_get_x_inline_
+#define _simple_child_proc_get_x_inline_
+
+
+static inline cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_child_proc_get_y_inline_
+#define _simple_child_proc_get_y_inline_
+
+
+static inline cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 simple_child_proc_result_count(simple_child_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code simple_child_proc_fetch_results(sqlite3 *_Nonnull _db_, simple_child_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define simple_child_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3775,18 +7327,89 @@ extern cql_string_ref _Nonnull simple_container_proc_stored_procedure_name;
 
 #define simple_container_proc_data_types_count 3
 
+extern uint8_t simple_container_proc_data_types[simple_container_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_container_proc_result_set
 #define result_set_type_decl_simple_container_proc_result_set 1
 cql_result_set_type_decl(simple_container_proc_result_set, simple_container_proc_result_set_ref);
 #endif
-extern cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value);
+#ifndef _simple_container_proc_get_a_is_null_inline_
+#define _simple_container_proc_get_a_is_null_inline_
+
+
+static inline cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_container_proc_get_a_value_inline_
+#define _simple_container_proc_get_a_value_inline_
+
+
+static inline cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_a_value_inline_
+#define _simple_container_proc_set_a_value_inline_
+
+static inline void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
+}
+
+#endif
+
+#ifndef _simple_container_proc_set_a_to_null_inline_
+#define _simple_container_proc_set_a_to_null_inline_
+
+static inline void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+#ifndef _simple_container_proc_get_b_inline_
+#define _simple_container_proc_get_b_inline_
+
+
+static inline cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_b_inline_
+#define _simple_container_proc_set_b_inline_
+
+static inline void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
+}
+
+#endif
+#ifndef _simple_container_proc_get_c_inline_
+#define _simple_container_proc_get_c_inline_
+
+
+static inline simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (simple_child_proc_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 2));
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_c_inline_
+#define _simple_container_proc_set_c_inline_
+
+static inline void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
+}
+
+#endif
+
 extern cql_int32 simple_container_proc_result_count(simple_container_proc_result_set_ref _Nonnull result_set);
 #define simple_container_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define simple_container_proc_row_equal(rs1, row1, rs2, row2) \
@@ -3832,19 +7455,103 @@ extern cql_string_ref _Nonnull use_generated_fragment_stored_procedure_name;
 
 #define use_generated_fragment_data_types_count 7
 
+extern uint8_t use_generated_fragment_data_types[use_generated_fragment_data_types_count];
+
 #ifndef result_set_type_decl_use_generated_fragment_result_set
 #define result_set_type_decl_use_generated_fragment_result_set 1
 cql_result_set_type_decl(use_generated_fragment_result_set, use_generated_fragment_result_set_ref);
 #endif
-extern cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_generated_fragment_get_rowid_inline_
+#define _use_generated_fragment_get_rowid_inline_
+
+
+static inline cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_flag_inline_
+#define _use_generated_fragment_get_flag_inline_
+
+
+static inline cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_id_is_null_inline_
+#define _use_generated_fragment_get_id_is_null_inline_
+
+
+static inline cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_id_value_inline_
+#define _use_generated_fragment_get_id_value_inline_
+
+
+static inline cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_name_inline_
+#define _use_generated_fragment_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_age_is_null_inline_
+#define _use_generated_fragment_get_age_is_null_inline_
+
+
+static inline cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_age_value_inline_
+#define _use_generated_fragment_get_age_value_inline_
+
+
+static inline cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_storage_inline_
+#define _use_generated_fragment_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_pk_inline_
+#define _use_generated_fragment_get_pk_inline_
+
+
+static inline cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_generated_fragment_result_count(use_generated_fragment_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_generated_fragment_fetch_results(sqlite3 *_Nonnull _db_, use_generated_fragment_result_set_ref _Nullable *_Nonnull result_set);
 #define use_generated_fragment_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3862,19 +7569,103 @@ extern cql_string_ref _Nonnull use_backed_table_directly_stored_procedure_name;
 
 #define use_backed_table_directly_data_types_count 7
 
+extern uint8_t use_backed_table_directly_data_types[use_backed_table_directly_data_types_count];
+
 #ifndef result_set_type_decl_use_backed_table_directly_result_set
 #define result_set_type_decl_use_backed_table_directly_result_set 1
 cql_result_set_type_decl(use_backed_table_directly_result_set, use_backed_table_directly_result_set_ref);
 #endif
-extern cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_backed_table_directly_get_rowid_inline_
+#define _use_backed_table_directly_get_rowid_inline_
+
+
+static inline cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_flag_inline_
+#define _use_backed_table_directly_get_flag_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_id_is_null_inline_
+#define _use_backed_table_directly_get_id_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_id_value_inline_
+#define _use_backed_table_directly_get_id_value_inline_
+
+
+static inline cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_name_inline_
+#define _use_backed_table_directly_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_age_is_null_inline_
+#define _use_backed_table_directly_get_age_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_age_value_inline_
+#define _use_backed_table_directly_get_age_value_inline_
+
+
+static inline cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_storage_inline_
+#define _use_backed_table_directly_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_pk_inline_
+#define _use_backed_table_directly_get_pk_inline_
+
+
+static inline cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_backed_table_directly_result_count(use_backed_table_directly_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_backed_table_directly_fetch_results(sqlite3 *_Nonnull _db_, use_backed_table_directly_result_set_ref _Nullable *_Nonnull result_set);
 #define use_backed_table_directly_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3895,19 +7686,103 @@ extern cql_string_ref _Nonnull use_backed_table_directly_in_with_select_stored_p
 
 #define use_backed_table_directly_in_with_select_data_types_count 7
 
+extern uint8_t use_backed_table_directly_in_with_select_data_types[use_backed_table_directly_in_with_select_data_types_count];
+
 #ifndef result_set_type_decl_use_backed_table_directly_in_with_select_result_set
 #define result_set_type_decl_use_backed_table_directly_in_with_select_result_set 1
 cql_result_set_type_decl(use_backed_table_directly_in_with_select_result_set, use_backed_table_directly_in_with_select_result_set_ref);
 #endif
-extern cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_backed_table_directly_in_with_select_get_rowid_inline_
+#define _use_backed_table_directly_in_with_select_get_rowid_inline_
+
+
+static inline cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_flag_inline_
+#define _use_backed_table_directly_in_with_select_get_flag_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_id_is_null_inline_
+#define _use_backed_table_directly_in_with_select_get_id_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_id_value_inline_
+#define _use_backed_table_directly_in_with_select_get_id_value_inline_
+
+
+static inline cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_name_inline_
+#define _use_backed_table_directly_in_with_select_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_age_is_null_inline_
+#define _use_backed_table_directly_in_with_select_get_age_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_age_value_inline_
+#define _use_backed_table_directly_in_with_select_get_age_value_inline_
+
+
+static inline cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_storage_inline_
+#define _use_backed_table_directly_in_with_select_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_pk_inline_
+#define _use_backed_table_directly_in_with_select_get_pk_inline_
+
+
+static inline cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_backed_table_directly_in_with_select_result_count(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select_fetch_results(sqlite3 *_Nonnull _db_, use_backed_table_directly_in_with_select_result_set_ref _Nullable *_Nonnull result_set);
 #define use_backed_table_directly_in_with_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -964,46 +964,6 @@ typedef struct with_result_set_row {
   cql_string_ref _Nullable name;
 } with_result_set_row;
 
-cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t with_result_set_data_types[with_result_set_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -1087,21 +1047,6 @@ typedef struct select_from_view_row {
   cql_int32 id;
   cql_nullable_int32 type;
 } select_from_view_row;
-
-cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t select_from_view_data_types[select_from_view_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -1240,46 +1185,6 @@ typedef struct get_data_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } get_data_row;
-
-cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t get_data_data_types[get_data_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -1589,41 +1494,6 @@ typedef struct complex_return_row {
   cql_string_ref _Nonnull _text;
 } complex_return_row;
 
-cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._bool;
-}
-
-cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._integer;
-}
-
-cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._longint;
-}
-
-cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._real;
-}
-
-cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._text;
-}
-
-cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._nullable_bool.is_null;
-}
-
-cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._nullable_bool.value;
-}
-
 uint8_t complex_return_data_types[complex_return_data_types_count] = {
   CQL_DATA_TYPE_BOOL | CQL_DATA_TYPE_NOT_NULL, // _bool
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // _integer
@@ -1721,11 +1591,6 @@ typedef struct hierarchical_query_row {
   cql_int32 id;
 } hierarchical_query_row;
 
-cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row) {
-  hierarchical_query_row *data = (hierarchical_query_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t hierarchical_query_data_types[hierarchical_query_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -1815,11 +1680,6 @@ typedef struct hierarchical_unmatched_query_row {
   cql_int32 id;
 } hierarchical_unmatched_query_row;
 
-cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row) {
-  hierarchical_unmatched_query_row *data = (hierarchical_unmatched_query_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t hierarchical_unmatched_query_data_types[hierarchical_unmatched_query_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -1903,11 +1763,6 @@ typedef struct union_select_row {
   cql_int32 A;
 } union_select_row;
 
-cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_select_row *data = (union_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].A;
-}
-
 uint8_t union_select_data_types[union_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
 };
@@ -1980,11 +1835,6 @@ cql_string_proc_name(union_all_select_stored_procedure_name, "union_all_select")
 typedef struct union_all_select_row {
   cql_int32 A;
 } union_all_select_row;
-
-cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_all_select_row *data = (union_all_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].A;
-}
 
 uint8_t union_all_select_data_types[union_all_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -2059,11 +1909,6 @@ cql_string_proc_name(union_all_with_nullable_stored_procedure_name, "union_all_w
 typedef struct union_all_with_nullable_row {
   cql_string_ref _Nullable name;
 } union_all_with_nullable_row;
-
-cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_all_with_nullable_row *data = (union_all_with_nullable_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
 
 uint8_t union_all_with_nullable_data_types[union_all_with_nullable_data_types_count] = {
   CQL_DATA_TYPE_STRING, // name
@@ -2208,21 +2053,6 @@ typedef struct with_stmt_row {
   cql_int32 c;
 } with_stmt_row;
 
-cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].c;
-}
-
 uint8_t with_stmt_data_types[with_stmt_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -2310,21 +2140,6 @@ typedef struct with_recursive_stmt_row {
   cql_int32 c;
 } with_recursive_stmt_row;
 
-cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].c;
-}
-
 uint8_t with_recursive_stmt_data_types[with_recursive_stmt_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -2407,21 +2222,6 @@ typedef struct parent_proc_row {
   cql_int32 three;
 } parent_proc_row;
 
-cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].one;
-}
-
-cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].two;
-}
-
-cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].three;
-}
-
 uint8_t parent_proc_data_types[parent_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // one
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // two
@@ -2496,21 +2296,6 @@ typedef struct parent_proc_child_row {
   cql_int32 five;
   cql_int32 six;
 } parent_proc_child_row;
-
-cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].four;
-}
-
-cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].five;
-}
-
-cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].six;
-}
 
 uint8_t parent_proc_child_data_types[parent_proc_child_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // four
@@ -2721,11 +2506,6 @@ END;
 static int32_t cursor_with_object_perf_index;
 
 cql_string_proc_name(cursor_with_object_stored_procedure_name, "cursor_with_object");
-
-cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set) {
-  cursor_with_object_row *data = (cursor_with_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->object_;
-}
 
 uint8_t cursor_with_object_data_types[cursor_with_object_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // object_
@@ -2975,46 +2755,6 @@ typedef struct uses_proc_for_result_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } uses_proc_for_result_row;
-
-cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t uses_proc_for_result_data_types[uses_proc_for_result_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -3324,21 +3064,6 @@ typedef struct blob_returner_row {
   cql_blob_ref _Nullable b_nullable;
 } blob_returner_row;
 
-cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].blob_id;
-}
-
-cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b_notnull;
-}
-
-cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b_nullable;
-}
-
 uint8_t blob_returner_data_types[blob_returner_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // blob_id
   CQL_DATA_TYPE_BLOB | CQL_DATA_TYPE_NOT_NULL, // b_notnull
@@ -3439,56 +3164,6 @@ END;
 static int32_t out_cursor_proc_perf_index;
 
 cql_string_proc_name(out_cursor_proc_stored_procedure_name, "out_cursor_proc");
-
-cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
-
-cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->extra1;
-}
-
-cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->extra2;
-}
 
 uint8_t out_cursor_proc_data_types[out_cursor_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -3762,11 +3437,6 @@ cql_string_proc_name(thread_theme_info_list_stored_procedure_name, "thread_theme
 typedef struct thread_theme_info_list_row {
   cql_int64 thread_key;
 } thread_theme_info_list_row;
-
-cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row) {
-  thread_theme_info_list_row *data = (thread_theme_info_list_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].thread_key;
-}
 
 uint8_t thread_theme_info_list_data_types[thread_theme_info_list_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // thread_key
@@ -4076,16 +3746,6 @@ static int32_t out_no_db_perf_index;
 
 cql_string_proc_name(out_no_db_stored_procedure_name, "out_no_db");
 
-cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set) {
-  out_no_db_row *data = (out_no_db_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set) {
-  out_no_db_row *data = (out_no_db_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
-
 uint8_t out_no_db_data_types[out_no_db_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
   CQL_DATA_TYPE_DOUBLE | CQL_DATA_TYPE_NOT_NULL, // B
@@ -4159,16 +3819,6 @@ END;
 static int32_t declare_cursor_like_cursor_perf_index;
 
 cql_string_proc_name(declare_cursor_like_cursor_stored_procedure_name, "declare_cursor_like_cursor");
-
-cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_cursor_row *data = (declare_cursor_like_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_cursor_row *data = (declare_cursor_like_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
 
 uint8_t declare_cursor_like_cursor_data_types[declare_cursor_like_cursor_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -4253,21 +3903,6 @@ static int32_t declare_cursor_like_proc_perf_index;
 
 cql_string_proc_name(declare_cursor_like_proc_stored_procedure_name, "declare_cursor_like_proc");
 
-cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->a.is_null;
-}
-
-cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->a.value;
-}
-
-cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b;
-}
-
 uint8_t declare_cursor_like_proc_data_types[declare_cursor_like_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // a
   CQL_DATA_TYPE_STRING, // b
@@ -4345,46 +3980,6 @@ END;
 static int32_t declare_cursor_like_table_perf_index;
 
 cql_string_proc_name(declare_cursor_like_table_stored_procedure_name, "declare_cursor_like_table");
-
-cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
 
 uint8_t declare_cursor_like_table_data_types[declare_cursor_like_table_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -4473,21 +4068,6 @@ END;
 static int32_t declare_cursor_like_view_perf_index;
 
 cql_string_proc_name(declare_cursor_like_view_stored_procedure_name, "declare_cursor_like_view");
-
-cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f1;
-}
-
-cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f2;
-}
-
-cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f3;
-}
 
 uint8_t declare_cursor_like_view_data_types[declare_cursor_like_view_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // f1
@@ -4823,16 +4403,6 @@ END;
 static int32_t fetch_to_cursor_from_cursor_perf_index;
 
 cql_string_proc_name(fetch_to_cursor_from_cursor_stored_procedure_name, "fetch_to_cursor_from_cursor");
-
-cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
-  fetch_to_cursor_from_cursor_row *data = (fetch_to_cursor_from_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
-  fetch_to_cursor_from_cursor_row *data = (fetch_to_cursor_from_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
 
 uint8_t fetch_to_cursor_from_cursor_data_types[fetch_to_cursor_from_cursor_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -5252,11 +4822,6 @@ static int32_t out_union_helper_perf_index;
 
 cql_string_proc_name(out_union_helper_stored_procedure_name, "out_union_helper");
 
-cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_helper_row *data = (out_union_helper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t out_union_helper_data_types[out_union_helper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5320,11 +4885,6 @@ END;
 static int32_t out_union_dml_helper_perf_index;
 
 cql_string_proc_name(out_union_dml_helper_stored_procedure_name, "out_union_dml_helper");
-
-cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_helper_row *data = (out_union_dml_helper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t out_union_dml_helper_data_types[out_union_dml_helper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -5462,11 +5022,6 @@ static int32_t forward_out_union_perf_index;
 
 cql_string_proc_name(forward_out_union_stored_procedure_name, "forward_out_union");
 
-cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_row *data = (forward_out_union_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t forward_out_union_data_types[forward_out_union_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5521,11 +5076,6 @@ static int32_t forward_out_union_extern_perf_index;
 
 cql_string_proc_name(forward_out_union_extern_stored_procedure_name, "forward_out_union_extern");
 
-cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_extern_row *data = (forward_out_union_extern_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t forward_out_union_extern_data_types[forward_out_union_extern_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5573,11 +5123,6 @@ END;
 static int32_t forward_out_union_dml_perf_index;
 
 cql_string_proc_name(forward_out_union_dml_stored_procedure_name, "forward_out_union_dml");
-
-cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_dml_row *data = (forward_out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t forward_out_union_dml_data_types[forward_out_union_dml_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -5867,16 +5412,6 @@ typedef struct simple_identity_row {
   cql_int32 data;
 } simple_identity_row;
 
-cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_identity_row *data = (simple_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_identity_row *data = (simple_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
-
 uint8_t simple_identity_data_types[simple_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // data
@@ -5956,21 +5491,6 @@ typedef struct complex_identity_row {
   cql_int32 data;
 } complex_identity_row;
 
-cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].col1;
-}
-
-cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].col2;
-}
-
-cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
-
 uint8_t complex_identity_data_types[complex_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // col1
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // col2
@@ -6049,16 +5569,6 @@ END;
 static int32_t out_cursor_identity_perf_index;
 
 cql_string_proc_name(out_cursor_identity_stored_procedure_name, "out_cursor_identity");
-
-cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set) {
-  out_cursor_identity_row *data = (out_cursor_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set) {
-  out_cursor_identity_row *data = (out_cursor_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->data;
-}
 
 uint8_t out_cursor_identity_data_types[out_cursor_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6157,16 +5667,6 @@ typedef struct radioactive_proc_row {
   cql_int32 id;
   cql_string_ref _Nullable data;
 } radioactive_proc_row;
-
-cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  radioactive_proc_row *data = (radioactive_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  radioactive_proc_row *data = (radioactive_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
 
 uint8_t radioactive_proc_data_types[radioactive_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6332,16 +5832,6 @@ typedef struct autodropper_row {
   cql_int32 b;
 } autodropper_row;
 
-cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  autodropper_row *data = (autodropper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  autodropper_row *data = (autodropper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
 uint8_t autodropper_data_types[autodropper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -6411,11 +5901,6 @@ END;
 static int32_t simple_cursor_proc_perf_index;
 
 cql_string_proc_name(simple_cursor_proc_stored_procedure_name, "simple_cursor_proc");
-
-cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set) {
-  simple_cursor_proc_row *data = (simple_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
 
 uint8_t simple_cursor_proc_data_types[simple_cursor_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6488,16 +5973,6 @@ typedef struct redundant_cast_row {
   cql_int32 plugh;
   cql_int32 five;
 } redundant_cast_row;
-
-cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
-  redundant_cast_row *data = (redundant_cast_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].plugh;
-}
-
-cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
-  redundant_cast_row *data = (redundant_cast_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].five;
-}
 
 uint8_t redundant_cast_data_types[redundant_cast_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // plugh
@@ -6650,16 +6125,6 @@ typedef struct top_level_select_alias_unused_row {
   cql_int32 x;
 } top_level_select_alias_unused_row;
 
-cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_unused_row *data = (top_level_select_alias_unused_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_unused_row *data = (top_level_select_alias_unused_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t top_level_select_alias_unused_data_types[top_level_select_alias_unused_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -6738,16 +6203,6 @@ typedef struct top_level_select_alias_used_in_orderby_row {
   cql_int32 id;
   cql_int32 x;
 } top_level_select_alias_used_in_orderby_row;
-
-cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_used_in_orderby_row *data = (top_level_select_alias_used_in_orderby_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_used_in_orderby_row *data = (top_level_select_alias_used_in_orderby_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t top_level_select_alias_used_in_orderby_data_types[top_level_select_alias_used_in_orderby_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -7173,16 +6628,6 @@ static int32_t out_union_two_perf_index;
 
 cql_string_proc_name(out_union_two_stored_procedure_name, "out_union_two");
 
-cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_two_row *data = (out_union_two_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_two_row *data = (out_union_two_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t out_union_two_data_types[out_union_two_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // y
@@ -7322,16 +6767,6 @@ END;
 static int32_t out_union_from_select_perf_index;
 
 cql_string_proc_name(out_union_from_select_stored_procedure_name, "out_union_from_select");
-
-cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_from_select_row *data = (out_union_from_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_from_select_row *data = (out_union_from_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
 
 uint8_t out_union_from_select_data_types[out_union_from_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -7487,16 +6922,6 @@ static int32_t out_union_values_perf_index;
 
 cql_string_proc_name(out_union_values_stored_procedure_name, "out_union_values");
 
-cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_values_row *data = (out_union_values_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_values_row *data = (out_union_values_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t out_union_values_data_types[out_union_values_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // y
@@ -7616,16 +7041,6 @@ END;
 static int32_t out_union_dml_perf_index;
 
 cql_string_proc_name(out_union_dml_stored_procedure_name, "out_union_dml");
-
-cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_row *data = (out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_row *data = (out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
 
 uint8_t out_union_dml_data_types[out_union_dml_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -7828,16 +7243,6 @@ typedef struct window_function_invocation_row {
   cql_int32 row_num;
 } window_function_invocation_row;
 
-cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window_function_invocation_row *data = (window_function_invocation_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window_function_invocation_row *data = (window_function_invocation_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].row_num;
-}
-
 uint8_t window_function_invocation_data_types[window_function_invocation_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // row_num
@@ -7965,11 +7370,6 @@ cql_string_proc_name(use_return_stored_procedure_name, "use_return");
 typedef struct use_return_row {
   cql_int32 x;
 } use_return_row;
-
-cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_return_row *data = (use_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t use_return_data_types[use_return_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -8386,46 +7786,6 @@ typedef struct sproc_with_copy_row {
   cql_string_ref _Nullable name;
 } sproc_with_copy_row;
 
-cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t sproc_with_copy_data_types[sproc_with_copy_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -8508,82 +7868,6 @@ END;
 static int32_t emit_object_with_setters_perf_index;
 
 cql_string_proc_name(emit_object_with_setters_stored_procedure_name, "emit_object_with_setters");
-
-cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
-extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
-}
-
-cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x;
-}
-
-extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
-}
-
-cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i;
-}
-
-extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
-}
-
-cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l;
-}
-
-extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
-}
-
-cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b;
-}
-
-extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
-  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
-}
-
-cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d;
-}
-
-extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
-}
-
-cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->t;
-}
-
-extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
-}
-
-cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->bl;
-}
-
-extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
-}
 
 uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data_types_count] = {
   CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
@@ -8703,114 +7987,6 @@ static int32_t emit_setters_with_nullables_perf_index;
 
 cql_string_proc_name(emit_setters_with_nullables_stored_procedure_name, "emit_setters_with_nullables");
 
-cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
-extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
-}
-
-cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x;
-}
-
-extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
-}
-
-cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i.is_null;
-}
-
-cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i.value;
-}
-
-extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
-}
-
-extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
-}
-
-cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l.is_null;
-}
-
-cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l.value;
-}
-
-extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
-}
-
-extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
-}
-
-cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b.is_null;
-}
-
-cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b.value;
-}
-
-extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
-  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
-}
-
-extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
-}
-
-cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d.is_null;
-}
-
-cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d.value;
-}
-
-extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
-}
-
-extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
-}
-
-cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->t;
-}
-
-extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
-}
-
-cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->bl;
-}
-
-extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
-  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
-}
-
 uint8_t emit_setters_with_nullables_data_types[emit_setters_with_nullables_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // o
   CQL_DATA_TYPE_OBJECT, // x
@@ -8928,78 +8104,6 @@ typedef struct no_out_with_setters_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } no_out_with_setters_row;
-
-cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
-}
-
-cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value) {
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, row, 1, new_value);
-}
-
-cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, row, 2, new_value);
-}
-
-extern void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 2);
-}
-
-cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 3, new_value);
-}
-
-extern void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 3);
-}
-
-cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
-extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, row, 4, new_value);
-}
-
-extern void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 4);
-}
 
 uint8_t no_out_with_setters_data_types[no_out_with_setters_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -9179,31 +8283,6 @@ typedef struct vault_sensitive_with_values_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_values_proc_row;
 
-cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_values_proc_data_types[vault_sensitive_with_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9294,26 +8373,6 @@ typedef struct vault_not_nullable_sensitive_with_values_proc_row {
   cql_string_ref _Nonnull title;
 } vault_not_nullable_sensitive_with_values_proc_row;
 
-cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type;
-}
-
 uint8_t vault_not_nullable_sensitive_with_values_proc_data_types[vault_not_nullable_sensitive_with_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_ENCODED, // name
@@ -9402,31 +8461,6 @@ typedef struct vault_sensitive_with_no_values_proc_row {
   cql_string_ref _Nullable name;
   cql_string_ref _Nullable title;
 } vault_sensitive_with_no_values_proc_row;
-
-cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t vault_sensitive_with_no_values_proc_data_types[vault_sensitive_with_no_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -9520,31 +8554,6 @@ typedef struct vault_union_all_table_proc_row {
   cql_string_ref _Nullable title;
 } vault_union_all_table_proc_row;
 
-cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_union_all_table_proc_data_types[vault_union_all_table_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9634,11 +8643,6 @@ typedef struct vault_alias_column_proc_row {
   cql_string_ref _Nullable alias_name;
 } vault_alias_column_proc_row;
 
-cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_alias_column_proc_row *data = (vault_alias_column_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].alias_name;
-}
-
 uint8_t vault_alias_column_proc_data_types[vault_alias_column_proc_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // alias_name
 };
@@ -9718,11 +8722,6 @@ cql_string_proc_name(vault_alias_column_name_proc_stored_procedure_name, "vault_
 typedef struct vault_alias_column_name_proc_row {
   cql_string_ref _Nullable alias_name;
 } vault_alias_column_name_proc_row;
-
-cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_alias_column_name_proc_row *data = (vault_alias_column_name_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].alias_name;
-}
 
 uint8_t vault_alias_column_name_proc_data_types[vault_alias_column_name_proc_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // alias_name
@@ -9859,31 +8858,6 @@ typedef struct vault_sensitive_with_context_and_sensitive_columns_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_context_and_sensitive_columns_proc_row;
 
-cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9973,31 +8947,6 @@ typedef struct vault_sensitive_with_no_context_and_sensitive_columns_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_no_context_and_sensitive_columns_proc_row;
 
-cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -10086,31 +9035,6 @@ typedef struct vault_sensitive_with_context_and_no_sensitive_columns_proc_row {
   cql_string_ref _Nullable name;
   cql_string_ref _Nullable title;
 } vault_sensitive_with_context_and_no_sensitive_columns_proc_row;
-
-cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -10788,36 +9712,6 @@ typedef struct window1_row {
   cql_nullable_double SalesMovingAverage;
 } window1_row;
 
-cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window1_data_types[window1_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -10896,36 +9790,6 @@ typedef struct window2_row {
   cql_nullable_double amount;
   cql_nullable_double RunningTotal;
 } window2_row;
-
-cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].RunningTotal.is_null;
-}
-
-cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].RunningTotal.value;
-}
 
 uint8_t window2_data_types[window2_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11006,36 +9870,6 @@ typedef struct window3_row {
   cql_nullable_double SalesMovingAverage;
 } window3_row;
 
-cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window3_data_types[window3_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11114,36 +9948,6 @@ typedef struct window4_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window4_row;
-
-cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window4_data_types[window4_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11224,36 +10028,6 @@ typedef struct window5_row {
   cql_nullable_double SalesMovingAverage;
 } window5_row;
 
-cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window5_data_types[window5_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11332,36 +10106,6 @@ typedef struct window6_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window6_row;
-
-cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window6_data_types[window6_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11442,36 +10186,6 @@ typedef struct window7_row {
   cql_nullable_double SalesMovingAverage;
 } window7_row;
 
-cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window7_data_types[window7_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11550,36 +10264,6 @@ typedef struct window8_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window8_row;
-
-cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window8_data_types[window8_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11660,36 +10344,6 @@ typedef struct window9_row {
   cql_nullable_double SalesMovingAverage;
 } window9_row;
 
-cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window9_data_types[window9_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11768,36 +10422,6 @@ typedef struct window10_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window10_row;
-
-cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window10_data_types[window10_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11878,36 +10502,6 @@ typedef struct window11_row {
   cql_nullable_double SalesMovingAverage;
 } window11_row;
 
-cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window11_data_types[window11_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11986,36 +10580,6 @@ typedef struct window12_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window12_row;
-
-cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window12_data_types[window12_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12096,36 +10660,6 @@ typedef struct window13_row {
   cql_nullable_double SalesMovingAverage;
 } window13_row;
 
-cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window13_data_types[window13_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -12204,36 +10738,6 @@ typedef struct window14_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window14_row;
-
-cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window14_data_types[window14_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12314,36 +10818,6 @@ typedef struct window15_row {
   cql_nullable_double SalesMovingAverage;
 } window15_row;
 
-cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window15_data_types[window15_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -12422,36 +10896,6 @@ typedef struct window16_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window16_row;
-
-cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window16_data_types[window16_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12920,26 +11364,6 @@ typedef struct virtual1_row {
   cql_int32 vz;
 } virtual1_row;
 
-cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vx;
-}
-
-cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.is_null;
-}
-
-cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.value;
-}
-
-cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vz;
-}
-
 uint8_t virtual1_data_types[virtual1_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // vx
   CQL_DATA_TYPE_INT32, // vy
@@ -13017,26 +11441,6 @@ typedef struct virtual2_row {
   cql_nullable_int32 vy;
   cql_int32 vz;
 } virtual2_row;
-
-cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vx;
-}
-
-cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.is_null;
-}
-
-cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.value;
-}
-
-cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vz;
-}
 
 uint8_t virtual2_data_types[virtual2_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // vx
@@ -13997,11 +12401,6 @@ static int32_t out_object_perf_index;
 
 cql_string_proc_name(out_object_stored_procedure_name, "out_object");
 
-cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
-  out_object_row *data = (out_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
 uint8_t out_object_data_types[out_object_data_types_count] = {
   CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
 };
@@ -14161,46 +12560,6 @@ typedef struct result_set_proc_with_contract_in_fetch_results_row {
   cql_string_ref _Nullable name;
 } result_set_proc_with_contract_in_fetch_results_row;
 
-cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t result_set_proc_with_contract_in_fetch_results_data_types[result_set_proc_with_contract_in_fetch_results_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -14283,46 +12642,6 @@ END;
 static int32_t out_proc_with_contract_in_fetch_results_perf_index;
 
 cql_string_proc_name(out_proc_with_contract_in_fetch_results_stored_procedure_name, "out_proc_with_contract_in_fetch_results");
-
-cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
 
 uint8_t out_proc_with_contract_in_fetch_results_data_types[out_proc_with_contract_in_fetch_results_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -14419,11 +12738,6 @@ cql_string_proc_name(nullability_improvements_are_erased_for_sql_stored_procedur
 typedef struct nullability_improvements_are_erased_for_sql_row {
   cql_int32 b;
 } nullability_improvements_are_erased_for_sql_row;
-
-cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row) {
-  nullability_improvements_are_erased_for_sql_row *data = (nullability_improvements_are_erased_for_sql_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
 
 uint8_t nullability_improvements_are_erased_for_sql_data_types[nullability_improvements_are_erased_for_sql_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -15283,11 +13597,6 @@ typedef struct sensitive_function_is_a_no_op_row {
   cql_string_ref _Nonnull y;
 } sensitive_function_is_a_no_op_row;
 
-cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sensitive_function_is_a_no_op_row *data = (sensitive_function_is_a_no_op_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t sensitive_function_is_a_no_op_data_types[sensitive_function_is_a_no_op_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // y
 };
@@ -15485,11 +13794,6 @@ typedef struct foo_row {
   cql_int32 shared_something;
 } foo_row;
 
-cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row) {
-  foo_row *data = (foo_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].shared_something;
-}
-
 uint8_t foo_data_types[foo_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // shared_something
 };
@@ -15592,46 +13896,6 @@ typedef struct shared_conditional_user_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } shared_conditional_user_row;
-
-cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t shared_conditional_user_data_types[shared_conditional_user_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -15784,11 +14048,6 @@ typedef struct nested_shared_stuff_row {
   cql_int32 x;
 } nested_shared_stuff_row;
 
-cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row) {
-  nested_shared_stuff_row *data = (nested_shared_stuff_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t nested_shared_stuff_data_types[nested_shared_stuff_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -15919,11 +14178,6 @@ cql_string_proc_name(use_nested_select_shared_frag_form_stored_procedure_name, "
 typedef struct use_nested_select_shared_frag_form_row {
   cql_int32 x;
 } use_nested_select_shared_frag_form_row;
-
-cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_nested_select_shared_frag_form_row *data = (use_nested_select_shared_frag_form_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t use_nested_select_shared_frag_form_data_types[use_nested_select_shared_frag_form_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -16114,11 +14368,6 @@ typedef struct shared_frag_else_nothing_test_row {
   cql_int32 id;
 } shared_frag_else_nothing_test_row;
 
-cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_test_row *data = (shared_frag_else_nothing_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t shared_frag_else_nothing_test_data_types[shared_frag_else_nothing_test_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -16216,21 +14465,6 @@ typedef struct shared_frag_else_nothing_in_from_clause_test_row {
   cql_nullable_int32 id1;
   cql_string_ref _Nonnull text1;
 } shared_frag_else_nothing_in_from_clause_test_row;
-
-cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id1.is_null;
-}
-
-cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id1.value;
-}
-
-cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].text1;
-}
 
 uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count] = {
   CQL_DATA_TYPE_INT32, // id1
@@ -16683,16 +14917,6 @@ static int32_t some_redeclared_out_proc_perf_index;
 
 cql_string_proc_name(some_redeclared_out_proc_stored_procedure_name, "some_redeclared_out_proc");
 
-cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
-  some_redeclared_out_proc_row *data = (some_redeclared_out_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x.is_null;
-}
-
-cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
-  some_redeclared_out_proc_row *data = (some_redeclared_out_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x.value;
-}
-
 uint8_t some_redeclared_out_proc_data_types[some_redeclared_out_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // x
 };
@@ -16788,16 +15012,6 @@ END;
 static int32_t some_redeclared_out_union_proc_perf_index;
 
 cql_string_proc_name(some_redeclared_out_union_proc_stored_procedure_name, "some_redeclared_out_union_proc");
-
-cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  some_redeclared_out_union_proc_row *data = (some_redeclared_out_union_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x.is_null;
-}
-
-cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  some_redeclared_out_union_proc_row *data = (some_redeclared_out_union_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x.value;
-}
 
 uint8_t some_redeclared_out_union_proc_data_types[some_redeclared_out_union_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // x
@@ -17098,16 +15312,6 @@ static int32_t a_proc_that_needs_dependents_perf_index;
 
 cql_string_proc_name(a_proc_that_needs_dependents_stored_procedure_name, "a_proc_that_needs_dependents");
 
-a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
-  a_proc_that_needs_dependents_row *data = (a_proc_that_needs_dependents_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (a_proc_we_need_result_set_ref _Nullable )data[row].a_foo;
-}
-
-a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
-  a_proc_that_needs_dependents_row *data = (a_proc_that_needs_dependents_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (a_proc_we_need_result_set_ref _Nullable )data[row].another_foo;
-}
-
 uint8_t a_proc_that_needs_dependents_data_types[a_proc_that_needs_dependents_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // a_foo
   CQL_DATA_TYPE_OBJECT, // another_foo
@@ -17226,16 +15430,6 @@ typedef struct simple_child_proc_row {
   cql_int32 y;
 } simple_child_proc_row;
 
-cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_child_proc_row *data = (simple_child_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_child_proc_row *data = (simple_child_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // y
@@ -17307,42 +15501,6 @@ END;
 static int32_t simple_container_proc_perf_index;
 
 cql_string_proc_name(simple_container_proc_stored_procedure_name, "simple_container_proc");
-
-cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a.is_null;
-}
-
-cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a.value;
-}
-
-extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
-}
-
-extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
-}
-
-cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-extern void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
-}
-
-simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (simple_child_proc_result_set_ref _Nullable )data[row].c;
-}
-
-extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
-}
 
 uint8_t simple_container_proc_data_types[simple_container_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // a
@@ -17633,51 +15791,6 @@ typedef struct use_generated_fragment_row {
   cql_blob_ref _Nullable storage;
 } use_generated_fragment_row;
 
-cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
-
 uint8_t use_generated_fragment_data_types[use_generated_fragment_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid
   CQL_DATA_TYPE_BOOL | CQL_DATA_TYPE_NOT_NULL, // flag
@@ -17787,51 +15900,6 @@ typedef struct use_backed_table_directly_row {
   cql_string_ref _Nullable name;
   cql_blob_ref _Nullable storage;
 } use_backed_table_directly_row;
-
-cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
 
 uint8_t use_backed_table_directly_data_types[use_backed_table_directly_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid
@@ -17999,51 +16067,6 @@ typedef struct use_backed_table_directly_in_with_select_row {
   cql_string_ref _Nullable name;
   cql_blob_ref _Nullable storage;
 } use_backed_table_directly_in_with_select_row;
-
-cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
 
 uint8_t use_backed_table_directly_in_with_select_data_types[use_backed_table_directly_in_with_select_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid

--- a/sources/test/cg_test_c_with_header.h.ref
+++ b/sources/test/cg_test_c_with_header.h.ref
@@ -282,18 +282,93 @@ extern cql_string_ref _Nonnull with_result_set_stored_procedure_name;
 
 #define with_result_set_data_types_count 5
 
+extern uint8_t with_result_set_data_types[with_result_set_data_types_count];
+
 #ifndef result_set_type_decl_with_result_set_result_set
 #define result_set_type_decl_with_result_set_result_set 1
 cql_result_set_type_decl(with_result_set_result_set, with_result_set_result_set_ref);
 #endif
-extern cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_result_set_get_id_inline_
+#define _with_result_set_get_id_inline_
+
+
+static inline cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_result_set_get_name_inline_
+#define _with_result_set_get_name_inline_
+
+
+static inline cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_result_set_get_rate_is_null_inline_
+#define _with_result_set_get_rate_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _with_result_set_get_rate_value_inline_
+#define _with_result_set_get_rate_value_inline_
+
+
+static inline cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _with_result_set_get_type_is_null_inline_
+#define _with_result_set_get_type_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _with_result_set_get_type_value_inline_
+#define _with_result_set_get_type_value_inline_
+
+
+static inline cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _with_result_set_get_size_is_null_inline_
+#define _with_result_set_get_size_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _with_result_set_get_size_value_inline_
+#define _with_result_set_get_size_value_inline_
+
+
+static inline cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 with_result_set_result_count(with_result_set_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_result_set_fetch_results(sqlite3 *_Nonnull _db_, with_result_set_result_set_ref _Nullable *_Nonnull result_set);
 #define with_result_set_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -311,13 +386,43 @@ extern cql_string_ref _Nonnull select_from_view_stored_procedure_name;
 
 #define select_from_view_data_types_count 2
 
+extern uint8_t select_from_view_data_types[select_from_view_data_types_count];
+
 #ifndef result_set_type_decl_select_from_view_result_set
 #define result_set_type_decl_select_from_view_result_set 1
 cql_result_set_type_decl(select_from_view_result_set, select_from_view_result_set_ref);
 #endif
-extern cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _select_from_view_get_id_inline_
+#define _select_from_view_get_id_inline_
+
+
+static inline cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _select_from_view_get_type_is_null_inline_
+#define _select_from_view_get_type_is_null_inline_
+
+
+static inline cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _select_from_view_get_type_value_inline_
+#define _select_from_view_get_type_value_inline_
+
+
+static inline cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 select_from_view_result_count(select_from_view_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code select_from_view_fetch_results(sqlite3 *_Nonnull _db_, select_from_view_result_set_ref _Nullable *_Nonnull result_set);
 #define select_from_view_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -341,18 +446,93 @@ extern cql_string_ref _Nonnull get_data_stored_procedure_name;
 
 #define get_data_data_types_count 5
 
+extern uint8_t get_data_data_types[get_data_data_types_count];
+
 #ifndef result_set_type_decl_get_data_result_set
 #define result_set_type_decl_get_data_result_set 1
 cql_result_set_type_decl(get_data_result_set, get_data_result_set_ref);
 #endif
-extern cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _get_data_get_id_inline_
+#define _get_data_get_id_inline_
+
+
+static inline cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _get_data_get_name_inline_
+#define _get_data_get_name_inline_
+
+
+static inline cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _get_data_get_rate_is_null_inline_
+#define _get_data_get_rate_is_null_inline_
+
+
+static inline cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _get_data_get_rate_value_inline_
+#define _get_data_get_rate_value_inline_
+
+
+static inline cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _get_data_get_type_is_null_inline_
+#define _get_data_get_type_is_null_inline_
+
+
+static inline cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _get_data_get_type_value_inline_
+#define _get_data_get_type_value_inline_
+
+
+static inline cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _get_data_get_size_is_null_inline_
+#define _get_data_get_size_is_null_inline_
+
+
+static inline cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _get_data_get_size_value_inline_
+#define _get_data_get_size_value_inline_
+
+
+static inline cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 get_data_result_count(get_data_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code get_data_fetch_results(sqlite3 *_Nonnull _db_, get_data_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull name_, cql_int32 id_);
 #define get_data_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -412,17 +592,83 @@ extern cql_string_ref _Nonnull complex_return_stored_procedure_name;
 
 #define complex_return_data_types_count 6
 
+extern uint8_t complex_return_data_types[complex_return_data_types_count];
+
 #ifndef result_set_type_decl_complex_return_result_set
 #define result_set_type_decl_complex_return_result_set 1
 cql_result_set_type_decl(complex_return_result_set, complex_return_result_set_ref);
 #endif
-extern cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _complex_return_get__bool_inline_
+#define _complex_return_get__bool_inline_
+
+
+static inline cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _complex_return_get__integer_inline_
+#define _complex_return_get__integer_inline_
+
+
+static inline cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _complex_return_get__longint_inline_
+#define _complex_return_get__longint_inline_
+
+
+static inline cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _complex_return_get__real_inline_
+#define _complex_return_get__real_inline_
+
+
+static inline cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _complex_return_get__text_inline_
+#define _complex_return_get__text_inline_
+
+
+static inline cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _complex_return_get__nullable_bool_is_null_inline_
+#define _complex_return_get__nullable_bool_is_null_inline_
+
+
+static inline cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _complex_return_get__nullable_bool_value_inline_
+#define _complex_return_get__nullable_bool_value_inline_
+
+
+static inline cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+
 extern cql_int32 complex_return_result_count(complex_return_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code complex_return_fetch_results(sqlite3 *_Nonnull _db_, complex_return_result_set_ref _Nullable *_Nonnull result_set);
 #define complex_return_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -440,11 +686,23 @@ extern cql_string_ref _Nonnull hierarchical_query_stored_procedure_name;
 
 #define hierarchical_query_data_types_count 1
 
+extern uint8_t hierarchical_query_data_types[hierarchical_query_data_types_count];
+
 #ifndef result_set_type_decl_hierarchical_query_result_set
 #define result_set_type_decl_hierarchical_query_result_set 1
 cql_result_set_type_decl(hierarchical_query_result_set, hierarchical_query_result_set_ref);
 #endif
-extern cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _hierarchical_query_get_id_inline_
+#define _hierarchical_query_get_id_inline_
+
+
+static inline cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 hierarchical_query_result_count(hierarchical_query_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code hierarchical_query_fetch_results(sqlite3 *_Nonnull _db_, hierarchical_query_result_set_ref _Nullable *_Nonnull result_set, cql_int64 rate_, cql_int32 limit_, cql_int32 offset_);
 #define hierarchical_query_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -462,11 +720,23 @@ extern cql_string_ref _Nonnull hierarchical_unmatched_query_stored_procedure_nam
 
 #define hierarchical_unmatched_query_data_types_count 1
 
+extern uint8_t hierarchical_unmatched_query_data_types[hierarchical_unmatched_query_data_types_count];
+
 #ifndef result_set_type_decl_hierarchical_unmatched_query_result_set
 #define result_set_type_decl_hierarchical_unmatched_query_result_set 1
 cql_result_set_type_decl(hierarchical_unmatched_query_result_set, hierarchical_unmatched_query_result_set_ref);
 #endif
-extern cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _hierarchical_unmatched_query_get_id_inline_
+#define _hierarchical_unmatched_query_get_id_inline_
+
+
+static inline cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 hierarchical_unmatched_query_result_count(hierarchical_unmatched_query_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code hierarchical_unmatched_query_fetch_results(sqlite3 *_Nonnull _db_, hierarchical_unmatched_query_result_set_ref _Nullable *_Nonnull result_set, cql_int64 rate_, cql_int32 limit_, cql_int32 offset_);
 #define hierarchical_unmatched_query_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -484,11 +754,23 @@ extern cql_string_ref _Nonnull union_select_stored_procedure_name;
 
 #define union_select_data_types_count 1
 
+extern uint8_t union_select_data_types[union_select_data_types_count];
+
 #ifndef result_set_type_decl_union_select_result_set
 #define result_set_type_decl_union_select_result_set 1
 cql_result_set_type_decl(union_select_result_set, union_select_result_set_ref);
 #endif
-extern cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_select_get_A_inline_
+#define _union_select_get_A_inline_
+
+
+static inline cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_select_result_count(union_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_select_fetch_results(sqlite3 *_Nonnull _db_, union_select_result_set_ref _Nullable *_Nonnull result_set);
 #define union_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -506,11 +788,23 @@ extern cql_string_ref _Nonnull union_all_select_stored_procedure_name;
 
 #define union_all_select_data_types_count 1
 
+extern uint8_t union_all_select_data_types[union_all_select_data_types_count];
+
 #ifndef result_set_type_decl_union_all_select_result_set
 #define result_set_type_decl_union_all_select_result_set 1
 cql_result_set_type_decl(union_all_select_result_set, union_all_select_result_set_ref);
 #endif
-extern cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_all_select_get_A_inline_
+#define _union_all_select_get_A_inline_
+
+
+static inline cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_all_select_result_count(union_all_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_all_select_fetch_results(sqlite3 *_Nonnull _db_, union_all_select_result_set_ref _Nullable *_Nonnull result_set);
 #define union_all_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -528,11 +822,23 @@ extern cql_string_ref _Nonnull union_all_with_nullable_stored_procedure_name;
 
 #define union_all_with_nullable_data_types_count 1
 
+extern uint8_t union_all_with_nullable_data_types[union_all_with_nullable_data_types_count];
+
 #ifndef result_set_type_decl_union_all_with_nullable_result_set
 #define result_set_type_decl_union_all_with_nullable_result_set 1
 cql_result_set_type_decl(union_all_with_nullable_result_set, union_all_with_nullable_result_set_ref);
 #endif
-extern cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_all_with_nullable_get_name_inline_
+#define _union_all_with_nullable_get_name_inline_
+
+
+static inline cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_all_with_nullable_result_count(union_all_with_nullable_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_all_with_nullable_fetch_results(sqlite3 *_Nonnull _db_, union_all_with_nullable_result_set_ref _Nullable *_Nonnull result_set);
 #define union_all_with_nullable_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -553,13 +859,43 @@ extern cql_string_ref _Nonnull with_stmt_stored_procedure_name;
 
 #define with_stmt_data_types_count 3
 
+extern uint8_t with_stmt_data_types[with_stmt_data_types_count];
+
 #ifndef result_set_type_decl_with_stmt_result_set
 #define result_set_type_decl_with_stmt_result_set 1
 cql_result_set_type_decl(with_stmt_result_set, with_stmt_result_set_ref);
 #endif
-extern cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_stmt_get_a_inline_
+#define _with_stmt_get_a_inline_
+
+
+static inline cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_stmt_get_b_inline_
+#define _with_stmt_get_b_inline_
+
+
+static inline cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_stmt_get_c_inline_
+#define _with_stmt_get_c_inline_
+
+
+static inline cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 with_stmt_result_count(with_stmt_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_stmt_fetch_results(sqlite3 *_Nonnull _db_, with_stmt_result_set_ref _Nullable *_Nonnull result_set);
 #define with_stmt_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -577,13 +913,43 @@ extern cql_string_ref _Nonnull with_recursive_stmt_stored_procedure_name;
 
 #define with_recursive_stmt_data_types_count 3
 
+extern uint8_t with_recursive_stmt_data_types[with_recursive_stmt_data_types_count];
+
 #ifndef result_set_type_decl_with_recursive_stmt_result_set
 #define result_set_type_decl_with_recursive_stmt_result_set 1
 cql_result_set_type_decl(with_recursive_stmt_result_set, with_recursive_stmt_result_set_ref);
 #endif
-extern cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_recursive_stmt_get_a_inline_
+#define _with_recursive_stmt_get_a_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_recursive_stmt_get_b_inline_
+#define _with_recursive_stmt_get_b_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_recursive_stmt_get_c_inline_
+#define _with_recursive_stmt_get_c_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 with_recursive_stmt_result_count(with_recursive_stmt_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_recursive_stmt_fetch_results(sqlite3 *_Nonnull _db_, with_recursive_stmt_result_set_ref _Nullable *_Nonnull result_set);
 #define with_recursive_stmt_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -601,13 +967,43 @@ extern cql_string_ref _Nonnull parent_proc_stored_procedure_name;
 
 #define parent_proc_data_types_count 3
 
+extern uint8_t parent_proc_data_types[parent_proc_data_types_count];
+
 #ifndef result_set_type_decl_parent_proc_result_set
 #define result_set_type_decl_parent_proc_result_set 1
 cql_result_set_type_decl(parent_proc_result_set, parent_proc_result_set_ref);
 #endif
-extern cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _parent_proc_get_one_inline_
+#define _parent_proc_get_one_inline_
+
+
+static inline cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _parent_proc_get_two_inline_
+#define _parent_proc_get_two_inline_
+
+
+static inline cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _parent_proc_get_three_inline_
+#define _parent_proc_get_three_inline_
+
+
+static inline cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 parent_proc_result_count(parent_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code parent_proc_fetch_results(sqlite3 *_Nonnull _db_, parent_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define parent_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -625,13 +1021,43 @@ extern cql_string_ref _Nonnull parent_proc_child_stored_procedure_name;
 
 #define parent_proc_child_data_types_count 3
 
+extern uint8_t parent_proc_child_data_types[parent_proc_child_data_types_count];
+
 #ifndef result_set_type_decl_parent_proc_child_result_set
 #define result_set_type_decl_parent_proc_child_result_set 1
 cql_result_set_type_decl(parent_proc_child_result_set, parent_proc_child_result_set_ref);
 #endif
-extern cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _parent_proc_child_get_four_inline_
+#define _parent_proc_child_get_four_inline_
+
+
+static inline cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _parent_proc_child_get_five_inline_
+#define _parent_proc_child_get_five_inline_
+
+
+static inline cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _parent_proc_child_get_six_inline_
+#define _parent_proc_child_get_six_inline_
+
+
+static inline cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 parent_proc_child_result_count(parent_proc_child_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code parent_proc_child_fetch_results(sqlite3 *_Nonnull _db_, parent_proc_child_result_set_ref _Nullable *_Nonnull result_set);
 #define parent_proc_child_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -698,11 +1124,23 @@ extern cql_string_ref _Nonnull cursor_with_object_stored_procedure_name;
 
 #define cursor_with_object_data_types_count 1
 
+extern uint8_t cursor_with_object_data_types[cursor_with_object_data_types_count];
+
 #ifndef result_set_type_decl_cursor_with_object_result_set
 #define result_set_type_decl_cursor_with_object_result_set 1
 cql_result_set_type_decl(cursor_with_object_result_set, cursor_with_object_result_set_ref);
 #endif
-extern cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set);
+#ifndef _cursor_with_object_get_object__inline_
+#define _cursor_with_object_get_object__inline_
+
+
+static inline cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 cursor_with_object_result_count(cursor_with_object_result_set_ref _Nonnull result_set);
 extern void cursor_with_object_fetch_results( cursor_with_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nullable object_);
 #define cursor_with_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -771,18 +1209,93 @@ extern cql_string_ref _Nonnull uses_proc_for_result_stored_procedure_name;
 
 #define uses_proc_for_result_data_types_count 5
 
+extern uint8_t uses_proc_for_result_data_types[uses_proc_for_result_data_types_count];
+
 #ifndef result_set_type_decl_uses_proc_for_result_result_set
 #define result_set_type_decl_uses_proc_for_result_result_set 1
 cql_result_set_type_decl(uses_proc_for_result_result_set, uses_proc_for_result_result_set_ref);
 #endif
-extern cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _uses_proc_for_result_get_id_inline_
+#define _uses_proc_for_result_get_id_inline_
+
+
+static inline cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_name_inline_
+#define _uses_proc_for_result_get_name_inline_
+
+
+static inline cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_rate_is_null_inline_
+#define _uses_proc_for_result_get_rate_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_rate_value_inline_
+#define _uses_proc_for_result_get_rate_value_inline_
+
+
+static inline cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_type_is_null_inline_
+#define _uses_proc_for_result_get_type_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_type_value_inline_
+#define _uses_proc_for_result_get_type_value_inline_
+
+
+static inline cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_size_is_null_inline_
+#define _uses_proc_for_result_get_size_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_size_value_inline_
+#define _uses_proc_for_result_get_size_value_inline_
+
+
+static inline cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 uses_proc_for_result_result_count(uses_proc_for_result_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code uses_proc_for_result_fetch_results(sqlite3 *_Nonnull _db_, uses_proc_for_result_result_set_ref _Nullable *_Nonnull result_set);
 #define uses_proc_for_result_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -889,13 +1402,43 @@ extern cql_string_ref _Nonnull blob_returner_stored_procedure_name;
 
 #define blob_returner_data_types_count 3
 
+extern uint8_t blob_returner_data_types[blob_returner_data_types_count];
+
 #ifndef result_set_type_decl_blob_returner_result_set
 #define result_set_type_decl_blob_returner_result_set 1
 cql_result_set_type_decl(blob_returner_result_set, blob_returner_result_set_ref);
 #endif
-extern cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _blob_returner_get_blob_id_inline_
+#define _blob_returner_get_blob_id_inline_
+
+
+static inline cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _blob_returner_get_b_notnull_inline_
+#define _blob_returner_get_b_notnull_inline_
+
+
+static inline cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _blob_returner_get_b_nullable_inline_
+#define _blob_returner_get_b_nullable_inline_
+
+
+static inline cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 blob_returner_result_count(blob_returner_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code blob_returner_fetch_results(sqlite3 *_Nonnull _db_, blob_returner_result_set_ref _Nullable *_Nonnull result_set);
 #define blob_returner_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -918,20 +1461,113 @@ extern cql_string_ref _Nonnull out_cursor_proc_stored_procedure_name;
 
 #define out_cursor_proc_data_types_count 7
 
+extern uint8_t out_cursor_proc_data_types[out_cursor_proc_data_types_count];
+
 #ifndef result_set_type_decl_out_cursor_proc_result_set
 #define result_set_type_decl_out_cursor_proc_result_set 1
 cql_result_set_type_decl(out_cursor_proc_result_set, out_cursor_proc_result_set_ref);
 #endif
-extern cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set);
+#ifndef _out_cursor_proc_get_id_inline_
+#define _out_cursor_proc_get_id_inline_
+
+
+static inline cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_name_inline_
+#define _out_cursor_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_rate_is_null_inline_
+#define _out_cursor_proc_get_rate_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_rate_value_inline_
+#define _out_cursor_proc_get_rate_value_inline_
+
+
+static inline cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_type_is_null_inline_
+#define _out_cursor_proc_get_type_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_type_value_inline_
+#define _out_cursor_proc_get_type_value_inline_
+
+
+static inline cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_size_is_null_inline_
+#define _out_cursor_proc_get_size_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_size_value_inline_
+#define _out_cursor_proc_get_size_value_inline_
+
+
+static inline cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_extra1_inline_
+#define _out_cursor_proc_get_extra1_inline_
+
+
+static inline cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_extra2_inline_
+#define _out_cursor_proc_get_extra2_inline_
+
+
+static inline cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
 extern cql_int32 out_cursor_proc_result_count(out_cursor_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code out_cursor_proc_fetch_results(sqlite3 *_Nonnull _db_, out_cursor_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define out_cursor_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -976,11 +1612,23 @@ extern cql_string_ref _Nonnull thread_theme_info_list_stored_procedure_name;
 
 #define thread_theme_info_list_data_types_count 1
 
+extern uint8_t thread_theme_info_list_data_types[thread_theme_info_list_data_types_count];
+
 #ifndef result_set_type_decl_thread_theme_info_list_result_set
 #define result_set_type_decl_thread_theme_info_list_result_set 1
 cql_result_set_type_decl(thread_theme_info_list_result_set, thread_theme_info_list_result_set_ref);
 #endif
-extern cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _thread_theme_info_list_get_thread_key_inline_
+#define _thread_theme_info_list_get_thread_key_inline_
+
+
+static inline cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 thread_theme_info_list_result_count(thread_theme_info_list_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code thread_theme_info_list_fetch_results(sqlite3 *_Nonnull _db_, thread_theme_info_list_result_set_ref _Nullable *_Nonnull result_set, cql_int64 thread_key_);
 #define thread_theme_info_list_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1013,12 +1661,33 @@ extern cql_string_ref _Nonnull out_no_db_stored_procedure_name;
 
 #define out_no_db_data_types_count 2
 
+extern uint8_t out_no_db_data_types[out_no_db_data_types_count];
+
 #ifndef result_set_type_decl_out_no_db_result_set
 #define result_set_type_decl_out_no_db_result_set 1
 cql_result_set_type_decl(out_no_db_result_set, out_no_db_result_set_ref);
 #endif
-extern cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set);
-extern cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set);
+#ifndef _out_no_db_get_A_inline_
+#define _out_no_db_get_A_inline_
+
+
+static inline cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_no_db_get_B_inline_
+#define _out_no_db_get_B_inline_
+
+
+static inline cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_no_db_result_count(out_no_db_result_set_ref _Nonnull result_set);
 extern void out_no_db_fetch_results( out_no_db_result_set_ref _Nullable *_Nonnull result_set);
 #define out_no_db_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1036,12 +1705,33 @@ extern cql_string_ref _Nonnull declare_cursor_like_cursor_stored_procedure_name;
 
 #define declare_cursor_like_cursor_data_types_count 2
 
+extern uint8_t declare_cursor_like_cursor_data_types[declare_cursor_like_cursor_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_cursor_result_set
 #define result_set_type_decl_declare_cursor_like_cursor_result_set 1
 cql_result_set_type_decl(declare_cursor_like_cursor_result_set, declare_cursor_like_cursor_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
-extern cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_cursor_get_A_inline_
+#define _declare_cursor_like_cursor_get_A_inline_
+
+
+static inline cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_cursor_get_B_inline_
+#define _declare_cursor_like_cursor_get_B_inline_
+
+
+static inline cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_cursor_result_count(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_cursor_fetch_results( declare_cursor_like_cursor_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_cursor_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1059,13 +1749,43 @@ extern cql_string_ref _Nonnull declare_cursor_like_proc_stored_procedure_name;
 
 #define declare_cursor_like_proc_data_types_count 2
 
+extern uint8_t declare_cursor_like_proc_data_types[declare_cursor_like_proc_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_proc_result_set
 #define result_set_type_decl_declare_cursor_like_proc_result_set 1
 cql_result_set_type_decl(declare_cursor_like_proc_result_set, declare_cursor_like_proc_result_set_ref);
 #endif
-extern cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_proc_get_a_is_null_inline_
+#define _declare_cursor_like_proc_get_a_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_proc_get_a_value_inline_
+#define _declare_cursor_like_proc_get_a_value_inline_
+
+
+static inline cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_proc_get_b_inline_
+#define _declare_cursor_like_proc_get_b_inline_
+
+
+static inline cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_proc_result_count(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_proc_fetch_results( declare_cursor_like_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1083,18 +1803,93 @@ extern cql_string_ref _Nonnull declare_cursor_like_table_stored_procedure_name;
 
 #define declare_cursor_like_table_data_types_count 5
 
+extern uint8_t declare_cursor_like_table_data_types[declare_cursor_like_table_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_table_result_set
 #define result_set_type_decl_declare_cursor_like_table_result_set 1
 cql_result_set_type_decl(declare_cursor_like_table_result_set, declare_cursor_like_table_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_table_get_id_inline_
+#define _declare_cursor_like_table_get_id_inline_
+
+
+static inline cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_name_inline_
+#define _declare_cursor_like_table_get_name_inline_
+
+
+static inline cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_rate_is_null_inline_
+#define _declare_cursor_like_table_get_rate_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_rate_value_inline_
+#define _declare_cursor_like_table_get_rate_value_inline_
+
+
+static inline cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_type_is_null_inline_
+#define _declare_cursor_like_table_get_type_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_type_value_inline_
+#define _declare_cursor_like_table_get_type_value_inline_
+
+
+static inline cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_size_is_null_inline_
+#define _declare_cursor_like_table_get_size_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_size_value_inline_
+#define _declare_cursor_like_table_get_size_value_inline_
+
+
+static inline cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_table_result_count(declare_cursor_like_table_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_table_fetch_results( declare_cursor_like_table_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_table_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1112,13 +1907,43 @@ extern cql_string_ref _Nonnull declare_cursor_like_view_stored_procedure_name;
 
 #define declare_cursor_like_view_data_types_count 3
 
+extern uint8_t declare_cursor_like_view_data_types[declare_cursor_like_view_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_view_result_set
 #define result_set_type_decl_declare_cursor_like_view_result_set 1
 cql_result_set_type_decl(declare_cursor_like_view_result_set, declare_cursor_like_view_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_view_get_f1_inline_
+#define _declare_cursor_like_view_get_f1_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_view_get_f2_inline_
+#define _declare_cursor_like_view_get_f2_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_view_get_f3_inline_
+#define _declare_cursor_like_view_get_f3_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_view_result_count(declare_cursor_like_view_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_view_fetch_results( declare_cursor_like_view_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_view_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1165,12 +1990,33 @@ extern cql_string_ref _Nonnull fetch_to_cursor_from_cursor_stored_procedure_name
 
 #define fetch_to_cursor_from_cursor_data_types_count 2
 
+extern uint8_t fetch_to_cursor_from_cursor_data_types[fetch_to_cursor_from_cursor_data_types_count];
+
 #ifndef result_set_type_decl_fetch_to_cursor_from_cursor_result_set
 #define result_set_type_decl_fetch_to_cursor_from_cursor_result_set 1
 cql_result_set_type_decl(fetch_to_cursor_from_cursor_result_set, fetch_to_cursor_from_cursor_result_set_ref);
 #endif
-extern cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
+#ifndef _fetch_to_cursor_from_cursor_get_A_inline_
+#define _fetch_to_cursor_from_cursor_get_A_inline_
+
+
+static inline cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _fetch_to_cursor_from_cursor_get_B_inline_
+#define _fetch_to_cursor_from_cursor_get_B_inline_
+
+
+static inline cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 fetch_to_cursor_from_cursor_result_count(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
 extern void fetch_to_cursor_from_cursor_fetch_results( fetch_to_cursor_from_cursor_result_set_ref _Nullable *_Nonnull result_set);
 #define fetch_to_cursor_from_cursor_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1205,11 +2051,23 @@ extern cql_string_ref _Nonnull out_union_helper_stored_procedure_name;
 
 #define out_union_helper_data_types_count 1
 
+extern uint8_t out_union_helper_data_types[out_union_helper_data_types_count];
+
 #ifndef result_set_type_decl_out_union_helper_result_set
 #define result_set_type_decl_out_union_helper_result_set 1
 cql_result_set_type_decl(out_union_helper_result_set, out_union_helper_result_set_ref);
 #endif
-extern cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_helper_get_x_inline_
+#define _out_union_helper_get_x_inline_
+
+
+static inline cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_union_helper_result_count(out_union_helper_result_set_ref _Nonnull result_set);
 #define out_union_helper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_helper_row_equal(rs1, row1, rs2, row2) \
@@ -1227,11 +2085,23 @@ extern cql_string_ref _Nonnull out_union_dml_helper_stored_procedure_name;
 
 #define out_union_dml_helper_data_types_count 1
 
+extern uint8_t out_union_dml_helper_data_types[out_union_dml_helper_data_types_count];
+
 #ifndef result_set_type_decl_out_union_dml_helper_result_set
 #define result_set_type_decl_out_union_dml_helper_result_set 1
 cql_result_set_type_decl(out_union_dml_helper_result_set, out_union_dml_helper_result_set_ref);
 #endif
-extern cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_dml_helper_get_x_inline_
+#define _out_union_dml_helper_get_x_inline_
+
+
+static inline cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_union_dml_helper_result_count(out_union_dml_helper_result_set_ref _Nonnull result_set);
 #define out_union_dml_helper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_dml_helper_row_equal(rs1, row1, rs2, row2) \
@@ -1252,11 +2122,23 @@ extern cql_string_ref _Nonnull forward_out_union_stored_procedure_name;
 
 #define forward_out_union_data_types_count 1
 
+extern uint8_t forward_out_union_data_types[forward_out_union_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_result_set
 #define result_set_type_decl_forward_out_union_result_set 1
 cql_result_set_type_decl(forward_out_union_result_set, forward_out_union_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_get_x_inline_
+#define _forward_out_union_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_result_count(forward_out_union_result_set_ref _Nonnull result_set);
 #define forward_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -1280,11 +2162,23 @@ extern cql_string_ref _Nonnull forward_out_union_extern_stored_procedure_name;
 
 #define forward_out_union_extern_data_types_count 1
 
+extern uint8_t forward_out_union_extern_data_types[forward_out_union_extern_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_extern_result_set
 #define result_set_type_decl_forward_out_union_extern_result_set 1
 cql_result_set_type_decl(forward_out_union_extern_result_set, forward_out_union_extern_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_extern_get_x_inline_
+#define _forward_out_union_extern_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_extern_result_count(forward_out_union_extern_result_set_ref _Nonnull result_set);
 #define forward_out_union_extern_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_extern_row_equal(rs1, row1, rs2, row2) \
@@ -1302,11 +2196,23 @@ extern cql_string_ref _Nonnull forward_out_union_dml_stored_procedure_name;
 
 #define forward_out_union_dml_data_types_count 1
 
+extern uint8_t forward_out_union_dml_data_types[forward_out_union_dml_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_dml_result_set
 #define result_set_type_decl_forward_out_union_dml_result_set 1
 cql_result_set_type_decl(forward_out_union_dml_result_set, forward_out_union_dml_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_dml_get_x_inline_
+#define _forward_out_union_dml_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_dml_result_count(forward_out_union_dml_result_set_ref _Nonnull result_set);
 #define forward_out_union_dml_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_dml_row_equal(rs1, row1, rs2, row2) \
@@ -1369,12 +2275,33 @@ extern cql_string_ref _Nonnull simple_identity_stored_procedure_name;
 
 #define simple_identity_data_types_count 2
 
+extern uint8_t simple_identity_data_types[simple_identity_data_types_count];
+
 #ifndef result_set_type_decl_simple_identity_result_set
 #define result_set_type_decl_simple_identity_result_set 1
 cql_result_set_type_decl(simple_identity_result_set, simple_identity_result_set_ref);
 #endif
-extern cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _simple_identity_get_id_inline_
+#define _simple_identity_get_id_inline_
+
+
+static inline cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_identity_get_data_inline_
+#define _simple_identity_get_data_inline_
+
+
+static inline cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_uint16 simple_identity_identity_columns[];
 
 extern cql_int32 simple_identity_result_count(simple_identity_result_set_ref _Nonnull result_set);
@@ -1400,13 +2327,43 @@ extern cql_string_ref _Nonnull complex_identity_stored_procedure_name;
 
 #define complex_identity_data_types_count 3
 
+extern uint8_t complex_identity_data_types[complex_identity_data_types_count];
+
 #ifndef result_set_type_decl_complex_identity_result_set
 #define result_set_type_decl_complex_identity_result_set 1
 cql_result_set_type_decl(complex_identity_result_set, complex_identity_result_set_ref);
 #endif
-extern cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _complex_identity_get_col1_inline_
+#define _complex_identity_get_col1_inline_
+
+
+static inline cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _complex_identity_get_col2_inline_
+#define _complex_identity_get_col2_inline_
+
+
+static inline cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _complex_identity_get_data_inline_
+#define _complex_identity_get_data_inline_
+
+
+static inline cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_uint16 complex_identity_identity_columns[];
 
 extern cql_int32 complex_identity_result_count(complex_identity_result_set_ref _Nonnull result_set);
@@ -1432,12 +2389,33 @@ extern cql_string_ref _Nonnull out_cursor_identity_stored_procedure_name;
 
 #define out_cursor_identity_data_types_count 2
 
+extern uint8_t out_cursor_identity_data_types[out_cursor_identity_data_types_count];
+
 #ifndef result_set_type_decl_out_cursor_identity_result_set
 #define result_set_type_decl_out_cursor_identity_result_set 1
 cql_result_set_type_decl(out_cursor_identity_result_set, out_cursor_identity_result_set_ref);
 #endif
-extern cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set);
-extern cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set);
+#ifndef _out_cursor_identity_get_id_inline_
+#define _out_cursor_identity_get_id_inline_
+
+
+static inline cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_cursor_identity_get_data_inline_
+#define _out_cursor_identity_get_data_inline_
+
+
+static inline cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_uint16 out_cursor_identity_identity_columns[];
 
 extern cql_int32 out_cursor_identity_result_count(out_cursor_identity_result_set_ref _Nonnull result_set);
@@ -1463,15 +2441,36 @@ extern cql_string_ref _Nonnull radioactive_proc_stored_procedure_name;
 
 #define radioactive_proc_data_types_count 2
 
+extern uint8_t radioactive_proc_data_types[radioactive_proc_data_types_count];
+
 #ifndef result_set_type_decl_radioactive_proc_result_set
 #define result_set_type_decl_radioactive_proc_result_set 1
 cql_result_set_type_decl(radioactive_proc_result_set, radioactive_proc_result_set_ref);
 #endif
-extern cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _radioactive_proc_get_id_inline_
+#define _radioactive_proc_get_id_inline_
+
+
+static inline cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _radioactive_proc_get_data_inline_
+#define _radioactive_proc_get_data_inline_
+
+
+static inline cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define radioactive_proc_get_data_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
+
 extern cql_int32 radioactive_proc_result_count(radioactive_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code radioactive_proc_fetch_results(sqlite3 *_Nonnull _db_, radioactive_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define radioactive_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1497,12 +2496,33 @@ extern cql_string_ref _Nonnull autodropper_stored_procedure_name;
 
 #define autodropper_data_types_count 2
 
+extern uint8_t autodropper_data_types[autodropper_data_types_count];
+
 #ifndef result_set_type_decl_autodropper_result_set
 #define result_set_type_decl_autodropper_result_set 1
 cql_result_set_type_decl(autodropper_result_set, autodropper_result_set_ref);
 #endif
-extern cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _autodropper_get_a_inline_
+#define _autodropper_get_a_inline_
+
+
+static inline cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _autodropper_get_b_inline_
+#define _autodropper_get_b_inline_
+
+
+static inline cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 autodropper_result_count(autodropper_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code autodropper_fetch_results(sqlite3 *_Nonnull _db_, autodropper_result_set_ref _Nullable *_Nonnull result_set);
 #define autodropper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1520,11 +2540,23 @@ extern cql_string_ref _Nonnull simple_cursor_proc_stored_procedure_name;
 
 #define simple_cursor_proc_data_types_count 1
 
+extern uint8_t simple_cursor_proc_data_types[simple_cursor_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_cursor_proc_result_set
 #define result_set_type_decl_simple_cursor_proc_result_set 1
 cql_result_set_type_decl(simple_cursor_proc_result_set, simple_cursor_proc_result_set_ref);
 #endif
-extern cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set);
+#ifndef _simple_cursor_proc_get_id_inline_
+#define _simple_cursor_proc_get_id_inline_
+
+
+static inline cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 simple_cursor_proc_result_count(simple_cursor_proc_result_set_ref _Nonnull result_set);
 extern void simple_cursor_proc_fetch_results( simple_cursor_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define simple_cursor_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1554,12 +2586,33 @@ extern cql_string_ref _Nonnull redundant_cast_stored_procedure_name;
 
 #define redundant_cast_data_types_count 2
 
+extern uint8_t redundant_cast_data_types[redundant_cast_data_types_count];
+
 #ifndef result_set_type_decl_redundant_cast_result_set
 #define result_set_type_decl_redundant_cast_result_set 1
 cql_result_set_type_decl(redundant_cast_result_set, redundant_cast_result_set_ref);
 #endif
-extern cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _redundant_cast_get_plugh_inline_
+#define _redundant_cast_get_plugh_inline_
+
+
+static inline cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _redundant_cast_get_five_inline_
+#define _redundant_cast_get_five_inline_
+
+
+static inline cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 redundant_cast_result_count(redundant_cast_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code redundant_cast_fetch_results(sqlite3 *_Nonnull _db_, redundant_cast_result_set_ref _Nullable *_Nonnull result_set);
 #define redundant_cast_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1585,12 +2638,33 @@ extern cql_string_ref _Nonnull top_level_select_alias_unused_stored_procedure_na
 
 #define top_level_select_alias_unused_data_types_count 2
 
+extern uint8_t top_level_select_alias_unused_data_types[top_level_select_alias_unused_data_types_count];
+
 #ifndef result_set_type_decl_top_level_select_alias_unused_result_set
 #define result_set_type_decl_top_level_select_alias_unused_result_set 1
 cql_result_set_type_decl(top_level_select_alias_unused_result_set, top_level_select_alias_unused_result_set_ref);
 #endif
-extern cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _top_level_select_alias_unused_get_id_inline_
+#define _top_level_select_alias_unused_get_id_inline_
+
+
+static inline cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _top_level_select_alias_unused_get_x_inline_
+#define _top_level_select_alias_unused_get_x_inline_
+
+
+static inline cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 top_level_select_alias_unused_result_count(top_level_select_alias_unused_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code top_level_select_alias_unused_fetch_results(sqlite3 *_Nonnull _db_, top_level_select_alias_unused_result_set_ref _Nullable *_Nonnull result_set);
 #define top_level_select_alias_unused_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1608,12 +2682,33 @@ extern cql_string_ref _Nonnull top_level_select_alias_used_in_orderby_stored_pro
 
 #define top_level_select_alias_used_in_orderby_data_types_count 2
 
+extern uint8_t top_level_select_alias_used_in_orderby_data_types[top_level_select_alias_used_in_orderby_data_types_count];
+
 #ifndef result_set_type_decl_top_level_select_alias_used_in_orderby_result_set
 #define result_set_type_decl_top_level_select_alias_used_in_orderby_result_set 1
 cql_result_set_type_decl(top_level_select_alias_used_in_orderby_result_set, top_level_select_alias_used_in_orderby_result_set_ref);
 #endif
-extern cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _top_level_select_alias_used_in_orderby_get_id_inline_
+#define _top_level_select_alias_used_in_orderby_get_id_inline_
+
+
+static inline cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _top_level_select_alias_used_in_orderby_get_x_inline_
+#define _top_level_select_alias_used_in_orderby_get_x_inline_
+
+
+static inline cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 top_level_select_alias_used_in_orderby_result_count(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code top_level_select_alias_used_in_orderby_fetch_results(sqlite3 *_Nonnull _db_, top_level_select_alias_used_in_orderby_result_set_ref _Nullable *_Nonnull result_set);
 #define top_level_select_alias_used_in_orderby_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1670,12 +2765,33 @@ extern cql_string_ref _Nonnull out_union_two_stored_procedure_name;
 
 #define out_union_two_data_types_count 2
 
+extern uint8_t out_union_two_data_types[out_union_two_data_types_count];
+
 #ifndef result_set_type_decl_out_union_two_result_set
 #define result_set_type_decl_out_union_two_result_set 1
 cql_result_set_type_decl(out_union_two_result_set, out_union_two_result_set_ref);
 #endif
-extern cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_two_get_x_inline_
+#define _out_union_two_get_x_inline_
+
+
+static inline cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_two_get_y_inline_
+#define _out_union_two_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_two_result_count(out_union_two_result_set_ref _Nonnull result_set);
 #define out_union_two_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_two_row_equal(rs1, row1, rs2, row2) \
@@ -1696,12 +2812,33 @@ extern cql_string_ref _Nonnull out_union_from_select_stored_procedure_name;
 
 #define out_union_from_select_data_types_count 2
 
+extern uint8_t out_union_from_select_data_types[out_union_from_select_data_types_count];
+
 #ifndef result_set_type_decl_out_union_from_select_result_set
 #define result_set_type_decl_out_union_from_select_result_set 1
 cql_result_set_type_decl(out_union_from_select_result_set, out_union_from_select_result_set_ref);
 #endif
-extern cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_from_select_get_x_inline_
+#define _out_union_from_select_get_x_inline_
+
+
+static inline cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_from_select_get_y_inline_
+#define _out_union_from_select_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_from_select_result_count(out_union_from_select_result_set_ref _Nonnull result_set);
 #define out_union_from_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_from_select_row_equal(rs1, row1, rs2, row2) \
@@ -1722,12 +2859,33 @@ extern cql_string_ref _Nonnull out_union_values_stored_procedure_name;
 
 #define out_union_values_data_types_count 2
 
+extern uint8_t out_union_values_data_types[out_union_values_data_types_count];
+
 #ifndef result_set_type_decl_out_union_values_result_set
 #define result_set_type_decl_out_union_values_result_set 1
 cql_result_set_type_decl(out_union_values_result_set, out_union_values_result_set_ref);
 #endif
-extern cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_values_get_x_inline_
+#define _out_union_values_get_x_inline_
+
+
+static inline cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_values_get_y_inline_
+#define _out_union_values_get_y_inline_
+
+
+static inline cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_values_result_count(out_union_values_result_set_ref _Nonnull result_set);
 #define out_union_values_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_values_row_equal(rs1, row1, rs2, row2) \
@@ -1748,15 +2906,36 @@ extern cql_string_ref _Nonnull out_union_dml_stored_procedure_name;
 
 #define out_union_dml_data_types_count 2
 
+extern uint8_t out_union_dml_data_types[out_union_dml_data_types_count];
+
 #ifndef result_set_type_decl_out_union_dml_result_set
 #define result_set_type_decl_out_union_dml_result_set 1
 cql_result_set_type_decl(out_union_dml_result_set, out_union_dml_result_set_ref);
 #endif
-extern cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_dml_get_id_inline_
+#define _out_union_dml_get_id_inline_
+
+
+static inline cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_dml_get_data_inline_
+#define _out_union_dml_get_data_inline_
+
+
+static inline cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define out_union_dml_get_data_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
+
 extern cql_int32 out_union_dml_result_count(out_union_dml_result_set_ref _Nonnull result_set);
 #define out_union_dml_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_dml_row_equal(rs1, row1, rs2, row2) \
@@ -1782,12 +2961,33 @@ extern cql_string_ref _Nonnull window_function_invocation_stored_procedure_name;
 
 #define window_function_invocation_data_types_count 2
 
+extern uint8_t window_function_invocation_data_types[window_function_invocation_data_types_count];
+
 #ifndef result_set_type_decl_window_function_invocation_result_set
 #define result_set_type_decl_window_function_invocation_result_set 1
 cql_result_set_type_decl(window_function_invocation_result_set, window_function_invocation_result_set_ref);
 #endif
-extern cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window_function_invocation_get_id_inline_
+#define _window_function_invocation_get_id_inline_
+
+
+static inline cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window_function_invocation_get_row_num_inline_
+#define _window_function_invocation_get_row_num_inline_
+
+
+static inline cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 window_function_invocation_result_count(window_function_invocation_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window_function_invocation_fetch_results(sqlite3 *_Nonnull _db_, window_function_invocation_result_set_ref _Nullable *_Nonnull result_set);
 #define window_function_invocation_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1820,11 +3020,23 @@ extern cql_string_ref _Nonnull use_return_stored_procedure_name;
 
 #define use_return_data_types_count 1
 
+extern uint8_t use_return_data_types[use_return_data_types_count];
+
 #ifndef result_set_type_decl_use_return_result_set
 #define result_set_type_decl_use_return_result_set 1
 cql_result_set_type_decl(use_return_result_set, use_return_result_set_ref);
 #endif
-extern cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_return_get_x_inline_
+#define _use_return_get_x_inline_
+
+
+static inline cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 use_return_result_count(use_return_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_return_fetch_results(sqlite3 *_Nonnull _db_, use_return_result_set_ref _Nullable *_Nonnull result_set);
 #define use_return_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1860,10 +3072,13 @@ extern cql_string_ref _Nonnull lotsa_columns_no_getters_stored_procedure_name;
 
 #define lotsa_columns_no_getters_data_types_count 5
 
+extern uint8_t lotsa_columns_no_getters_data_types[lotsa_columns_no_getters_data_types_count];
+
 #ifndef result_set_type_decl_lotsa_columns_no_getters_result_set
 #define result_set_type_decl_lotsa_columns_no_getters_result_set 1
 cql_result_set_type_decl(lotsa_columns_no_getters_result_set, lotsa_columns_no_getters_result_set_ref);
 #endif
+
 extern cql_int32 lotsa_columns_no_getters_result_count(lotsa_columns_no_getters_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code lotsa_columns_no_getters_fetch_results(sqlite3 *_Nonnull _db_, lotsa_columns_no_getters_result_set_ref _Nullable *_Nonnull result_set);
 #define lotsa_columns_no_getters_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1881,18 +3096,93 @@ extern cql_string_ref _Nonnull sproc_with_copy_stored_procedure_name;
 
 #define sproc_with_copy_data_types_count 5
 
+extern uint8_t sproc_with_copy_data_types[sproc_with_copy_data_types_count];
+
 #ifndef result_set_type_decl_sproc_with_copy_result_set
 #define result_set_type_decl_sproc_with_copy_result_set 1
 cql_result_set_type_decl(sproc_with_copy_result_set, sproc_with_copy_result_set_ref);
 #endif
-extern cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _sproc_with_copy_get_id_inline_
+#define _sproc_with_copy_get_id_inline_
+
+
+static inline cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_name_inline_
+#define _sproc_with_copy_get_name_inline_
+
+
+static inline cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_rate_is_null_inline_
+#define _sproc_with_copy_get_rate_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_rate_value_inline_
+#define _sproc_with_copy_get_rate_value_inline_
+
+
+static inline cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_type_is_null_inline_
+#define _sproc_with_copy_get_type_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_type_value_inline_
+#define _sproc_with_copy_get_type_value_inline_
+
+
+static inline cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_size_is_null_inline_
+#define _sproc_with_copy_get_size_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_size_value_inline_
+#define _sproc_with_copy_get_size_value_inline_
+
+
+static inline cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 sproc_with_copy_result_count(sproc_with_copy_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sproc_with_copy_fetch_results(sqlite3 *_Nonnull _db_, sproc_with_copy_result_set_ref _Nullable *_Nonnull result_set);
 #define sproc_with_copy_copy(result_set, result_set_to, from, count) \
@@ -1916,26 +3206,169 @@ extern cql_string_ref _Nonnull emit_object_with_setters_stored_procedure_name;
 
 #define emit_object_with_setters_data_types_count 8
 
+extern uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data_types_count];
+
 #ifndef result_set_type_decl_emit_object_with_setters_result_set
 #define result_set_type_decl_emit_object_with_setters_result_set 1
 cql_result_set_type_decl(emit_object_with_setters_result_set, emit_object_with_setters_result_set_ref);
 #endif
-extern cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value);
-extern cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value);
-extern cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value);
-extern cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value);
-extern cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value);
-extern cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value);
-extern cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value);
-extern cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value);
+#ifndef _emit_object_with_setters_get_o_inline_
+#define _emit_object_with_setters_get_o_inline_
+
+
+static inline cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_o_inline_
+#define _emit_object_with_setters_set_o_inline_
+
+static inline void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_x_inline_
+#define _emit_object_with_setters_get_x_inline_
+
+
+static inline cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_x_inline_
+#define _emit_object_with_setters_set_x_inline_
+
+static inline void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_i_inline_
+#define _emit_object_with_setters_get_i_inline_
+
+
+static inline cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_i_inline_
+#define _emit_object_with_setters_set_i_inline_
+
+static inline void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_l_inline_
+#define _emit_object_with_setters_get_l_inline_
+
+
+static inline cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_l_inline_
+#define _emit_object_with_setters_set_l_inline_
+
+static inline void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_b_inline_
+#define _emit_object_with_setters_get_b_inline_
+
+
+static inline cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_b_inline_
+#define _emit_object_with_setters_set_b_inline_
+
+static inline void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
+  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_d_inline_
+#define _emit_object_with_setters_get_d_inline_
+
+
+static inline cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_d_inline_
+#define _emit_object_with_setters_set_d_inline_
+
+static inline void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_t_inline_
+#define _emit_object_with_setters_get_t_inline_
+
+
+static inline cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_t_inline_
+#define _emit_object_with_setters_set_t_inline_
+
+static inline void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_bl_inline_
+#define _emit_object_with_setters_get_bl_inline_
+
+
+static inline cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_blob_col((cql_result_set_ref)result_set, 0, 7);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_bl_inline_
+#define _emit_object_with_setters_set_bl_inline_
+
+static inline void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+}
+
+#endif
+
 extern cql_int32 emit_object_with_setters_result_count(emit_object_with_setters_result_set_ref _Nonnull result_set);
 extern void emit_object_with_setters_fetch_results( emit_object_with_setters_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o, cql_object_ref _Nonnull x, cql_int32 i, cql_int64 l, cql_bool b, cql_double d, cql_string_ref _Nonnull t, cql_blob_ref _Nonnull bl);
 #define emit_object_with_setters_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1953,34 +3386,241 @@ extern cql_string_ref _Nonnull emit_setters_with_nullables_stored_procedure_name
 
 #define emit_setters_with_nullables_data_types_count 8
 
+extern uint8_t emit_setters_with_nullables_data_types[emit_setters_with_nullables_data_types_count];
+
 #ifndef result_set_type_decl_emit_setters_with_nullables_result_set
 #define result_set_type_decl_emit_setters_with_nullables_result_set 1
 cql_result_set_type_decl(emit_setters_with_nullables_result_set, emit_setters_with_nullables_result_set_ref);
 #endif
-extern cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value);
-extern cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value);
-extern cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value);
-extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value);
-extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value);
-extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value);
-extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value);
-extern cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value);
+#ifndef _emit_setters_with_nullables_get_o_inline_
+#define _emit_setters_with_nullables_get_o_inline_
+
+
+static inline cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_o_inline_
+#define _emit_setters_with_nullables_set_o_inline_
+
+static inline void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_x_inline_
+#define _emit_setters_with_nullables_get_x_inline_
+
+
+static inline cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_x_inline_
+#define _emit_setters_with_nullables_set_x_inline_
+
+static inline void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_i_is_null_inline_
+#define _emit_setters_with_nullables_get_i_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_i_value_inline_
+#define _emit_setters_with_nullables_get_i_value_inline_
+
+
+static inline cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_i_value_inline_
+#define _emit_setters_with_nullables_set_i_value_inline_
+
+static inline void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_i_to_null_inline_
+#define _emit_setters_with_nullables_set_i_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_l_is_null_inline_
+#define _emit_setters_with_nullables_get_l_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_l_value_inline_
+#define _emit_setters_with_nullables_get_l_value_inline_
+
+
+static inline cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_l_value_inline_
+#define _emit_setters_with_nullables_set_l_value_inline_
+
+static inline void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_l_to_null_inline_
+#define _emit_setters_with_nullables_set_l_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_b_is_null_inline_
+#define _emit_setters_with_nullables_get_b_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_b_value_inline_
+#define _emit_setters_with_nullables_get_b_value_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_b_value_inline_
+#define _emit_setters_with_nullables_set_b_value_inline_
+
+static inline void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
+  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_b_to_null_inline_
+#define _emit_setters_with_nullables_set_b_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_d_is_null_inline_
+#define _emit_setters_with_nullables_get_d_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_d_value_inline_
+#define _emit_setters_with_nullables_get_d_value_inline_
+
+
+static inline cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_d_value_inline_
+#define _emit_setters_with_nullables_set_d_value_inline_
+
+static inline void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_d_to_null_inline_
+#define _emit_setters_with_nullables_set_d_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_t_inline_
+#define _emit_setters_with_nullables_get_t_inline_
+
+
+static inline cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 6) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_t_inline_
+#define _emit_setters_with_nullables_set_t_inline_
+
+static inline void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_bl_inline_
+#define _emit_setters_with_nullables_get_bl_inline_
+
+
+static inline cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 7) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, 0, 7);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_bl_inline_
+#define _emit_setters_with_nullables_set_bl_inline_
+
+static inline void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
+  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+}
+
+#endif
+
 extern cql_int32 emit_setters_with_nullables_result_count(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
 extern void emit_setters_with_nullables_fetch_results( emit_setters_with_nullables_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nullable o, cql_object_ref _Nullable x, cql_nullable_int32 i, cql_nullable_int64 l, cql_nullable_bool b, cql_nullable_double d, cql_string_ref _Nullable t, cql_blob_ref _Nullable bl);
 #define emit_setters_with_nullables_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1998,26 +3638,165 @@ extern cql_string_ref _Nonnull no_out_with_setters_stored_procedure_name;
 
 #define no_out_with_setters_data_types_count 5
 
+extern uint8_t no_out_with_setters_data_types[no_out_with_setters_data_types_count];
+
 #ifndef result_set_type_decl_no_out_with_setters_result_set
 #define result_set_type_decl_no_out_with_setters_result_set 1
 cql_result_set_type_decl(no_out_with_setters_result_set, no_out_with_setters_result_set_ref);
 #endif
-extern cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value);
-extern cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value);
-extern void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value);
-extern void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _no_out_with_setters_get_id_inline_
+#define _no_out_with_setters_get_id_inline_
+
+
+static inline cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_id_inline_
+#define _no_out_with_setters_set_id_inline_
+
+static inline void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_name_inline_
+#define _no_out_with_setters_get_name_inline_
+
+
+static inline cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_name_inline_
+#define _no_out_with_setters_set_name_inline_
+
+static inline void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value) {
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, row, 1, new_value);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_rate_is_null_inline_
+#define _no_out_with_setters_get_rate_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_rate_value_inline_
+#define _no_out_with_setters_get_rate_value_inline_
+
+
+static inline cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_rate_value_inline_
+#define _no_out_with_setters_set_rate_value_inline_
+
+static inline void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, row, 2, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_rate_to_null_inline_
+#define _no_out_with_setters_set_rate_to_null_inline_
+
+static inline void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_type_is_null_inline_
+#define _no_out_with_setters_get_type_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_type_value_inline_
+#define _no_out_with_setters_get_type_value_inline_
+
+
+static inline cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_type_value_inline_
+#define _no_out_with_setters_set_type_value_inline_
+
+static inline void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 3, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_type_to_null_inline_
+#define _no_out_with_setters_set_type_to_null_inline_
+
+static inline void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_size_is_null_inline_
+#define _no_out_with_setters_get_size_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_size_value_inline_
+#define _no_out_with_setters_get_size_value_inline_
+
+
+static inline cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_size_value_inline_
+#define _no_out_with_setters_set_size_value_inline_
+
+static inline void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, row, 4, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_size_to_null_inline_
+#define _no_out_with_setters_set_size_to_null_inline_
+
+static inline void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
 extern cql_int32 no_out_with_setters_result_count(no_out_with_setters_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code no_out_with_setters_fetch_results(sqlite3 *_Nonnull _db_, no_out_with_setters_result_set_ref _Nullable *_Nonnull result_set);
 #define no_out_with_setters_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2040,21 +3819,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_values_proc_stored_procedure
 
 #define vault_sensitive_with_values_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_values_proc_data_types[vault_sensitive_with_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_values_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_values_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_values_proc_result_set, vault_sensitive_with_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_values_proc_get_id_inline_
+#define _vault_sensitive_with_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_name_inline_
+#define _vault_sensitive_with_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_values_proc_get_title_inline_
+#define _vault_sensitive_with_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_values_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_type_value_inline_
+#define _vault_sensitive_with_values_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_values_proc_result_count(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2074,20 +3901,59 @@ extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_sto
 
 #define vault_not_nullable_sensitive_with_values_proc_data_types_count 4
 
+extern uint8_t vault_not_nullable_sensitive_with_values_proc_data_types[vault_not_nullable_sensitive_with_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_not_nullable_sensitive_with_values_proc_result_set
 #define result_set_type_decl_vault_not_nullable_sensitive_with_values_proc_result_set 1
 cql_result_set_type_decl(vault_not_nullable_sensitive_with_values_proc_result_set, vault_not_nullable_sensitive_with_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_id_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_name_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_not_nullable_sensitive_with_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_title_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_type_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_type_inline_
+
+
+static inline cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_not_nullable_sensitive_with_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_not_nullable_sensitive_with_values_proc_result_count(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_not_nullable_sensitive_with_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_not_nullable_sensitive_with_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2107,21 +3973,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_no_values_proc_stored_proced
 
 #define vault_sensitive_with_no_values_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_no_values_proc_data_types[vault_sensitive_with_no_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_no_values_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_no_values_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_no_values_proc_result_set, vault_sensitive_with_no_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_values_proc_get_id_inline_
+#define _vault_sensitive_with_no_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_name_inline_
+#define _vault_sensitive_with_no_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_values_proc_get_title_inline_
+#define _vault_sensitive_with_no_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_no_values_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_type_value_inline_
+#define _vault_sensitive_with_no_values_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_no_values_proc_result_count(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_no_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_no_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_no_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2141,21 +4055,69 @@ extern cql_string_ref _Nonnull vault_union_all_table_proc_stored_procedure_name;
 
 #define vault_union_all_table_proc_data_types_count 4
 
+extern uint8_t vault_union_all_table_proc_data_types[vault_union_all_table_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_union_all_table_proc_result_set
 #define result_set_type_decl_vault_union_all_table_proc_result_set 1
 cql_result_set_type_decl(vault_union_all_table_proc_result_set, vault_union_all_table_proc_result_set_ref);
 #endif
-extern cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_union_all_table_proc_get_id_inline_
+#define _vault_union_all_table_proc_get_id_inline_
+
+
+static inline cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_name_inline_
+#define _vault_union_all_table_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_union_all_table_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_union_all_table_proc_get_title_inline_
+#define _vault_union_all_table_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_type_is_null_inline_
+#define _vault_union_all_table_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_type_value_inline_
+#define _vault_union_all_table_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_union_all_table_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_union_all_table_proc_result_count(vault_union_all_table_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_union_all_table_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_union_all_table_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_union_all_table_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2175,14 +4137,26 @@ extern cql_string_ref _Nonnull vault_alias_column_proc_stored_procedure_name;
 
 #define vault_alias_column_proc_data_types_count 1
 
+extern uint8_t vault_alias_column_proc_data_types[vault_alias_column_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_alias_column_proc_result_set
 #define result_set_type_decl_vault_alias_column_proc_result_set 1
 cql_result_set_type_decl(vault_alias_column_proc_result_set, vault_alias_column_proc_result_set_ref);
 #endif
-extern cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_alias_column_proc_get_alias_name_inline_
+#define _vault_alias_column_proc_get_alias_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
 
 #define vault_alias_column_proc_get_alias_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 0)
+
 extern cql_int32 vault_alias_column_proc_result_count(vault_alias_column_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_alias_column_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_alias_column_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_alias_column_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2202,14 +4176,26 @@ extern cql_string_ref _Nonnull vault_alias_column_name_proc_stored_procedure_nam
 
 #define vault_alias_column_name_proc_data_types_count 1
 
+extern uint8_t vault_alias_column_name_proc_data_types[vault_alias_column_name_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_alias_column_name_proc_result_set
 #define result_set_type_decl_vault_alias_column_name_proc_result_set 1
 cql_result_set_type_decl(vault_alias_column_name_proc_result_set, vault_alias_column_name_proc_result_set_ref);
 #endif
-extern cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_alias_column_name_proc_get_alias_name_inline_
+#define _vault_alias_column_name_proc_get_alias_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
 
 #define vault_alias_column_name_proc_get_alias_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 0)
+
 extern cql_int32 vault_alias_column_name_proc_result_count(vault_alias_column_name_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_alias_column_name_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_alias_column_name_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_alias_column_name_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2232,21 +4218,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_context_and_sensitive_column
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_context_and_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_context_and_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_context_and_sensitive_columns_proc_result_set, vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_result_count(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_context_and_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_context_and_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2266,21 +4300,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_no_context_and_sensitive_col
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set, vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_result_count(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_no_context_and_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2300,15 +4382,63 @@ extern cql_string_ref _Nonnull vault_sensitive_with_context_and_no_sensitive_col
 
 #define vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set, vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+
 extern cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_result_count(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_context_and_no_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_context_and_no_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2456,16 +4586,73 @@ extern cql_string_ref _Nonnull window1_stored_procedure_name;
 
 #define window1_data_types_count 3
 
+extern uint8_t window1_data_types[window1_data_types_count];
+
 #ifndef result_set_type_decl_window1_result_set
 #define result_set_type_decl_window1_result_set 1
 cql_result_set_type_decl(window1_result_set, window1_result_set_ref);
 #endif
-extern cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window1_get_month_is_null_inline_
+#define _window1_get_month_is_null_inline_
+
+
+static inline cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window1_get_month_value_inline_
+#define _window1_get_month_value_inline_
+
+
+static inline cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window1_get_amount_is_null_inline_
+#define _window1_get_amount_is_null_inline_
+
+
+static inline cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window1_get_amount_value_inline_
+#define _window1_get_amount_value_inline_
+
+
+static inline cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window1_get_SalesMovingAverage_is_null_inline_
+#define _window1_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window1_get_SalesMovingAverage_value_inline_
+#define _window1_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window1_result_count(window1_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window1_fetch_results(sqlite3 *_Nonnull _db_, window1_result_set_ref _Nullable *_Nonnull result_set);
 #define window1_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2483,16 +4670,73 @@ extern cql_string_ref _Nonnull window2_stored_procedure_name;
 
 #define window2_data_types_count 3
 
+extern uint8_t window2_data_types[window2_data_types_count];
+
 #ifndef result_set_type_decl_window2_result_set
 #define result_set_type_decl_window2_result_set 1
 cql_result_set_type_decl(window2_result_set, window2_result_set_ref);
 #endif
-extern cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window2_get_month_is_null_inline_
+#define _window2_get_month_is_null_inline_
+
+
+static inline cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window2_get_month_value_inline_
+#define _window2_get_month_value_inline_
+
+
+static inline cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window2_get_amount_is_null_inline_
+#define _window2_get_amount_is_null_inline_
+
+
+static inline cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window2_get_amount_value_inline_
+#define _window2_get_amount_value_inline_
+
+
+static inline cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window2_get_RunningTotal_is_null_inline_
+#define _window2_get_RunningTotal_is_null_inline_
+
+
+static inline cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window2_get_RunningTotal_value_inline_
+#define _window2_get_RunningTotal_value_inline_
+
+
+static inline cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window2_result_count(window2_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window2_fetch_results(sqlite3 *_Nonnull _db_, window2_result_set_ref _Nullable *_Nonnull result_set);
 #define window2_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2510,16 +4754,73 @@ extern cql_string_ref _Nonnull window3_stored_procedure_name;
 
 #define window3_data_types_count 3
 
+extern uint8_t window3_data_types[window3_data_types_count];
+
 #ifndef result_set_type_decl_window3_result_set
 #define result_set_type_decl_window3_result_set 1
 cql_result_set_type_decl(window3_result_set, window3_result_set_ref);
 #endif
-extern cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window3_get_month_is_null_inline_
+#define _window3_get_month_is_null_inline_
+
+
+static inline cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window3_get_month_value_inline_
+#define _window3_get_month_value_inline_
+
+
+static inline cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window3_get_amount_is_null_inline_
+#define _window3_get_amount_is_null_inline_
+
+
+static inline cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window3_get_amount_value_inline_
+#define _window3_get_amount_value_inline_
+
+
+static inline cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window3_get_SalesMovingAverage_is_null_inline_
+#define _window3_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window3_get_SalesMovingAverage_value_inline_
+#define _window3_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window3_result_count(window3_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window3_fetch_results(sqlite3 *_Nonnull _db_, window3_result_set_ref _Nullable *_Nonnull result_set);
 #define window3_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2537,16 +4838,73 @@ extern cql_string_ref _Nonnull window4_stored_procedure_name;
 
 #define window4_data_types_count 3
 
+extern uint8_t window4_data_types[window4_data_types_count];
+
 #ifndef result_set_type_decl_window4_result_set
 #define result_set_type_decl_window4_result_set 1
 cql_result_set_type_decl(window4_result_set, window4_result_set_ref);
 #endif
-extern cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window4_get_month_is_null_inline_
+#define _window4_get_month_is_null_inline_
+
+
+static inline cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window4_get_month_value_inline_
+#define _window4_get_month_value_inline_
+
+
+static inline cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window4_get_amount_is_null_inline_
+#define _window4_get_amount_is_null_inline_
+
+
+static inline cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window4_get_amount_value_inline_
+#define _window4_get_amount_value_inline_
+
+
+static inline cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window4_get_SalesMovingAverage_is_null_inline_
+#define _window4_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window4_get_SalesMovingAverage_value_inline_
+#define _window4_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window4_result_count(window4_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window4_fetch_results(sqlite3 *_Nonnull _db_, window4_result_set_ref _Nullable *_Nonnull result_set);
 #define window4_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2564,16 +4922,73 @@ extern cql_string_ref _Nonnull window5_stored_procedure_name;
 
 #define window5_data_types_count 3
 
+extern uint8_t window5_data_types[window5_data_types_count];
+
 #ifndef result_set_type_decl_window5_result_set
 #define result_set_type_decl_window5_result_set 1
 cql_result_set_type_decl(window5_result_set, window5_result_set_ref);
 #endif
-extern cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window5_get_month_is_null_inline_
+#define _window5_get_month_is_null_inline_
+
+
+static inline cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window5_get_month_value_inline_
+#define _window5_get_month_value_inline_
+
+
+static inline cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window5_get_amount_is_null_inline_
+#define _window5_get_amount_is_null_inline_
+
+
+static inline cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window5_get_amount_value_inline_
+#define _window5_get_amount_value_inline_
+
+
+static inline cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window5_get_SalesMovingAverage_is_null_inline_
+#define _window5_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window5_get_SalesMovingAverage_value_inline_
+#define _window5_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window5_result_count(window5_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window5_fetch_results(sqlite3 *_Nonnull _db_, window5_result_set_ref _Nullable *_Nonnull result_set);
 #define window5_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2591,16 +5006,73 @@ extern cql_string_ref _Nonnull window6_stored_procedure_name;
 
 #define window6_data_types_count 3
 
+extern uint8_t window6_data_types[window6_data_types_count];
+
 #ifndef result_set_type_decl_window6_result_set
 #define result_set_type_decl_window6_result_set 1
 cql_result_set_type_decl(window6_result_set, window6_result_set_ref);
 #endif
-extern cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window6_get_month_is_null_inline_
+#define _window6_get_month_is_null_inline_
+
+
+static inline cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window6_get_month_value_inline_
+#define _window6_get_month_value_inline_
+
+
+static inline cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window6_get_amount_is_null_inline_
+#define _window6_get_amount_is_null_inline_
+
+
+static inline cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window6_get_amount_value_inline_
+#define _window6_get_amount_value_inline_
+
+
+static inline cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window6_get_SalesMovingAverage_is_null_inline_
+#define _window6_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window6_get_SalesMovingAverage_value_inline_
+#define _window6_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window6_result_count(window6_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window6_fetch_results(sqlite3 *_Nonnull _db_, window6_result_set_ref _Nullable *_Nonnull result_set);
 #define window6_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2618,16 +5090,73 @@ extern cql_string_ref _Nonnull window7_stored_procedure_name;
 
 #define window7_data_types_count 3
 
+extern uint8_t window7_data_types[window7_data_types_count];
+
 #ifndef result_set_type_decl_window7_result_set
 #define result_set_type_decl_window7_result_set 1
 cql_result_set_type_decl(window7_result_set, window7_result_set_ref);
 #endif
-extern cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window7_get_month_is_null_inline_
+#define _window7_get_month_is_null_inline_
+
+
+static inline cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window7_get_month_value_inline_
+#define _window7_get_month_value_inline_
+
+
+static inline cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window7_get_amount_is_null_inline_
+#define _window7_get_amount_is_null_inline_
+
+
+static inline cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window7_get_amount_value_inline_
+#define _window7_get_amount_value_inline_
+
+
+static inline cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window7_get_SalesMovingAverage_is_null_inline_
+#define _window7_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window7_get_SalesMovingAverage_value_inline_
+#define _window7_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window7_result_count(window7_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window7_fetch_results(sqlite3 *_Nonnull _db_, window7_result_set_ref _Nullable *_Nonnull result_set);
 #define window7_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2645,16 +5174,73 @@ extern cql_string_ref _Nonnull window8_stored_procedure_name;
 
 #define window8_data_types_count 3
 
+extern uint8_t window8_data_types[window8_data_types_count];
+
 #ifndef result_set_type_decl_window8_result_set
 #define result_set_type_decl_window8_result_set 1
 cql_result_set_type_decl(window8_result_set, window8_result_set_ref);
 #endif
-extern cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window8_get_month_is_null_inline_
+#define _window8_get_month_is_null_inline_
+
+
+static inline cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window8_get_month_value_inline_
+#define _window8_get_month_value_inline_
+
+
+static inline cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window8_get_amount_is_null_inline_
+#define _window8_get_amount_is_null_inline_
+
+
+static inline cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window8_get_amount_value_inline_
+#define _window8_get_amount_value_inline_
+
+
+static inline cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window8_get_SalesMovingAverage_is_null_inline_
+#define _window8_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window8_get_SalesMovingAverage_value_inline_
+#define _window8_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window8_result_count(window8_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window8_fetch_results(sqlite3 *_Nonnull _db_, window8_result_set_ref _Nullable *_Nonnull result_set);
 #define window8_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2672,16 +5258,73 @@ extern cql_string_ref _Nonnull window9_stored_procedure_name;
 
 #define window9_data_types_count 3
 
+extern uint8_t window9_data_types[window9_data_types_count];
+
 #ifndef result_set_type_decl_window9_result_set
 #define result_set_type_decl_window9_result_set 1
 cql_result_set_type_decl(window9_result_set, window9_result_set_ref);
 #endif
-extern cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window9_get_month_is_null_inline_
+#define _window9_get_month_is_null_inline_
+
+
+static inline cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window9_get_month_value_inline_
+#define _window9_get_month_value_inline_
+
+
+static inline cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window9_get_amount_is_null_inline_
+#define _window9_get_amount_is_null_inline_
+
+
+static inline cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window9_get_amount_value_inline_
+#define _window9_get_amount_value_inline_
+
+
+static inline cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window9_get_SalesMovingAverage_is_null_inline_
+#define _window9_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window9_get_SalesMovingAverage_value_inline_
+#define _window9_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window9_result_count(window9_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window9_fetch_results(sqlite3 *_Nonnull _db_, window9_result_set_ref _Nullable *_Nonnull result_set);
 #define window9_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2699,16 +5342,73 @@ extern cql_string_ref _Nonnull window10_stored_procedure_name;
 
 #define window10_data_types_count 3
 
+extern uint8_t window10_data_types[window10_data_types_count];
+
 #ifndef result_set_type_decl_window10_result_set
 #define result_set_type_decl_window10_result_set 1
 cql_result_set_type_decl(window10_result_set, window10_result_set_ref);
 #endif
-extern cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window10_get_month_is_null_inline_
+#define _window10_get_month_is_null_inline_
+
+
+static inline cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window10_get_month_value_inline_
+#define _window10_get_month_value_inline_
+
+
+static inline cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window10_get_amount_is_null_inline_
+#define _window10_get_amount_is_null_inline_
+
+
+static inline cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window10_get_amount_value_inline_
+#define _window10_get_amount_value_inline_
+
+
+static inline cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window10_get_SalesMovingAverage_is_null_inline_
+#define _window10_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window10_get_SalesMovingAverage_value_inline_
+#define _window10_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window10_result_count(window10_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window10_fetch_results(sqlite3 *_Nonnull _db_, window10_result_set_ref _Nullable *_Nonnull result_set);
 #define window10_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2726,16 +5426,73 @@ extern cql_string_ref _Nonnull window11_stored_procedure_name;
 
 #define window11_data_types_count 3
 
+extern uint8_t window11_data_types[window11_data_types_count];
+
 #ifndef result_set_type_decl_window11_result_set
 #define result_set_type_decl_window11_result_set 1
 cql_result_set_type_decl(window11_result_set, window11_result_set_ref);
 #endif
-extern cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window11_get_month_is_null_inline_
+#define _window11_get_month_is_null_inline_
+
+
+static inline cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window11_get_month_value_inline_
+#define _window11_get_month_value_inline_
+
+
+static inline cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window11_get_amount_is_null_inline_
+#define _window11_get_amount_is_null_inline_
+
+
+static inline cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window11_get_amount_value_inline_
+#define _window11_get_amount_value_inline_
+
+
+static inline cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window11_get_SalesMovingAverage_is_null_inline_
+#define _window11_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window11_get_SalesMovingAverage_value_inline_
+#define _window11_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window11_result_count(window11_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window11_fetch_results(sqlite3 *_Nonnull _db_, window11_result_set_ref _Nullable *_Nonnull result_set);
 #define window11_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2753,16 +5510,73 @@ extern cql_string_ref _Nonnull window12_stored_procedure_name;
 
 #define window12_data_types_count 3
 
+extern uint8_t window12_data_types[window12_data_types_count];
+
 #ifndef result_set_type_decl_window12_result_set
 #define result_set_type_decl_window12_result_set 1
 cql_result_set_type_decl(window12_result_set, window12_result_set_ref);
 #endif
-extern cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window12_get_month_is_null_inline_
+#define _window12_get_month_is_null_inline_
+
+
+static inline cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window12_get_month_value_inline_
+#define _window12_get_month_value_inline_
+
+
+static inline cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window12_get_amount_is_null_inline_
+#define _window12_get_amount_is_null_inline_
+
+
+static inline cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window12_get_amount_value_inline_
+#define _window12_get_amount_value_inline_
+
+
+static inline cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window12_get_SalesMovingAverage_is_null_inline_
+#define _window12_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window12_get_SalesMovingAverage_value_inline_
+#define _window12_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window12_result_count(window12_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window12_fetch_results(sqlite3 *_Nonnull _db_, window12_result_set_ref _Nullable *_Nonnull result_set);
 #define window12_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2780,16 +5594,73 @@ extern cql_string_ref _Nonnull window13_stored_procedure_name;
 
 #define window13_data_types_count 3
 
+extern uint8_t window13_data_types[window13_data_types_count];
+
 #ifndef result_set_type_decl_window13_result_set
 #define result_set_type_decl_window13_result_set 1
 cql_result_set_type_decl(window13_result_set, window13_result_set_ref);
 #endif
-extern cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window13_get_month_is_null_inline_
+#define _window13_get_month_is_null_inline_
+
+
+static inline cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window13_get_month_value_inline_
+#define _window13_get_month_value_inline_
+
+
+static inline cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window13_get_amount_is_null_inline_
+#define _window13_get_amount_is_null_inline_
+
+
+static inline cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window13_get_amount_value_inline_
+#define _window13_get_amount_value_inline_
+
+
+static inline cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window13_get_SalesMovingAverage_is_null_inline_
+#define _window13_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window13_get_SalesMovingAverage_value_inline_
+#define _window13_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window13_result_count(window13_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window13_fetch_results(sqlite3 *_Nonnull _db_, window13_result_set_ref _Nullable *_Nonnull result_set);
 #define window13_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2807,16 +5678,73 @@ extern cql_string_ref _Nonnull window14_stored_procedure_name;
 
 #define window14_data_types_count 3
 
+extern uint8_t window14_data_types[window14_data_types_count];
+
 #ifndef result_set_type_decl_window14_result_set
 #define result_set_type_decl_window14_result_set 1
 cql_result_set_type_decl(window14_result_set, window14_result_set_ref);
 #endif
-extern cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window14_get_month_is_null_inline_
+#define _window14_get_month_is_null_inline_
+
+
+static inline cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window14_get_month_value_inline_
+#define _window14_get_month_value_inline_
+
+
+static inline cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window14_get_amount_is_null_inline_
+#define _window14_get_amount_is_null_inline_
+
+
+static inline cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window14_get_amount_value_inline_
+#define _window14_get_amount_value_inline_
+
+
+static inline cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window14_get_SalesMovingAverage_is_null_inline_
+#define _window14_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window14_get_SalesMovingAverage_value_inline_
+#define _window14_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window14_result_count(window14_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window14_fetch_results(sqlite3 *_Nonnull _db_, window14_result_set_ref _Nullable *_Nonnull result_set);
 #define window14_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2834,16 +5762,73 @@ extern cql_string_ref _Nonnull window15_stored_procedure_name;
 
 #define window15_data_types_count 3
 
+extern uint8_t window15_data_types[window15_data_types_count];
+
 #ifndef result_set_type_decl_window15_result_set
 #define result_set_type_decl_window15_result_set 1
 cql_result_set_type_decl(window15_result_set, window15_result_set_ref);
 #endif
-extern cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window15_get_month_is_null_inline_
+#define _window15_get_month_is_null_inline_
+
+
+static inline cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window15_get_month_value_inline_
+#define _window15_get_month_value_inline_
+
+
+static inline cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window15_get_amount_is_null_inline_
+#define _window15_get_amount_is_null_inline_
+
+
+static inline cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window15_get_amount_value_inline_
+#define _window15_get_amount_value_inline_
+
+
+static inline cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window15_get_SalesMovingAverage_is_null_inline_
+#define _window15_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window15_get_SalesMovingAverage_value_inline_
+#define _window15_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window15_result_count(window15_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window15_fetch_results(sqlite3 *_Nonnull _db_, window15_result_set_ref _Nullable *_Nonnull result_set);
 #define window15_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2861,16 +5846,73 @@ extern cql_string_ref _Nonnull window16_stored_procedure_name;
 
 #define window16_data_types_count 3
 
+extern uint8_t window16_data_types[window16_data_types_count];
+
 #ifndef result_set_type_decl_window16_result_set
 #define result_set_type_decl_window16_result_set 1
 cql_result_set_type_decl(window16_result_set, window16_result_set_ref);
 #endif
-extern cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window16_get_month_is_null_inline_
+#define _window16_get_month_is_null_inline_
+
+
+static inline cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window16_get_month_value_inline_
+#define _window16_get_month_value_inline_
+
+
+static inline cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window16_get_amount_is_null_inline_
+#define _window16_get_amount_is_null_inline_
+
+
+static inline cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window16_get_amount_value_inline_
+#define _window16_get_amount_value_inline_
+
+
+static inline cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window16_get_SalesMovingAverage_is_null_inline_
+#define _window16_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window16_get_SalesMovingAverage_value_inline_
+#define _window16_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window16_result_count(window16_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window16_fetch_results(sqlite3 *_Nonnull _db_, window16_result_set_ref _Nullable *_Nonnull result_set);
 #define window16_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2971,14 +6013,53 @@ extern cql_string_ref _Nonnull virtual1_stored_procedure_name;
 
 #define virtual1_data_types_count 3
 
+extern uint8_t virtual1_data_types[virtual1_data_types_count];
+
 #ifndef result_set_type_decl_virtual1_result_set
 #define result_set_type_decl_virtual1_result_set 1
 cql_result_set_type_decl(virtual1_result_set, virtual1_result_set_ref);
 #endif
-extern cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _virtual1_get_vx_inline_
+#define _virtual1_get_vx_inline_
+
+
+static inline cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _virtual1_get_vy_is_null_inline_
+#define _virtual1_get_vy_is_null_inline_
+
+
+static inline cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual1_get_vy_value_inline_
+#define _virtual1_get_vy_value_inline_
+
+
+static inline cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual1_get_vz_inline_
+#define _virtual1_get_vz_inline_
+
+
+static inline cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 virtual1_result_count(virtual1_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code virtual1_fetch_results(sqlite3 *_Nonnull _db_, virtual1_result_set_ref _Nullable *_Nonnull result_set);
 #define virtual1_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2996,14 +6077,53 @@ extern cql_string_ref _Nonnull virtual2_stored_procedure_name;
 
 #define virtual2_data_types_count 3
 
+extern uint8_t virtual2_data_types[virtual2_data_types_count];
+
 #ifndef result_set_type_decl_virtual2_result_set
 #define result_set_type_decl_virtual2_result_set 1
 cql_result_set_type_decl(virtual2_result_set, virtual2_result_set_ref);
 #endif
-extern cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _virtual2_get_vx_inline_
+#define _virtual2_get_vx_inline_
+
+
+static inline cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _virtual2_get_vy_is_null_inline_
+#define _virtual2_get_vy_is_null_inline_
+
+
+static inline cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual2_get_vy_value_inline_
+#define _virtual2_get_vy_value_inline_
+
+
+static inline cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual2_get_vz_inline_
+#define _virtual2_get_vz_inline_
+
+
+static inline cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 virtual2_result_count(virtual2_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code virtual2_fetch_results(sqlite3 *_Nonnull _db_, virtual2_result_set_ref _Nullable *_Nonnull result_set);
 #define virtual2_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3038,10 +6158,13 @@ extern cql_string_ref _Nonnull private_out_union_stored_procedure_name;
 
 #define private_out_union_data_types_count 1
 
+extern uint8_t private_out_union_data_types[private_out_union_data_types_count];
+
 #ifndef result_set_type_decl_private_out_union_result_set
 #define result_set_type_decl_private_out_union_result_set 1
 cql_result_set_type_decl(private_out_union_result_set, private_out_union_result_set_ref);
 #endif
+
 extern cql_int32 private_out_union_result_count(private_out_union_result_set_ref _Nonnull result_set);
 #define private_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define private_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3065,10 +6188,13 @@ extern cql_string_ref _Nonnull no_getters_out_union_stored_procedure_name;
 
 #define no_getters_out_union_data_types_count 1
 
+extern uint8_t no_getters_out_union_data_types[no_getters_out_union_data_types_count];
+
 #ifndef result_set_type_decl_no_getters_out_union_result_set
 #define result_set_type_decl_no_getters_out_union_result_set 1
 cql_result_set_type_decl(no_getters_out_union_result_set, no_getters_out_union_result_set_ref);
 #endif
+
 extern cql_int32 no_getters_out_union_result_count(no_getters_out_union_result_set_ref _Nonnull result_set);
 #define no_getters_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define no_getters_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3089,10 +6215,13 @@ extern cql_string_ref _Nonnull suppress_results_out_union_stored_procedure_name;
 
 #define suppress_results_out_union_data_types_count 1
 
+extern uint8_t suppress_results_out_union_data_types[suppress_results_out_union_data_types_count];
+
 #ifndef result_set_type_decl_suppress_results_out_union_result_set
 #define result_set_type_decl_suppress_results_out_union_result_set 1
 cql_result_set_type_decl(suppress_results_out_union_result_set, suppress_results_out_union_result_set_ref);
 #endif
+
 extern cql_int32 suppress_results_out_union_result_count(suppress_results_out_union_result_set_ref _Nonnull result_set);
 #define suppress_results_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define suppress_results_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3164,11 +6293,23 @@ extern cql_string_ref _Nonnull out_object_stored_procedure_name;
 
 #define out_object_data_types_count 1
 
+extern uint8_t out_object_data_types[out_object_data_types_count];
+
 #ifndef result_set_type_decl_out_object_result_set
 #define result_set_type_decl_out_object_result_set 1
 cql_result_set_type_decl(out_object_result_set, out_object_result_set_ref);
 #endif
-extern cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set);
+#ifndef _out_object_get_o_inline_
+#define _out_object_get_o_inline_
+
+
+static inline cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set);
 extern void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o);
 #define out_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3195,18 +6336,93 @@ extern cql_string_ref _Nonnull result_set_proc_with_contract_in_fetch_results_st
 
 #define result_set_proc_with_contract_in_fetch_results_data_types_count 5
 
+extern uint8_t result_set_proc_with_contract_in_fetch_results_data_types[result_set_proc_with_contract_in_fetch_results_data_types_count];
+
 #ifndef result_set_type_decl_result_set_proc_with_contract_in_fetch_results_result_set
 #define result_set_type_decl_result_set_proc_with_contract_in_fetch_results_result_set 1
 cql_result_set_type_decl(result_set_proc_with_contract_in_fetch_results_result_set, result_set_proc_with_contract_in_fetch_results_result_set_ref);
 #endif
-extern cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_id_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_id_inline_
+
+
+static inline cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_name_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_name_inline_
+
+
+static inline cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_rate_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_rate_value_inline_
+
+
+static inline cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_type_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_type_value_inline_
+
+
+static inline cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_size_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_size_value_inline_
+
+
+static inline cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 result_set_proc_with_contract_in_fetch_results_result_count(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code result_set_proc_with_contract_in_fetch_results_fetch_results(sqlite3 *_Nonnull _db_, result_set_proc_with_contract_in_fetch_results_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull t);
 #define result_set_proc_with_contract_in_fetch_results_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3224,18 +6440,93 @@ extern cql_string_ref _Nonnull out_proc_with_contract_in_fetch_results_stored_pr
 
 #define out_proc_with_contract_in_fetch_results_data_types_count 5
 
+extern uint8_t out_proc_with_contract_in_fetch_results_data_types[out_proc_with_contract_in_fetch_results_data_types_count];
+
 #ifndef result_set_type_decl_out_proc_with_contract_in_fetch_results_result_set
 #define result_set_type_decl_out_proc_with_contract_in_fetch_results_result_set 1
 cql_result_set_type_decl(out_proc_with_contract_in_fetch_results_result_set, out_proc_with_contract_in_fetch_results_result_set_ref);
 #endif
-extern cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
+#ifndef _out_proc_with_contract_in_fetch_results_get_id_inline_
+#define _out_proc_with_contract_in_fetch_results_get_id_inline_
+
+
+static inline cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_name_inline_
+#define _out_proc_with_contract_in_fetch_results_get_name_inline_
+
+
+static inline cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_rate_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_rate_value_inline_
+
+
+static inline cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_type_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_type_value_inline_
+
+
+static inline cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_size_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_size_value_inline_
+
+
+static inline cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
 extern cql_int32 out_proc_with_contract_in_fetch_results_result_count(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
 extern void out_proc_with_contract_in_fetch_results_fetch_results( out_proc_with_contract_in_fetch_results_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull t);
 #define out_proc_with_contract_in_fetch_results_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3253,11 +6544,23 @@ extern cql_string_ref _Nonnull nullability_improvements_are_erased_for_sql_store
 
 #define nullability_improvements_are_erased_for_sql_data_types_count 1
 
+extern uint8_t nullability_improvements_are_erased_for_sql_data_types[nullability_improvements_are_erased_for_sql_data_types_count];
+
 #ifndef result_set_type_decl_nullability_improvements_are_erased_for_sql_result_set
 #define result_set_type_decl_nullability_improvements_are_erased_for_sql_result_set 1
 cql_result_set_type_decl(nullability_improvements_are_erased_for_sql_result_set, nullability_improvements_are_erased_for_sql_result_set_ref);
 #endif
-extern cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _nullability_improvements_are_erased_for_sql_get_b_inline_
+#define _nullability_improvements_are_erased_for_sql_get_b_inline_
+
+
+static inline cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 nullability_improvements_are_erased_for_sql_result_count(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code nullability_improvements_are_erased_for_sql_fetch_results(sqlite3 *_Nonnull _db_, nullability_improvements_are_erased_for_sql_result_set_ref _Nullable *_Nonnull result_set);
 #define nullability_improvements_are_erased_for_sql_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3357,11 +6660,23 @@ extern cql_string_ref _Nonnull sensitive_function_is_a_no_op_stored_procedure_na
 
 #define sensitive_function_is_a_no_op_data_types_count 1
 
+extern uint8_t sensitive_function_is_a_no_op_data_types[sensitive_function_is_a_no_op_data_types_count];
+
 #ifndef result_set_type_decl_sensitive_function_is_a_no_op_result_set
 #define result_set_type_decl_sensitive_function_is_a_no_op_result_set 1
 cql_result_set_type_decl(sensitive_function_is_a_no_op_result_set, sensitive_function_is_a_no_op_result_set_ref);
 #endif
-extern cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _sensitive_function_is_a_no_op_get_y_inline_
+#define _sensitive_function_is_a_no_op_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 sensitive_function_is_a_no_op_result_count(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sensitive_function_is_a_no_op_fetch_results(sqlite3 *_Nonnull _db_, sensitive_function_is_a_no_op_result_set_ref _Nullable *_Nonnull result_set);
 #define sensitive_function_is_a_no_op_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3390,11 +6705,23 @@ extern cql_string_ref _Nonnull foo_stored_procedure_name;
 
 #define foo_data_types_count 1
 
+extern uint8_t foo_data_types[foo_data_types_count];
+
 #ifndef result_set_type_decl_foo_result_set
 #define result_set_type_decl_foo_result_set 1
 cql_result_set_type_decl(foo_result_set, foo_result_set_ref);
 #endif
-extern cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _foo_get_shared_something_inline_
+#define _foo_get_shared_something_inline_
+
+
+static inline cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 foo_result_count(foo_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code foo_fetch_results(sqlite3 *_Nonnull _db_, foo_result_set_ref _Nullable *_Nonnull result_set);
 #define foo_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3417,18 +6744,93 @@ extern cql_string_ref _Nonnull shared_conditional_user_stored_procedure_name;
 
 #define shared_conditional_user_data_types_count 5
 
+extern uint8_t shared_conditional_user_data_types[shared_conditional_user_data_types_count];
+
 #ifndef result_set_type_decl_shared_conditional_user_result_set
 #define result_set_type_decl_shared_conditional_user_result_set 1
 cql_result_set_type_decl(shared_conditional_user_result_set, shared_conditional_user_result_set_ref);
 #endif
-extern cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_conditional_user_get_id_inline_
+#define _shared_conditional_user_get_id_inline_
+
+
+static inline cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_name_inline_
+#define _shared_conditional_user_get_name_inline_
+
+
+static inline cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_rate_is_null_inline_
+#define _shared_conditional_user_get_rate_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_rate_value_inline_
+#define _shared_conditional_user_get_rate_value_inline_
+
+
+static inline cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_type_is_null_inline_
+#define _shared_conditional_user_get_type_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_type_value_inline_
+#define _shared_conditional_user_get_type_value_inline_
+
+
+static inline cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_size_is_null_inline_
+#define _shared_conditional_user_get_size_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_size_value_inline_
+#define _shared_conditional_user_get_size_value_inline_
+
+
+static inline cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 shared_conditional_user_result_count(shared_conditional_user_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_conditional_user_fetch_results(sqlite3 *_Nonnull _db_, shared_conditional_user_result_set_ref _Nullable *_Nonnull result_set, cql_int32 x);
 #define shared_conditional_user_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3451,11 +6853,23 @@ extern cql_string_ref _Nonnull nested_shared_stuff_stored_procedure_name;
 
 #define nested_shared_stuff_data_types_count 1
 
+extern uint8_t nested_shared_stuff_data_types[nested_shared_stuff_data_types_count];
+
 #ifndef result_set_type_decl_nested_shared_stuff_result_set
 #define result_set_type_decl_nested_shared_stuff_result_set 1
 cql_result_set_type_decl(nested_shared_stuff_result_set, nested_shared_stuff_result_set_ref);
 #endif
-extern cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _nested_shared_stuff_get_x_inline_
+#define _nested_shared_stuff_get_x_inline_
+
+
+static inline cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 nested_shared_stuff_result_count(nested_shared_stuff_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code nested_shared_stuff_fetch_results(sqlite3 *_Nonnull _db_, nested_shared_stuff_result_set_ref _Nullable *_Nonnull result_set);
 #define nested_shared_stuff_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3473,11 +6887,23 @@ extern cql_string_ref _Nonnull use_nested_select_shared_frag_form_stored_procedu
 
 #define use_nested_select_shared_frag_form_data_types_count 1
 
+extern uint8_t use_nested_select_shared_frag_form_data_types[use_nested_select_shared_frag_form_data_types_count];
+
 #ifndef result_set_type_decl_use_nested_select_shared_frag_form_result_set
 #define result_set_type_decl_use_nested_select_shared_frag_form_result_set 1
 cql_result_set_type_decl(use_nested_select_shared_frag_form_result_set, use_nested_select_shared_frag_form_result_set_ref);
 #endif
-extern cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_nested_select_shared_frag_form_get_x_inline_
+#define _use_nested_select_shared_frag_form_get_x_inline_
+
+
+static inline cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 use_nested_select_shared_frag_form_result_count(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form_fetch_results(sqlite3 *_Nonnull _db_, use_nested_select_shared_frag_form_result_set_ref _Nullable *_Nonnull result_set);
 #define use_nested_select_shared_frag_form_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3502,11 +6928,23 @@ extern cql_string_ref _Nonnull shared_frag_else_nothing_test_stored_procedure_na
 
 #define shared_frag_else_nothing_test_data_types_count 1
 
+extern uint8_t shared_frag_else_nothing_test_data_types[shared_frag_else_nothing_test_data_types_count];
+
 #ifndef result_set_type_decl_shared_frag_else_nothing_test_result_set
 #define result_set_type_decl_shared_frag_else_nothing_test_result_set 1
 cql_result_set_type_decl(shared_frag_else_nothing_test_result_set, shared_frag_else_nothing_test_result_set_ref);
 #endif
-extern cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_frag_else_nothing_test_get_id_inline_
+#define _shared_frag_else_nothing_test_get_id_inline_
+
+
+static inline cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 shared_frag_else_nothing_test_result_count(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_test_result_set_ref _Nullable *_Nonnull result_set);
 #define shared_frag_else_nothing_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3524,13 +6962,43 @@ extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_stor
 
 #define shared_frag_else_nothing_in_from_clause_test_data_types_count 2
 
+extern uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count];
+
 #ifndef result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set
 #define result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set 1
 cql_result_set_type_decl(shared_frag_else_nothing_in_from_clause_test_result_set, shared_frag_else_nothing_in_from_clause_test_result_set_ref);
 #endif
-extern cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_id1_is_null_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_id1_is_null_inline_
+
+
+static inline cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_id1_value_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_id1_value_inline_
+
+
+static inline cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_text1_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_text1_inline_
+
+
+static inline cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set);
 #define shared_frag_else_nothing_in_from_clause_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3635,12 +7103,33 @@ extern cql_string_ref _Nonnull some_redeclared_out_proc_stored_procedure_name;
 
 #define some_redeclared_out_proc_data_types_count 1
 
+extern uint8_t some_redeclared_out_proc_data_types[some_redeclared_out_proc_data_types_count];
+
 #ifndef result_set_type_decl_some_redeclared_out_proc_result_set
 #define result_set_type_decl_some_redeclared_out_proc_result_set 1
 cql_result_set_type_decl(some_redeclared_out_proc_result_set, some_redeclared_out_proc_result_set_ref);
 #endif
-extern cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
+#ifndef _some_redeclared_out_proc_get_x_is_null_inline_
+#define _some_redeclared_out_proc_get_x_is_null_inline_
+
+
+static inline cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _some_redeclared_out_proc_get_x_value_inline_
+#define _some_redeclared_out_proc_get_x_value_inline_
+
+
+static inline cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 some_redeclared_out_proc_result_count(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code some_redeclared_out_proc_fetch_results(sqlite3 *_Nonnull _db_, some_redeclared_out_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define some_redeclared_out_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3670,12 +7159,33 @@ extern cql_string_ref _Nonnull some_redeclared_out_union_proc_stored_procedure_n
 
 #define some_redeclared_out_union_proc_data_types_count 1
 
+extern uint8_t some_redeclared_out_union_proc_data_types[some_redeclared_out_union_proc_data_types_count];
+
 #ifndef result_set_type_decl_some_redeclared_out_union_proc_result_set
 #define result_set_type_decl_some_redeclared_out_union_proc_result_set 1
 cql_result_set_type_decl(some_redeclared_out_union_proc_result_set, some_redeclared_out_union_proc_result_set_ref);
 #endif
-extern cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _some_redeclared_out_union_proc_get_x_is_null_inline_
+#define _some_redeclared_out_union_proc_get_x_is_null_inline_
+
+
+static inline cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _some_redeclared_out_union_proc_get_x_value_inline_
+#define _some_redeclared_out_union_proc_get_x_value_inline_
+
+
+static inline cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 some_redeclared_out_union_proc_result_count(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set);
 #define some_redeclared_out_union_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define some_redeclared_out_union_proc_row_equal(rs1, row1, rs2, row2) \
@@ -3726,12 +7236,33 @@ extern cql_string_ref _Nonnull a_proc_that_needs_dependents_stored_procedure_nam
 
 #define a_proc_that_needs_dependents_data_types_count 2
 
+extern uint8_t a_proc_that_needs_dependents_data_types[a_proc_that_needs_dependents_data_types_count];
+
 #ifndef result_set_type_decl_a_proc_that_needs_dependents_result_set
 #define result_set_type_decl_a_proc_that_needs_dependents_result_set 1
 cql_result_set_type_decl(a_proc_that_needs_dependents_result_set, a_proc_that_needs_dependents_result_set_ref);
 #endif
-extern a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row);
-extern a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _a_proc_that_needs_dependents_get_a_foo_inline_
+#define _a_proc_that_needs_dependents_get_a_foo_inline_
+
+
+static inline a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (a_proc_we_need_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 0));
+}
+
+#endif
+
+#ifndef _a_proc_that_needs_dependents_get_another_foo_inline_
+#define _a_proc_that_needs_dependents_get_another_foo_inline_
+
+
+static inline a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (a_proc_we_need_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 1));
+}
+
+#endif
+
+
 extern cql_int32 a_proc_that_needs_dependents_result_count(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set);
 #define a_proc_that_needs_dependents_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define a_proc_that_needs_dependents_row_equal(rs1, row1, rs2, row2) \
@@ -3752,12 +7283,33 @@ extern cql_string_ref _Nonnull simple_child_proc_stored_procedure_name;
 
 #define simple_child_proc_data_types_count 2
 
+extern uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_child_proc_result_set
 #define result_set_type_decl_simple_child_proc_result_set 1
 cql_result_set_type_decl(simple_child_proc_result_set, simple_child_proc_result_set_ref);
 #endif
-extern cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _simple_child_proc_get_x_inline_
+#define _simple_child_proc_get_x_inline_
+
+
+static inline cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_child_proc_get_y_inline_
+#define _simple_child_proc_get_y_inline_
+
+
+static inline cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 simple_child_proc_result_count(simple_child_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code simple_child_proc_fetch_results(sqlite3 *_Nonnull _db_, simple_child_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define simple_child_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3775,18 +7327,89 @@ extern cql_string_ref _Nonnull simple_container_proc_stored_procedure_name;
 
 #define simple_container_proc_data_types_count 3
 
+extern uint8_t simple_container_proc_data_types[simple_container_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_container_proc_result_set
 #define result_set_type_decl_simple_container_proc_result_set 1
 cql_result_set_type_decl(simple_container_proc_result_set, simple_container_proc_result_set_ref);
 #endif
-extern cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value);
+#ifndef _simple_container_proc_get_a_is_null_inline_
+#define _simple_container_proc_get_a_is_null_inline_
+
+
+static inline cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_container_proc_get_a_value_inline_
+#define _simple_container_proc_get_a_value_inline_
+
+
+static inline cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_a_value_inline_
+#define _simple_container_proc_set_a_value_inline_
+
+static inline void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
+}
+
+#endif
+
+#ifndef _simple_container_proc_set_a_to_null_inline_
+#define _simple_container_proc_set_a_to_null_inline_
+
+static inline void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+#ifndef _simple_container_proc_get_b_inline_
+#define _simple_container_proc_get_b_inline_
+
+
+static inline cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_b_inline_
+#define _simple_container_proc_set_b_inline_
+
+static inline void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
+}
+
+#endif
+#ifndef _simple_container_proc_get_c_inline_
+#define _simple_container_proc_get_c_inline_
+
+
+static inline simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (simple_child_proc_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 2));
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_c_inline_
+#define _simple_container_proc_set_c_inline_
+
+static inline void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
+}
+
+#endif
+
 extern cql_int32 simple_container_proc_result_count(simple_container_proc_result_set_ref _Nonnull result_set);
 #define simple_container_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define simple_container_proc_row_equal(rs1, row1, rs2, row2) \
@@ -3832,19 +7455,103 @@ extern cql_string_ref _Nonnull use_generated_fragment_stored_procedure_name;
 
 #define use_generated_fragment_data_types_count 7
 
+extern uint8_t use_generated_fragment_data_types[use_generated_fragment_data_types_count];
+
 #ifndef result_set_type_decl_use_generated_fragment_result_set
 #define result_set_type_decl_use_generated_fragment_result_set 1
 cql_result_set_type_decl(use_generated_fragment_result_set, use_generated_fragment_result_set_ref);
 #endif
-extern cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_generated_fragment_get_rowid_inline_
+#define _use_generated_fragment_get_rowid_inline_
+
+
+static inline cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_flag_inline_
+#define _use_generated_fragment_get_flag_inline_
+
+
+static inline cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_id_is_null_inline_
+#define _use_generated_fragment_get_id_is_null_inline_
+
+
+static inline cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_id_value_inline_
+#define _use_generated_fragment_get_id_value_inline_
+
+
+static inline cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_name_inline_
+#define _use_generated_fragment_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_age_is_null_inline_
+#define _use_generated_fragment_get_age_is_null_inline_
+
+
+static inline cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_age_value_inline_
+#define _use_generated_fragment_get_age_value_inline_
+
+
+static inline cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_storage_inline_
+#define _use_generated_fragment_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_pk_inline_
+#define _use_generated_fragment_get_pk_inline_
+
+
+static inline cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_generated_fragment_result_count(use_generated_fragment_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_generated_fragment_fetch_results(sqlite3 *_Nonnull _db_, use_generated_fragment_result_set_ref _Nullable *_Nonnull result_set);
 #define use_generated_fragment_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3862,19 +7569,103 @@ extern cql_string_ref _Nonnull use_backed_table_directly_stored_procedure_name;
 
 #define use_backed_table_directly_data_types_count 7
 
+extern uint8_t use_backed_table_directly_data_types[use_backed_table_directly_data_types_count];
+
 #ifndef result_set_type_decl_use_backed_table_directly_result_set
 #define result_set_type_decl_use_backed_table_directly_result_set 1
 cql_result_set_type_decl(use_backed_table_directly_result_set, use_backed_table_directly_result_set_ref);
 #endif
-extern cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_backed_table_directly_get_rowid_inline_
+#define _use_backed_table_directly_get_rowid_inline_
+
+
+static inline cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_flag_inline_
+#define _use_backed_table_directly_get_flag_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_id_is_null_inline_
+#define _use_backed_table_directly_get_id_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_id_value_inline_
+#define _use_backed_table_directly_get_id_value_inline_
+
+
+static inline cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_name_inline_
+#define _use_backed_table_directly_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_age_is_null_inline_
+#define _use_backed_table_directly_get_age_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_age_value_inline_
+#define _use_backed_table_directly_get_age_value_inline_
+
+
+static inline cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_storage_inline_
+#define _use_backed_table_directly_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_pk_inline_
+#define _use_backed_table_directly_get_pk_inline_
+
+
+static inline cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_backed_table_directly_result_count(use_backed_table_directly_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_backed_table_directly_fetch_results(sqlite3 *_Nonnull _db_, use_backed_table_directly_result_set_ref _Nullable *_Nonnull result_set);
 #define use_backed_table_directly_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3895,19 +7686,103 @@ extern cql_string_ref _Nonnull use_backed_table_directly_in_with_select_stored_p
 
 #define use_backed_table_directly_in_with_select_data_types_count 7
 
+extern uint8_t use_backed_table_directly_in_with_select_data_types[use_backed_table_directly_in_with_select_data_types_count];
+
 #ifndef result_set_type_decl_use_backed_table_directly_in_with_select_result_set
 #define result_set_type_decl_use_backed_table_directly_in_with_select_result_set 1
 cql_result_set_type_decl(use_backed_table_directly_in_with_select_result_set, use_backed_table_directly_in_with_select_result_set_ref);
 #endif
-extern cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_backed_table_directly_in_with_select_get_rowid_inline_
+#define _use_backed_table_directly_in_with_select_get_rowid_inline_
+
+
+static inline cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_flag_inline_
+#define _use_backed_table_directly_in_with_select_get_flag_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_id_is_null_inline_
+#define _use_backed_table_directly_in_with_select_get_id_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_id_value_inline_
+#define _use_backed_table_directly_in_with_select_get_id_value_inline_
+
+
+static inline cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_name_inline_
+#define _use_backed_table_directly_in_with_select_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_age_is_null_inline_
+#define _use_backed_table_directly_in_with_select_get_age_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_age_value_inline_
+#define _use_backed_table_directly_in_with_select_get_age_value_inline_
+
+
+static inline cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_storage_inline_
+#define _use_backed_table_directly_in_with_select_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_pk_inline_
+#define _use_backed_table_directly_in_with_select_get_pk_inline_
+
+
+static inline cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_backed_table_directly_in_with_select_result_count(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select_fetch_results(sqlite3 *_Nonnull _db_, use_backed_table_directly_in_with_select_result_set_ref _Nullable *_Nonnull result_set);
 #define use_backed_table_directly_in_with_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -964,46 +964,6 @@ typedef struct with_result_set_row {
   cql_string_ref _Nullable name;
 } with_result_set_row;
 
-cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_result_set_row *data = (with_result_set_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t with_result_set_data_types[with_result_set_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -1087,21 +1047,6 @@ typedef struct select_from_view_row {
   cql_int32 id;
   cql_nullable_int32 type;
 } select_from_view_row;
-
-cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
-  select_from_view_row *data = (select_from_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t select_from_view_data_types[select_from_view_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -1240,46 +1185,6 @@ typedef struct get_data_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } get_data_row;
-
-cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
-  get_data_row *data = (get_data_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t get_data_data_types[get_data_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -1589,41 +1494,6 @@ typedef struct complex_return_row {
   cql_string_ref _Nonnull _text;
 } complex_return_row;
 
-cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._bool;
-}
-
-cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._integer;
-}
-
-cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._longint;
-}
-
-cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._real;
-}
-
-cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._text;
-}
-
-cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._nullable_bool.is_null;
-}
-
-cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_return_row *data = (complex_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row]._nullable_bool.value;
-}
-
 uint8_t complex_return_data_types[complex_return_data_types_count] = {
   CQL_DATA_TYPE_BOOL | CQL_DATA_TYPE_NOT_NULL, // _bool
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // _integer
@@ -1721,11 +1591,6 @@ typedef struct hierarchical_query_row {
   cql_int32 id;
 } hierarchical_query_row;
 
-cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row) {
-  hierarchical_query_row *data = (hierarchical_query_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t hierarchical_query_data_types[hierarchical_query_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -1815,11 +1680,6 @@ typedef struct hierarchical_unmatched_query_row {
   cql_int32 id;
 } hierarchical_unmatched_query_row;
 
-cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row) {
-  hierarchical_unmatched_query_row *data = (hierarchical_unmatched_query_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t hierarchical_unmatched_query_data_types[hierarchical_unmatched_query_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -1903,11 +1763,6 @@ typedef struct union_select_row {
   cql_int32 A;
 } union_select_row;
 
-cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_select_row *data = (union_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].A;
-}
-
 uint8_t union_select_data_types[union_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
 };
@@ -1980,11 +1835,6 @@ cql_string_proc_name(union_all_select_stored_procedure_name, "union_all_select")
 typedef struct union_all_select_row {
   cql_int32 A;
 } union_all_select_row;
-
-cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_all_select_row *data = (union_all_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].A;
-}
 
 uint8_t union_all_select_data_types[union_all_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -2059,11 +1909,6 @@ cql_string_proc_name(union_all_with_nullable_stored_procedure_name, "union_all_w
 typedef struct union_all_with_nullable_row {
   cql_string_ref _Nullable name;
 } union_all_with_nullable_row;
-
-cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row) {
-  union_all_with_nullable_row *data = (union_all_with_nullable_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
 
 uint8_t union_all_with_nullable_data_types[union_all_with_nullable_data_types_count] = {
   CQL_DATA_TYPE_STRING, // name
@@ -2208,21 +2053,6 @@ typedef struct with_stmt_row {
   cql_int32 c;
 } with_stmt_row;
 
-cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_stmt_row *data = (with_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].c;
-}
-
 uint8_t with_stmt_data_types[with_stmt_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -2310,21 +2140,6 @@ typedef struct with_recursive_stmt_row {
   cql_int32 c;
 } with_recursive_stmt_row;
 
-cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
-  with_recursive_stmt_row *data = (with_recursive_stmt_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].c;
-}
-
 uint8_t with_recursive_stmt_data_types[with_recursive_stmt_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -2407,21 +2222,6 @@ typedef struct parent_proc_row {
   cql_int32 three;
 } parent_proc_row;
 
-cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].one;
-}
-
-cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].two;
-}
-
-cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_row *data = (parent_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].three;
-}
-
 uint8_t parent_proc_data_types[parent_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // one
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // two
@@ -2496,21 +2296,6 @@ typedef struct parent_proc_child_row {
   cql_int32 five;
   cql_int32 six;
 } parent_proc_child_row;
-
-cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].four;
-}
-
-cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].five;
-}
-
-cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
-  parent_proc_child_row *data = (parent_proc_child_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].six;
-}
 
 uint8_t parent_proc_child_data_types[parent_proc_child_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // four
@@ -2721,11 +2506,6 @@ END;
 static int32_t cursor_with_object_perf_index;
 
 cql_string_proc_name(cursor_with_object_stored_procedure_name, "cursor_with_object");
-
-cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set) {
-  cursor_with_object_row *data = (cursor_with_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->object_;
-}
 
 uint8_t cursor_with_object_data_types[cursor_with_object_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // object_
@@ -2975,46 +2755,6 @@ typedef struct uses_proc_for_result_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } uses_proc_for_result_row;
-
-cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
-  uses_proc_for_result_row *data = (uses_proc_for_result_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t uses_proc_for_result_data_types[uses_proc_for_result_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -3324,21 +3064,6 @@ typedef struct blob_returner_row {
   cql_blob_ref _Nullable b_nullable;
 } blob_returner_row;
 
-cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].blob_id;
-}
-
-cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b_notnull;
-}
-
-cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
-  blob_returner_row *data = (blob_returner_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b_nullable;
-}
-
 uint8_t blob_returner_data_types[blob_returner_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // blob_id
   CQL_DATA_TYPE_BLOB | CQL_DATA_TYPE_NOT_NULL, // b_notnull
@@ -3439,56 +3164,6 @@ END;
 static int32_t out_cursor_proc_perf_index;
 
 cql_string_proc_name(out_cursor_proc_stored_procedure_name, "out_cursor_proc");
-
-cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
-
-cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->extra1;
-}
-
-cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set) {
-  out_cursor_proc_row *data = (out_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->extra2;
-}
 
 uint8_t out_cursor_proc_data_types[out_cursor_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -3762,11 +3437,6 @@ cql_string_proc_name(thread_theme_info_list_stored_procedure_name, "thread_theme
 typedef struct thread_theme_info_list_row {
   cql_int64 thread_key;
 } thread_theme_info_list_row;
-
-cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row) {
-  thread_theme_info_list_row *data = (thread_theme_info_list_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].thread_key;
-}
 
 uint8_t thread_theme_info_list_data_types[thread_theme_info_list_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // thread_key
@@ -4076,16 +3746,6 @@ static int32_t out_no_db_perf_index;
 
 cql_string_proc_name(out_no_db_stored_procedure_name, "out_no_db");
 
-cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set) {
-  out_no_db_row *data = (out_no_db_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set) {
-  out_no_db_row *data = (out_no_db_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
-
 uint8_t out_no_db_data_types[out_no_db_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
   CQL_DATA_TYPE_DOUBLE | CQL_DATA_TYPE_NOT_NULL, // B
@@ -4159,16 +3819,6 @@ END;
 static int32_t declare_cursor_like_cursor_perf_index;
 
 cql_string_proc_name(declare_cursor_like_cursor_stored_procedure_name, "declare_cursor_like_cursor");
-
-cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_cursor_row *data = (declare_cursor_like_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_cursor_row *data = (declare_cursor_like_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
 
 uint8_t declare_cursor_like_cursor_data_types[declare_cursor_like_cursor_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -4253,21 +3903,6 @@ static int32_t declare_cursor_like_proc_perf_index;
 
 cql_string_proc_name(declare_cursor_like_proc_stored_procedure_name, "declare_cursor_like_proc");
 
-cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->a.is_null;
-}
-
-cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->a.value;
-}
-
-cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_proc_row *data = (declare_cursor_like_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b;
-}
-
 uint8_t declare_cursor_like_proc_data_types[declare_cursor_like_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // a
   CQL_DATA_TYPE_STRING, // b
@@ -4345,46 +3980,6 @@ END;
 static int32_t declare_cursor_like_table_perf_index;
 
 cql_string_proc_name(declare_cursor_like_table_stored_procedure_name, "declare_cursor_like_table");
-
-cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_table_row *data = (declare_cursor_like_table_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
 
 uint8_t declare_cursor_like_table_data_types[declare_cursor_like_table_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -4473,21 +4068,6 @@ END;
 static int32_t declare_cursor_like_view_perf_index;
 
 cql_string_proc_name(declare_cursor_like_view_stored_procedure_name, "declare_cursor_like_view");
-
-cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f1;
-}
-
-cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f2;
-}
-
-cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
-  declare_cursor_like_view_row *data = (declare_cursor_like_view_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->f3;
-}
 
 uint8_t declare_cursor_like_view_data_types[declare_cursor_like_view_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // f1
@@ -4823,16 +4403,6 @@ END;
 static int32_t fetch_to_cursor_from_cursor_perf_index;
 
 cql_string_proc_name(fetch_to_cursor_from_cursor_stored_procedure_name, "fetch_to_cursor_from_cursor");
-
-cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
-  fetch_to_cursor_from_cursor_row *data = (fetch_to_cursor_from_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->A;
-}
-
-cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
-  fetch_to_cursor_from_cursor_row *data = (fetch_to_cursor_from_cursor_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->B;
-}
 
 uint8_t fetch_to_cursor_from_cursor_data_types[fetch_to_cursor_from_cursor_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // A
@@ -5252,11 +4822,6 @@ static int32_t out_union_helper_perf_index;
 
 cql_string_proc_name(out_union_helper_stored_procedure_name, "out_union_helper");
 
-cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_helper_row *data = (out_union_helper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t out_union_helper_data_types[out_union_helper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5320,11 +4885,6 @@ END;
 static int32_t out_union_dml_helper_perf_index;
 
 cql_string_proc_name(out_union_dml_helper_stored_procedure_name, "out_union_dml_helper");
-
-cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_helper_row *data = (out_union_dml_helper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t out_union_dml_helper_data_types[out_union_dml_helper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -5462,11 +5022,6 @@ static int32_t forward_out_union_perf_index;
 
 cql_string_proc_name(forward_out_union_stored_procedure_name, "forward_out_union");
 
-cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_row *data = (forward_out_union_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t forward_out_union_data_types[forward_out_union_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5521,11 +5076,6 @@ static int32_t forward_out_union_extern_perf_index;
 
 cql_string_proc_name(forward_out_union_extern_stored_procedure_name, "forward_out_union_extern");
 
-cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_extern_row *data = (forward_out_union_extern_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t forward_out_union_extern_data_types[forward_out_union_extern_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -5573,11 +5123,6 @@ END;
 static int32_t forward_out_union_dml_perf_index;
 
 cql_string_proc_name(forward_out_union_dml_stored_procedure_name, "forward_out_union_dml");
-
-cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  forward_out_union_dml_row *data = (forward_out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t forward_out_union_dml_data_types[forward_out_union_dml_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -5867,16 +5412,6 @@ typedef struct simple_identity_row {
   cql_int32 data;
 } simple_identity_row;
 
-cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_identity_row *data = (simple_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_identity_row *data = (simple_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
-
 uint8_t simple_identity_data_types[simple_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // data
@@ -5956,21 +5491,6 @@ typedef struct complex_identity_row {
   cql_int32 data;
 } complex_identity_row;
 
-cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].col1;
-}
-
-cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].col2;
-}
-
-cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
-  complex_identity_row *data = (complex_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
-
 uint8_t complex_identity_data_types[complex_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // col1
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // col2
@@ -6049,16 +5569,6 @@ END;
 static int32_t out_cursor_identity_perf_index;
 
 cql_string_proc_name(out_cursor_identity_stored_procedure_name, "out_cursor_identity");
-
-cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set) {
-  out_cursor_identity_row *data = (out_cursor_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set) {
-  out_cursor_identity_row *data = (out_cursor_identity_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->data;
-}
 
 uint8_t out_cursor_identity_data_types[out_cursor_identity_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6157,16 +5667,6 @@ typedef struct radioactive_proc_row {
   cql_int32 id;
   cql_string_ref _Nullable data;
 } radioactive_proc_row;
-
-cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  radioactive_proc_row *data = (radioactive_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  radioactive_proc_row *data = (radioactive_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
 
 uint8_t radioactive_proc_data_types[radioactive_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6332,16 +5832,6 @@ typedef struct autodropper_row {
   cql_int32 b;
 } autodropper_row;
 
-cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  autodropper_row *data = (autodropper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a;
-}
-
-cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
-  autodropper_row *data = (autodropper_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
 uint8_t autodropper_data_types[autodropper_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // a
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -6411,11 +5901,6 @@ END;
 static int32_t simple_cursor_proc_perf_index;
 
 cql_string_proc_name(simple_cursor_proc_stored_procedure_name, "simple_cursor_proc");
-
-cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set) {
-  simple_cursor_proc_row *data = (simple_cursor_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
 
 uint8_t simple_cursor_proc_data_types[simple_cursor_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -6488,16 +5973,6 @@ typedef struct redundant_cast_row {
   cql_int32 plugh;
   cql_int32 five;
 } redundant_cast_row;
-
-cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
-  redundant_cast_row *data = (redundant_cast_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].plugh;
-}
-
-cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
-  redundant_cast_row *data = (redundant_cast_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].five;
-}
 
 uint8_t redundant_cast_data_types[redundant_cast_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // plugh
@@ -6650,16 +6125,6 @@ typedef struct top_level_select_alias_unused_row {
   cql_int32 x;
 } top_level_select_alias_unused_row;
 
-cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_unused_row *data = (top_level_select_alias_unused_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_unused_row *data = (top_level_select_alias_unused_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t top_level_select_alias_unused_data_types[top_level_select_alias_unused_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -6738,16 +6203,6 @@ typedef struct top_level_select_alias_used_in_orderby_row {
   cql_int32 id;
   cql_int32 x;
 } top_level_select_alias_used_in_orderby_row;
-
-cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_used_in_orderby_row *data = (top_level_select_alias_used_in_orderby_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
-  top_level_select_alias_used_in_orderby_row *data = (top_level_select_alias_used_in_orderby_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t top_level_select_alias_used_in_orderby_data_types[top_level_select_alias_used_in_orderby_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -7173,16 +6628,6 @@ static int32_t out_union_two_perf_index;
 
 cql_string_proc_name(out_union_two_stored_procedure_name, "out_union_two");
 
-cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_two_row *data = (out_union_two_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_two_row *data = (out_union_two_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t out_union_two_data_types[out_union_two_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // y
@@ -7322,16 +6767,6 @@ END;
 static int32_t out_union_from_select_perf_index;
 
 cql_string_proc_name(out_union_from_select_stored_procedure_name, "out_union_from_select");
-
-cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_from_select_row *data = (out_union_from_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_from_select_row *data = (out_union_from_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
 
 uint8_t out_union_from_select_data_types[out_union_from_select_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -7487,16 +6922,6 @@ static int32_t out_union_values_perf_index;
 
 cql_string_proc_name(out_union_values_stored_procedure_name, "out_union_values");
 
-cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_values_row *data = (out_union_values_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_values_row *data = (out_union_values_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t out_union_values_data_types[out_union_values_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // y
@@ -7616,16 +7041,6 @@ END;
 static int32_t out_union_dml_perf_index;
 
 cql_string_proc_name(out_union_dml_stored_procedure_name, "out_union_dml");
-
-cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_row *data = (out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
-  out_union_dml_row *data = (out_union_dml_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].data;
-}
 
 uint8_t out_union_dml_data_types[out_union_dml_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -7828,16 +7243,6 @@ typedef struct window_function_invocation_row {
   cql_int32 row_num;
 } window_function_invocation_row;
 
-cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window_function_invocation_row *data = (window_function_invocation_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window_function_invocation_row *data = (window_function_invocation_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].row_num;
-}
-
 uint8_t window_function_invocation_data_types[window_function_invocation_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // row_num
@@ -7965,11 +7370,6 @@ cql_string_proc_name(use_return_stored_procedure_name, "use_return");
 typedef struct use_return_row {
   cql_int32 x;
 } use_return_row;
-
-cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_return_row *data = (use_return_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t use_return_data_types[use_return_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -8386,46 +7786,6 @@ typedef struct sproc_with_copy_row {
   cql_string_ref _Nullable name;
 } sproc_with_copy_row;
 
-cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sproc_with_copy_row *data = (sproc_with_copy_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t sproc_with_copy_data_types[sproc_with_copy_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -8508,82 +7868,6 @@ END;
 static int32_t emit_object_with_setters_perf_index;
 
 cql_string_proc_name(emit_object_with_setters_stored_procedure_name, "emit_object_with_setters");
-
-cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
-extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
-}
-
-cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x;
-}
-
-extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
-}
-
-cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i;
-}
-
-extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
-}
-
-cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l;
-}
-
-extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
-}
-
-cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b;
-}
-
-extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
-  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
-}
-
-cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d;
-}
-
-extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
-}
-
-cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->t;
-}
-
-extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
-}
-
-cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set) {
-  emit_object_with_setters_row *data = (emit_object_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->bl;
-}
-
-extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
-  cql_contract_argument_notnull((void *)new_value, 2);
-  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
-}
 
 uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data_types_count] = {
   CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
@@ -8703,114 +7987,6 @@ static int32_t emit_setters_with_nullables_perf_index;
 
 cql_string_proc_name(emit_setters_with_nullables_stored_procedure_name, "emit_setters_with_nullables");
 
-cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
-extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
-}
-
-cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x;
-}
-
-extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
-}
-
-cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i.is_null;
-}
-
-cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->i.value;
-}
-
-extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
-}
-
-extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
-}
-
-cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l.is_null;
-}
-
-cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->l.value;
-}
-
-extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
-}
-
-extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
-}
-
-cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b.is_null;
-}
-
-cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->b.value;
-}
-
-extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
-  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
-}
-
-extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
-}
-
-cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d.is_null;
-}
-
-cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->d.value;
-}
-
-extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
-}
-
-extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
-}
-
-cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->t;
-}
-
-extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
-}
-
-cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
-  emit_setters_with_nullables_row *data = (emit_setters_with_nullables_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->bl;
-}
-
-extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
-  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
-}
-
 uint8_t emit_setters_with_nullables_data_types[emit_setters_with_nullables_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // o
   CQL_DATA_TYPE_OBJECT, // x
@@ -8928,78 +8104,6 @@ typedef struct no_out_with_setters_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } no_out_with_setters_row;
-
-cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
-}
-
-cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value) {
-  cql_result_set_set_string_col((cql_result_set_ref)result_set, row, 1, new_value);
-}
-
-cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value) {
-  cql_result_set_set_int64_col((cql_result_set_ref)result_set, row, 2, new_value);
-}
-
-extern void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 2);
-}
-
-cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 3, new_value);
-}
-
-extern void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 3);
-}
-
-cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  no_out_with_setters_row *data = (no_out_with_setters_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
-extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value) {
-  cql_result_set_set_double_col((cql_result_set_ref)result_set, row, 4, new_value);
-}
-
-extern void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 4);
-}
 
 uint8_t no_out_with_setters_data_types[no_out_with_setters_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -9179,31 +8283,6 @@ typedef struct vault_sensitive_with_values_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_values_proc_row;
 
-cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_values_proc_row *data = (vault_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_values_proc_data_types[vault_sensitive_with_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9294,26 +8373,6 @@ typedef struct vault_not_nullable_sensitive_with_values_proc_row {
   cql_string_ref _Nonnull title;
 } vault_not_nullable_sensitive_with_values_proc_row;
 
-cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_not_nullable_sensitive_with_values_proc_row *data = (vault_not_nullable_sensitive_with_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type;
-}
-
 uint8_t vault_not_nullable_sensitive_with_values_proc_data_types[vault_not_nullable_sensitive_with_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_ENCODED, // name
@@ -9402,31 +8461,6 @@ typedef struct vault_sensitive_with_no_values_proc_row {
   cql_string_ref _Nullable name;
   cql_string_ref _Nullable title;
 } vault_sensitive_with_no_values_proc_row;
-
-cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_values_proc_row *data = (vault_sensitive_with_no_values_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t vault_sensitive_with_no_values_proc_data_types[vault_sensitive_with_no_values_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -9520,31 +8554,6 @@ typedef struct vault_union_all_table_proc_row {
   cql_string_ref _Nullable title;
 } vault_union_all_table_proc_row;
 
-cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_union_all_table_proc_row *data = (vault_union_all_table_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_union_all_table_proc_data_types[vault_union_all_table_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9634,11 +8643,6 @@ typedef struct vault_alias_column_proc_row {
   cql_string_ref _Nullable alias_name;
 } vault_alias_column_proc_row;
 
-cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_alias_column_proc_row *data = (vault_alias_column_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].alias_name;
-}
-
 uint8_t vault_alias_column_proc_data_types[vault_alias_column_proc_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // alias_name
 };
@@ -9718,11 +8722,6 @@ cql_string_proc_name(vault_alias_column_name_proc_stored_procedure_name, "vault_
 typedef struct vault_alias_column_name_proc_row {
   cql_string_ref _Nullable alias_name;
 } vault_alias_column_name_proc_row;
-
-cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_alias_column_name_proc_row *data = (vault_alias_column_name_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].alias_name;
-}
 
 uint8_t vault_alias_column_name_proc_data_types[vault_alias_column_name_proc_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // alias_name
@@ -9859,31 +8858,6 @@ typedef struct vault_sensitive_with_context_and_sensitive_columns_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_context_and_sensitive_columns_proc_row;
 
-cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -9973,31 +8947,6 @@ typedef struct vault_sensitive_with_no_context_and_sensitive_columns_proc_row {
   cql_string_ref _Nullable title;
 } vault_sensitive_with_no_context_and_sensitive_columns_proc_row;
 
-cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_no_context_and_sensitive_columns_proc_row *data = (vault_sensitive_with_no_context_and_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
 uint8_t vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_ENCODED, // name
@@ -10086,31 +9035,6 @@ typedef struct vault_sensitive_with_context_and_no_sensitive_columns_proc_row {
   cql_string_ref _Nullable name;
   cql_string_ref _Nullable title;
 } vault_sensitive_with_context_and_no_sensitive_columns_proc_row;
-
-cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].title;
-}
-
-cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  vault_sensitive_with_context_and_no_sensitive_columns_proc_row *data = (vault_sensitive_with_context_and_no_sensitive_columns_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
 
 uint8_t vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -10788,36 +9712,6 @@ typedef struct window1_row {
   cql_nullable_double SalesMovingAverage;
 } window1_row;
 
-cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window1_row *data = (window1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window1_data_types[window1_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -10896,36 +9790,6 @@ typedef struct window2_row {
   cql_nullable_double amount;
   cql_nullable_double RunningTotal;
 } window2_row;
-
-cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].RunningTotal.is_null;
-}
-
-cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window2_row *data = (window2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].RunningTotal.value;
-}
 
 uint8_t window2_data_types[window2_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11006,36 +9870,6 @@ typedef struct window3_row {
   cql_nullable_double SalesMovingAverage;
 } window3_row;
 
-cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window3_row *data = (window3_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window3_data_types[window3_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11114,36 +9948,6 @@ typedef struct window4_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window4_row;
-
-cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window4_row *data = (window4_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window4_data_types[window4_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11224,36 +10028,6 @@ typedef struct window5_row {
   cql_nullable_double SalesMovingAverage;
 } window5_row;
 
-cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window5_row *data = (window5_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window5_data_types[window5_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11332,36 +10106,6 @@ typedef struct window6_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window6_row;
-
-cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window6_row *data = (window6_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window6_data_types[window6_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11442,36 +10186,6 @@ typedef struct window7_row {
   cql_nullable_double SalesMovingAverage;
 } window7_row;
 
-cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window7_row *data = (window7_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window7_data_types[window7_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11550,36 +10264,6 @@ typedef struct window8_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window8_row;
-
-cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window8_row *data = (window8_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window8_data_types[window8_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11660,36 +10344,6 @@ typedef struct window9_row {
   cql_nullable_double SalesMovingAverage;
 } window9_row;
 
-cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window9_row *data = (window9_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window9_data_types[window9_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11768,36 +10422,6 @@ typedef struct window10_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window10_row;
-
-cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window10_row *data = (window10_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window10_data_types[window10_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -11878,36 +10502,6 @@ typedef struct window11_row {
   cql_nullable_double SalesMovingAverage;
 } window11_row;
 
-cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window11_row *data = (window11_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window11_data_types[window11_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -11986,36 +10580,6 @@ typedef struct window12_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window12_row;
-
-cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window12_row *data = (window12_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window12_data_types[window12_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12096,36 +10660,6 @@ typedef struct window13_row {
   cql_nullable_double SalesMovingAverage;
 } window13_row;
 
-cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window13_row *data = (window13_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window13_data_types[window13_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -12204,36 +10738,6 @@ typedef struct window14_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window14_row;
-
-cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window14_row *data = (window14_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window14_data_types[window14_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12314,36 +10818,6 @@ typedef struct window15_row {
   cql_nullable_double SalesMovingAverage;
 } window15_row;
 
-cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window15_row *data = (window15_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
-
 uint8_t window15_data_types[window15_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
   CQL_DATA_TYPE_DOUBLE, // amount
@@ -12422,36 +10896,6 @@ typedef struct window16_row {
   cql_nullable_double amount;
   cql_nullable_double SalesMovingAverage;
 } window16_row;
-
-cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.is_null;
-}
-
-cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].month.value;
-}
-
-cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.is_null;
-}
-
-cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].amount.value;
-}
-
-cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.is_null;
-}
-
-cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
-  window16_row *data = (window16_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].SalesMovingAverage.value;
-}
 
 uint8_t window16_data_types[window16_data_types_count] = {
   CQL_DATA_TYPE_INT32, // month
@@ -12920,26 +11364,6 @@ typedef struct virtual1_row {
   cql_int32 vz;
 } virtual1_row;
 
-cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vx;
-}
-
-cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.is_null;
-}
-
-cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.value;
-}
-
-cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual1_row *data = (virtual1_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vz;
-}
-
 uint8_t virtual1_data_types[virtual1_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // vx
   CQL_DATA_TYPE_INT32, // vy
@@ -13017,26 +11441,6 @@ typedef struct virtual2_row {
   cql_nullable_int32 vy;
   cql_int32 vz;
 } virtual2_row;
-
-cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vx;
-}
-
-cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.is_null;
-}
-
-cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vy.value;
-}
-
-cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
-  virtual2_row *data = (virtual2_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].vz;
-}
 
 uint8_t virtual2_data_types[virtual2_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // vx
@@ -13997,11 +12401,6 @@ static int32_t out_object_perf_index;
 
 cql_string_proc_name(out_object_stored_procedure_name, "out_object");
 
-cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
-  out_object_row *data = (out_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->o;
-}
-
 uint8_t out_object_data_types[out_object_data_types_count] = {
   CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
 };
@@ -14161,46 +12560,6 @@ typedef struct result_set_proc_with_contract_in_fetch_results_row {
   cql_string_ref _Nullable name;
 } result_set_proc_with_contract_in_fetch_results_row;
 
-cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
-  result_set_proc_with_contract_in_fetch_results_row *data = (result_set_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
-
 uint8_t result_set_proc_with_contract_in_fetch_results_data_types[result_set_proc_with_contract_in_fetch_results_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
   CQL_DATA_TYPE_STRING, // name
@@ -14283,46 +12642,6 @@ END;
 static int32_t out_proc_with_contract_in_fetch_results_perf_index;
 
 cql_string_proc_name(out_proc_with_contract_in_fetch_results_stored_procedure_name, "out_proc_with_contract_in_fetch_results");
-
-cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->id;
-}
-
-cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->name;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.is_null;
-}
-
-cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->rate.value;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.is_null;
-}
-
-cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->type.value;
-}
-
-cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.is_null;
-}
-
-cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
-  out_proc_with_contract_in_fetch_results_row *data = (out_proc_with_contract_in_fetch_results_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->size.value;
-}
 
 uint8_t out_proc_with_contract_in_fetch_results_data_types[out_proc_with_contract_in_fetch_results_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -14419,11 +12738,6 @@ cql_string_proc_name(nullability_improvements_are_erased_for_sql_stored_procedur
 typedef struct nullability_improvements_are_erased_for_sql_row {
   cql_int32 b;
 } nullability_improvements_are_erased_for_sql_row;
-
-cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row) {
-  nullability_improvements_are_erased_for_sql_row *data = (nullability_improvements_are_erased_for_sql_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
 
 uint8_t nullability_improvements_are_erased_for_sql_data_types[nullability_improvements_are_erased_for_sql_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // b
@@ -15283,11 +13597,6 @@ typedef struct sensitive_function_is_a_no_op_row {
   cql_string_ref _Nonnull y;
 } sensitive_function_is_a_no_op_row;
 
-cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row) {
-  sensitive_function_is_a_no_op_row *data = (sensitive_function_is_a_no_op_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t sensitive_function_is_a_no_op_data_types[sensitive_function_is_a_no_op_data_types_count] = {
   CQL_DATA_TYPE_STRING | CQL_DATA_TYPE_NOT_NULL, // y
 };
@@ -15485,11 +13794,6 @@ typedef struct foo_row {
   cql_int32 shared_something;
 } foo_row;
 
-cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row) {
-  foo_row *data = (foo_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].shared_something;
-}
-
 uint8_t foo_data_types[foo_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // shared_something
 };
@@ -15592,46 +13896,6 @@ typedef struct shared_conditional_user_row {
   cql_nullable_double size;
   cql_string_ref _Nullable name;
 } shared_conditional_user_row;
-
-cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
-cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.is_null;
-}
-
-cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rate.value;
-}
-
-cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.is_null;
-}
-
-cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].type.value;
-}
-
-cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.is_null;
-}
-
-cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_conditional_user_row *data = (shared_conditional_user_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].size.value;
-}
 
 uint8_t shared_conditional_user_data_types[shared_conditional_user_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
@@ -15784,11 +14048,6 @@ typedef struct nested_shared_stuff_row {
   cql_int32 x;
 } nested_shared_stuff_row;
 
-cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row) {
-  nested_shared_stuff_row *data = (nested_shared_stuff_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
 uint8_t nested_shared_stuff_data_types[nested_shared_stuff_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
 };
@@ -15919,11 +14178,6 @@ cql_string_proc_name(use_nested_select_shared_frag_form_stored_procedure_name, "
 typedef struct use_nested_select_shared_frag_form_row {
   cql_int32 x;
 } use_nested_select_shared_frag_form_row;
-
-cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_nested_select_shared_frag_form_row *data = (use_nested_select_shared_frag_form_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
 
 uint8_t use_nested_select_shared_frag_form_data_types[use_nested_select_shared_frag_form_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
@@ -16114,11 +14368,6 @@ typedef struct shared_frag_else_nothing_test_row {
   cql_int32 id;
 } shared_frag_else_nothing_test_row;
 
-cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_test_row *data = (shared_frag_else_nothing_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id;
-}
-
 uint8_t shared_frag_else_nothing_test_data_types[shared_frag_else_nothing_test_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // id
 };
@@ -16216,21 +14465,6 @@ typedef struct shared_frag_else_nothing_in_from_clause_test_row {
   cql_nullable_int32 id1;
   cql_string_ref _Nonnull text1;
 } shared_frag_else_nothing_in_from_clause_test_row;
-
-cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id1.is_null;
-}
-
-cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id1.value;
-}
-
-cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
-  shared_frag_else_nothing_in_from_clause_test_row *data = (shared_frag_else_nothing_in_from_clause_test_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].text1;
-}
 
 uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count] = {
   CQL_DATA_TYPE_INT32, // id1
@@ -16683,16 +14917,6 @@ static int32_t some_redeclared_out_proc_perf_index;
 
 cql_string_proc_name(some_redeclared_out_proc_stored_procedure_name, "some_redeclared_out_proc");
 
-cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
-  some_redeclared_out_proc_row *data = (some_redeclared_out_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x.is_null;
-}
-
-cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
-  some_redeclared_out_proc_row *data = (some_redeclared_out_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data->x.value;
-}
-
 uint8_t some_redeclared_out_proc_data_types[some_redeclared_out_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // x
 };
@@ -16788,16 +15012,6 @@ END;
 static int32_t some_redeclared_out_union_proc_perf_index;
 
 cql_string_proc_name(some_redeclared_out_union_proc_stored_procedure_name, "some_redeclared_out_union_proc");
-
-cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  some_redeclared_out_union_proc_row *data = (some_redeclared_out_union_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x.is_null;
-}
-
-cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  some_redeclared_out_union_proc_row *data = (some_redeclared_out_union_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x.value;
-}
 
 uint8_t some_redeclared_out_union_proc_data_types[some_redeclared_out_union_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // x
@@ -17098,16 +15312,6 @@ static int32_t a_proc_that_needs_dependents_perf_index;
 
 cql_string_proc_name(a_proc_that_needs_dependents_stored_procedure_name, "a_proc_that_needs_dependents");
 
-a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
-  a_proc_that_needs_dependents_row *data = (a_proc_that_needs_dependents_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (a_proc_we_need_result_set_ref _Nullable )data[row].a_foo;
-}
-
-a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
-  a_proc_that_needs_dependents_row *data = (a_proc_that_needs_dependents_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (a_proc_we_need_result_set_ref _Nullable )data[row].another_foo;
-}
-
 uint8_t a_proc_that_needs_dependents_data_types[a_proc_that_needs_dependents_data_types_count] = {
   CQL_DATA_TYPE_OBJECT, // a_foo
   CQL_DATA_TYPE_OBJECT, // another_foo
@@ -17226,16 +15430,6 @@ typedef struct simple_child_proc_row {
   cql_int32 y;
 } simple_child_proc_row;
 
-cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_child_proc_row *data = (simple_child_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].x;
-}
-
-cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_child_proc_row *data = (simple_child_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].y;
-}
-
 uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // x
   CQL_DATA_TYPE_INT32 | CQL_DATA_TYPE_NOT_NULL, // y
@@ -17307,42 +15501,6 @@ END;
 static int32_t simple_container_proc_perf_index;
 
 cql_string_proc_name(simple_container_proc_stored_procedure_name, "simple_container_proc");
-
-cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a.is_null;
-}
-
-cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].a.value;
-}
-
-extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
-}
-
-extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
-}
-
-cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].b;
-}
-
-extern void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
-  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
-}
-
-simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
-  simple_container_proc_row *data = (simple_container_proc_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return (simple_child_proc_result_set_ref _Nullable )data[row].c;
-}
-
-extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
-  cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
-}
 
 uint8_t simple_container_proc_data_types[simple_container_proc_data_types_count] = {
   CQL_DATA_TYPE_INT32, // a
@@ -17633,51 +15791,6 @@ typedef struct use_generated_fragment_row {
   cql_blob_ref _Nullable storage;
 } use_generated_fragment_row;
 
-cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_generated_fragment_row *data = (use_generated_fragment_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
-
 uint8_t use_generated_fragment_data_types[use_generated_fragment_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid
   CQL_DATA_TYPE_BOOL | CQL_DATA_TYPE_NOT_NULL, // flag
@@ -17787,51 +15900,6 @@ typedef struct use_backed_table_directly_row {
   cql_string_ref _Nullable name;
   cql_blob_ref _Nullable storage;
 } use_backed_table_directly_row;
-
-cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_row *data = (use_backed_table_directly_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
 
 uint8_t use_backed_table_directly_data_types[use_backed_table_directly_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid
@@ -17999,51 +16067,6 @@ typedef struct use_backed_table_directly_in_with_select_row {
   cql_string_ref _Nullable name;
   cql_blob_ref _Nullable storage;
 } use_backed_table_directly_in_with_select_row;
-
-cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].rowid;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].flag;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.is_null;
-}
-
-cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].id.value;
-}
-
-cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].name;
-}
-
-cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.is_null;
-}
-
-cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].age.value;
-}
-
-cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].storage;
-}
-
-cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
-  use_backed_table_directly_in_with_select_row *data = (use_backed_table_directly_in_with_select_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
-  return data[row].pk;
-}
 
 uint8_t use_backed_table_directly_in_with_select_data_types[use_backed_table_directly_in_with_select_data_types_count] = {
   CQL_DATA_TYPE_INT64 | CQL_DATA_TYPE_NOT_NULL, // rowid

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -282,18 +282,93 @@ extern cql_string_ref _Nonnull with_result_set_stored_procedure_name;
 
 #define with_result_set_data_types_count 5
 
+extern uint8_t with_result_set_data_types[with_result_set_data_types_count];
+
 #ifndef result_set_type_decl_with_result_set_result_set
 #define result_set_type_decl_with_result_set_result_set 1
 cql_result_set_type_decl(with_result_set_result_set, with_result_set_result_set_ref);
 #endif
-extern cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_result_set_get_id_inline_
+#define _with_result_set_get_id_inline_
+
+
+static inline cql_int32 with_result_set_get_id(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_result_set_get_name_inline_
+#define _with_result_set_get_name_inline_
+
+
+static inline cql_string_ref _Nullable with_result_set_get_name(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_result_set_get_rate_is_null_inline_
+#define _with_result_set_get_rate_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_rate_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _with_result_set_get_rate_value_inline_
+#define _with_result_set_get_rate_value_inline_
+
+
+static inline cql_int64 with_result_set_get_rate_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _with_result_set_get_type_is_null_inline_
+#define _with_result_set_get_type_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_type_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _with_result_set_get_type_value_inline_
+#define _with_result_set_get_type_value_inline_
+
+
+static inline cql_int32 with_result_set_get_type_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _with_result_set_get_size_is_null_inline_
+#define _with_result_set_get_size_is_null_inline_
+
+
+static inline cql_bool with_result_set_get_size_is_null(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _with_result_set_get_size_value_inline_
+#define _with_result_set_get_size_value_inline_
+
+
+static inline cql_double with_result_set_get_size_value(with_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 with_result_set_result_count(with_result_set_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_result_set_fetch_results(sqlite3 *_Nonnull _db_, with_result_set_result_set_ref _Nullable *_Nonnull result_set);
 #define with_result_set_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -311,13 +386,43 @@ extern cql_string_ref _Nonnull select_from_view_stored_procedure_name;
 
 #define select_from_view_data_types_count 2
 
+extern uint8_t select_from_view_data_types[select_from_view_data_types_count];
+
 #ifndef result_set_type_decl_select_from_view_result_set
 #define result_set_type_decl_select_from_view_result_set 1
 cql_result_set_type_decl(select_from_view_result_set, select_from_view_result_set_ref);
 #endif
-extern cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _select_from_view_get_id_inline_
+#define _select_from_view_get_id_inline_
+
+
+static inline cql_int32 select_from_view_get_id(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _select_from_view_get_type_is_null_inline_
+#define _select_from_view_get_type_is_null_inline_
+
+
+static inline cql_bool select_from_view_get_type_is_null(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _select_from_view_get_type_value_inline_
+#define _select_from_view_get_type_value_inline_
+
+
+static inline cql_int32 select_from_view_get_type_value(select_from_view_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 select_from_view_result_count(select_from_view_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code select_from_view_fetch_results(sqlite3 *_Nonnull _db_, select_from_view_result_set_ref _Nullable *_Nonnull result_set);
 #define select_from_view_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -341,18 +446,93 @@ extern cql_string_ref _Nonnull get_data_stored_procedure_name;
 
 #define get_data_data_types_count 5
 
+extern uint8_t get_data_data_types[get_data_data_types_count];
+
 #ifndef result_set_type_decl_get_data_result_set
 #define result_set_type_decl_get_data_result_set 1
 cql_result_set_type_decl(get_data_result_set, get_data_result_set_ref);
 #endif
-extern cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _get_data_get_id_inline_
+#define _get_data_get_id_inline_
+
+
+static inline cql_int32 get_data_get_id(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _get_data_get_name_inline_
+#define _get_data_get_name_inline_
+
+
+static inline cql_string_ref _Nullable get_data_get_name(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _get_data_get_rate_is_null_inline_
+#define _get_data_get_rate_is_null_inline_
+
+
+static inline cql_bool get_data_get_rate_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _get_data_get_rate_value_inline_
+#define _get_data_get_rate_value_inline_
+
+
+static inline cql_int64 get_data_get_rate_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _get_data_get_type_is_null_inline_
+#define _get_data_get_type_is_null_inline_
+
+
+static inline cql_bool get_data_get_type_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _get_data_get_type_value_inline_
+#define _get_data_get_type_value_inline_
+
+
+static inline cql_int32 get_data_get_type_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _get_data_get_size_is_null_inline_
+#define _get_data_get_size_is_null_inline_
+
+
+static inline cql_bool get_data_get_size_is_null(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _get_data_get_size_value_inline_
+#define _get_data_get_size_value_inline_
+
+
+static inline cql_double get_data_get_size_value(get_data_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 get_data_result_count(get_data_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code get_data_fetch_results(sqlite3 *_Nonnull _db_, get_data_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull name_, cql_int32 id_);
 #define get_data_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -412,17 +592,83 @@ extern cql_string_ref _Nonnull complex_return_stored_procedure_name;
 
 #define complex_return_data_types_count 6
 
+extern uint8_t complex_return_data_types[complex_return_data_types_count];
+
 #ifndef result_set_type_decl_complex_return_result_set
 #define result_set_type_decl_complex_return_result_set 1
 cql_result_set_type_decl(complex_return_result_set, complex_return_result_set_ref);
 #endif
-extern cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _complex_return_get__bool_inline_
+#define _complex_return_get__bool_inline_
+
+
+static inline cql_bool complex_return_get__bool(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _complex_return_get__integer_inline_
+#define _complex_return_get__integer_inline_
+
+
+static inline cql_int32 complex_return_get__integer(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _complex_return_get__longint_inline_
+#define _complex_return_get__longint_inline_
+
+
+static inline cql_int64 complex_return_get__longint(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _complex_return_get__real_inline_
+#define _complex_return_get__real_inline_
+
+
+static inline cql_double complex_return_get__real(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _complex_return_get__text_inline_
+#define _complex_return_get__text_inline_
+
+
+static inline cql_string_ref _Nonnull complex_return_get__text(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _complex_return_get__nullable_bool_is_null_inline_
+#define _complex_return_get__nullable_bool_is_null_inline_
+
+
+static inline cql_bool complex_return_get__nullable_bool_is_null(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _complex_return_get__nullable_bool_value_inline_
+#define _complex_return_get__nullable_bool_value_inline_
+
+
+static inline cql_bool complex_return_get__nullable_bool_value(complex_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+
 extern cql_int32 complex_return_result_count(complex_return_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code complex_return_fetch_results(sqlite3 *_Nonnull _db_, complex_return_result_set_ref _Nullable *_Nonnull result_set);
 #define complex_return_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -440,11 +686,23 @@ extern cql_string_ref _Nonnull hierarchical_query_stored_procedure_name;
 
 #define hierarchical_query_data_types_count 1
 
+extern uint8_t hierarchical_query_data_types[hierarchical_query_data_types_count];
+
 #ifndef result_set_type_decl_hierarchical_query_result_set
 #define result_set_type_decl_hierarchical_query_result_set 1
 cql_result_set_type_decl(hierarchical_query_result_set, hierarchical_query_result_set_ref);
 #endif
-extern cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _hierarchical_query_get_id_inline_
+#define _hierarchical_query_get_id_inline_
+
+
+static inline cql_int32 hierarchical_query_get_id(hierarchical_query_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 hierarchical_query_result_count(hierarchical_query_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code hierarchical_query_fetch_results(sqlite3 *_Nonnull _db_, hierarchical_query_result_set_ref _Nullable *_Nonnull result_set, cql_int64 rate_, cql_int32 limit_, cql_int32 offset_);
 #define hierarchical_query_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -462,11 +720,23 @@ extern cql_string_ref _Nonnull hierarchical_unmatched_query_stored_procedure_nam
 
 #define hierarchical_unmatched_query_data_types_count 1
 
+extern uint8_t hierarchical_unmatched_query_data_types[hierarchical_unmatched_query_data_types_count];
+
 #ifndef result_set_type_decl_hierarchical_unmatched_query_result_set
 #define result_set_type_decl_hierarchical_unmatched_query_result_set 1
 cql_result_set_type_decl(hierarchical_unmatched_query_result_set, hierarchical_unmatched_query_result_set_ref);
 #endif
-extern cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _hierarchical_unmatched_query_get_id_inline_
+#define _hierarchical_unmatched_query_get_id_inline_
+
+
+static inline cql_int32 hierarchical_unmatched_query_get_id(hierarchical_unmatched_query_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 hierarchical_unmatched_query_result_count(hierarchical_unmatched_query_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code hierarchical_unmatched_query_fetch_results(sqlite3 *_Nonnull _db_, hierarchical_unmatched_query_result_set_ref _Nullable *_Nonnull result_set, cql_int64 rate_, cql_int32 limit_, cql_int32 offset_);
 #define hierarchical_unmatched_query_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -484,11 +754,23 @@ extern cql_string_ref _Nonnull union_select_stored_procedure_name;
 
 #define union_select_data_types_count 1
 
+extern uint8_t union_select_data_types[union_select_data_types_count];
+
 #ifndef result_set_type_decl_union_select_result_set
 #define result_set_type_decl_union_select_result_set 1
 cql_result_set_type_decl(union_select_result_set, union_select_result_set_ref);
 #endif
-extern cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_select_get_A_inline_
+#define _union_select_get_A_inline_
+
+
+static inline cql_int32 union_select_get_A(union_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_select_result_count(union_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_select_fetch_results(sqlite3 *_Nonnull _db_, union_select_result_set_ref _Nullable *_Nonnull result_set);
 #define union_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -506,11 +788,23 @@ extern cql_string_ref _Nonnull union_all_select_stored_procedure_name;
 
 #define union_all_select_data_types_count 1
 
+extern uint8_t union_all_select_data_types[union_all_select_data_types_count];
+
 #ifndef result_set_type_decl_union_all_select_result_set
 #define result_set_type_decl_union_all_select_result_set 1
 cql_result_set_type_decl(union_all_select_result_set, union_all_select_result_set_ref);
 #endif
-extern cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_all_select_get_A_inline_
+#define _union_all_select_get_A_inline_
+
+
+static inline cql_int32 union_all_select_get_A(union_all_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_all_select_result_count(union_all_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_all_select_fetch_results(sqlite3 *_Nonnull _db_, union_all_select_result_set_ref _Nullable *_Nonnull result_set);
 #define union_all_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -528,11 +822,23 @@ extern cql_string_ref _Nonnull union_all_with_nullable_stored_procedure_name;
 
 #define union_all_with_nullable_data_types_count 1
 
+extern uint8_t union_all_with_nullable_data_types[union_all_with_nullable_data_types_count];
+
 #ifndef result_set_type_decl_union_all_with_nullable_result_set
 #define result_set_type_decl_union_all_with_nullable_result_set 1
 cql_result_set_type_decl(union_all_with_nullable_result_set, union_all_with_nullable_result_set_ref);
 #endif
-extern cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _union_all_with_nullable_get_name_inline_
+#define _union_all_with_nullable_get_name_inline_
+
+
+static inline cql_string_ref _Nullable union_all_with_nullable_get_name(union_all_with_nullable_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 union_all_with_nullable_result_count(union_all_with_nullable_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code union_all_with_nullable_fetch_results(sqlite3 *_Nonnull _db_, union_all_with_nullable_result_set_ref _Nullable *_Nonnull result_set);
 #define union_all_with_nullable_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -553,13 +859,43 @@ extern cql_string_ref _Nonnull with_stmt_stored_procedure_name;
 
 #define with_stmt_data_types_count 3
 
+extern uint8_t with_stmt_data_types[with_stmt_data_types_count];
+
 #ifndef result_set_type_decl_with_stmt_result_set
 #define result_set_type_decl_with_stmt_result_set 1
 cql_result_set_type_decl(with_stmt_result_set, with_stmt_result_set_ref);
 #endif
-extern cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_stmt_get_a_inline_
+#define _with_stmt_get_a_inline_
+
+
+static inline cql_int32 with_stmt_get_a(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_stmt_get_b_inline_
+#define _with_stmt_get_b_inline_
+
+
+static inline cql_int32 with_stmt_get_b(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_stmt_get_c_inline_
+#define _with_stmt_get_c_inline_
+
+
+static inline cql_int32 with_stmt_get_c(with_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 with_stmt_result_count(with_stmt_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_stmt_fetch_results(sqlite3 *_Nonnull _db_, with_stmt_result_set_ref _Nullable *_Nonnull result_set);
 #define with_stmt_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -577,13 +913,43 @@ extern cql_string_ref _Nonnull with_recursive_stmt_stored_procedure_name;
 
 #define with_recursive_stmt_data_types_count 3
 
+extern uint8_t with_recursive_stmt_data_types[with_recursive_stmt_data_types_count];
+
 #ifndef result_set_type_decl_with_recursive_stmt_result_set
 #define result_set_type_decl_with_recursive_stmt_result_set 1
 cql_result_set_type_decl(with_recursive_stmt_result_set, with_recursive_stmt_result_set_ref);
 #endif
-extern cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _with_recursive_stmt_get_a_inline_
+#define _with_recursive_stmt_get_a_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_a(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _with_recursive_stmt_get_b_inline_
+#define _with_recursive_stmt_get_b_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_b(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _with_recursive_stmt_get_c_inline_
+#define _with_recursive_stmt_get_c_inline_
+
+
+static inline cql_int32 with_recursive_stmt_get_c(with_recursive_stmt_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 with_recursive_stmt_result_count(with_recursive_stmt_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code with_recursive_stmt_fetch_results(sqlite3 *_Nonnull _db_, with_recursive_stmt_result_set_ref _Nullable *_Nonnull result_set);
 #define with_recursive_stmt_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -601,13 +967,43 @@ extern cql_string_ref _Nonnull parent_proc_stored_procedure_name;
 
 #define parent_proc_data_types_count 3
 
+extern uint8_t parent_proc_data_types[parent_proc_data_types_count];
+
 #ifndef result_set_type_decl_parent_proc_result_set
 #define result_set_type_decl_parent_proc_result_set 1
 cql_result_set_type_decl(parent_proc_result_set, parent_proc_result_set_ref);
 #endif
-extern cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _parent_proc_get_one_inline_
+#define _parent_proc_get_one_inline_
+
+
+static inline cql_int32 parent_proc_get_one(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _parent_proc_get_two_inline_
+#define _parent_proc_get_two_inline_
+
+
+static inline cql_int32 parent_proc_get_two(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _parent_proc_get_three_inline_
+#define _parent_proc_get_three_inline_
+
+
+static inline cql_int32 parent_proc_get_three(parent_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 parent_proc_result_count(parent_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code parent_proc_fetch_results(sqlite3 *_Nonnull _db_, parent_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define parent_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -625,13 +1021,43 @@ extern cql_string_ref _Nonnull parent_proc_child_stored_procedure_name;
 
 #define parent_proc_child_data_types_count 3
 
+extern uint8_t parent_proc_child_data_types[parent_proc_child_data_types_count];
+
 #ifndef result_set_type_decl_parent_proc_child_result_set
 #define result_set_type_decl_parent_proc_child_result_set 1
 cql_result_set_type_decl(parent_proc_child_result_set, parent_proc_child_result_set_ref);
 #endif
-extern cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _parent_proc_child_get_four_inline_
+#define _parent_proc_child_get_four_inline_
+
+
+static inline cql_int32 parent_proc_child_get_four(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _parent_proc_child_get_five_inline_
+#define _parent_proc_child_get_five_inline_
+
+
+static inline cql_int32 parent_proc_child_get_five(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _parent_proc_child_get_six_inline_
+#define _parent_proc_child_get_six_inline_
+
+
+static inline cql_int32 parent_proc_child_get_six(parent_proc_child_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 parent_proc_child_result_count(parent_proc_child_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code parent_proc_child_fetch_results(sqlite3 *_Nonnull _db_, parent_proc_child_result_set_ref _Nullable *_Nonnull result_set);
 #define parent_proc_child_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -698,11 +1124,23 @@ extern cql_string_ref _Nonnull cursor_with_object_stored_procedure_name;
 
 #define cursor_with_object_data_types_count 1
 
+extern uint8_t cursor_with_object_data_types[cursor_with_object_data_types_count];
+
 #ifndef result_set_type_decl_cursor_with_object_result_set
 #define result_set_type_decl_cursor_with_object_result_set 1
 cql_result_set_type_decl(cursor_with_object_result_set, cursor_with_object_result_set_ref);
 #endif
-extern cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set);
+#ifndef _cursor_with_object_get_object__inline_
+#define _cursor_with_object_get_object__inline_
+
+
+static inline cql_object_ref _Nullable cursor_with_object_get_object_(cursor_with_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 cursor_with_object_result_count(cursor_with_object_result_set_ref _Nonnull result_set);
 extern void cursor_with_object_fetch_results( cursor_with_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nullable object_);
 #define cursor_with_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -771,18 +1209,93 @@ extern cql_string_ref _Nonnull uses_proc_for_result_stored_procedure_name;
 
 #define uses_proc_for_result_data_types_count 5
 
+extern uint8_t uses_proc_for_result_data_types[uses_proc_for_result_data_types_count];
+
 #ifndef result_set_type_decl_uses_proc_for_result_result_set
 #define result_set_type_decl_uses_proc_for_result_result_set 1
 cql_result_set_type_decl(uses_proc_for_result_result_set, uses_proc_for_result_result_set_ref);
 #endif
-extern cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _uses_proc_for_result_get_id_inline_
+#define _uses_proc_for_result_get_id_inline_
+
+
+static inline cql_int32 uses_proc_for_result_get_id(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_name_inline_
+#define _uses_proc_for_result_get_name_inline_
+
+
+static inline cql_string_ref _Nullable uses_proc_for_result_get_name(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_rate_is_null_inline_
+#define _uses_proc_for_result_get_rate_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_rate_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_rate_value_inline_
+#define _uses_proc_for_result_get_rate_value_inline_
+
+
+static inline cql_int64 uses_proc_for_result_get_rate_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_type_is_null_inline_
+#define _uses_proc_for_result_get_type_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_type_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_type_value_inline_
+#define _uses_proc_for_result_get_type_value_inline_
+
+
+static inline cql_int32 uses_proc_for_result_get_type_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_size_is_null_inline_
+#define _uses_proc_for_result_get_size_is_null_inline_
+
+
+static inline cql_bool uses_proc_for_result_get_size_is_null(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _uses_proc_for_result_get_size_value_inline_
+#define _uses_proc_for_result_get_size_value_inline_
+
+
+static inline cql_double uses_proc_for_result_get_size_value(uses_proc_for_result_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 uses_proc_for_result_result_count(uses_proc_for_result_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code uses_proc_for_result_fetch_results(sqlite3 *_Nonnull _db_, uses_proc_for_result_result_set_ref _Nullable *_Nonnull result_set);
 #define uses_proc_for_result_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -889,13 +1402,43 @@ extern cql_string_ref _Nonnull blob_returner_stored_procedure_name;
 
 #define blob_returner_data_types_count 3
 
+extern uint8_t blob_returner_data_types[blob_returner_data_types_count];
+
 #ifndef result_set_type_decl_blob_returner_result_set
 #define result_set_type_decl_blob_returner_result_set 1
 cql_result_set_type_decl(blob_returner_result_set, blob_returner_result_set_ref);
 #endif
-extern cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _blob_returner_get_blob_id_inline_
+#define _blob_returner_get_blob_id_inline_
+
+
+static inline cql_int32 blob_returner_get_blob_id(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _blob_returner_get_b_notnull_inline_
+#define _blob_returner_get_b_notnull_inline_
+
+
+static inline cql_blob_ref _Nonnull blob_returner_get_b_notnull(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _blob_returner_get_b_nullable_inline_
+#define _blob_returner_get_b_nullable_inline_
+
+
+static inline cql_blob_ref _Nullable blob_returner_get_b_nullable(blob_returner_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 blob_returner_result_count(blob_returner_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code blob_returner_fetch_results(sqlite3 *_Nonnull _db_, blob_returner_result_set_ref _Nullable *_Nonnull result_set);
 #define blob_returner_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -918,20 +1461,113 @@ extern cql_string_ref _Nonnull out_cursor_proc_stored_procedure_name;
 
 #define out_cursor_proc_data_types_count 7
 
+extern uint8_t out_cursor_proc_data_types[out_cursor_proc_data_types_count];
+
 #ifndef result_set_type_decl_out_cursor_proc_result_set
 #define result_set_type_decl_out_cursor_proc_result_set 1
 cql_result_set_type_decl(out_cursor_proc_result_set, out_cursor_proc_result_set_ref);
 #endif
-extern cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set);
+#ifndef _out_cursor_proc_get_id_inline_
+#define _out_cursor_proc_get_id_inline_
+
+
+static inline cql_int32 out_cursor_proc_get_id(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_name_inline_
+#define _out_cursor_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable out_cursor_proc_get_name(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_rate_is_null_inline_
+#define _out_cursor_proc_get_rate_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_rate_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_rate_value_inline_
+#define _out_cursor_proc_get_rate_value_inline_
+
+
+static inline cql_int64 out_cursor_proc_get_rate_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_type_is_null_inline_
+#define _out_cursor_proc_get_type_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_type_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_type_value_inline_
+#define _out_cursor_proc_get_type_value_inline_
+
+
+static inline cql_int32 out_cursor_proc_get_type_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_size_is_null_inline_
+#define _out_cursor_proc_get_size_is_null_inline_
+
+
+static inline cql_bool out_cursor_proc_get_size_is_null(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_size_value_inline_
+#define _out_cursor_proc_get_size_value_inline_
+
+
+static inline cql_double out_cursor_proc_get_size_value(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_extra1_inline_
+#define _out_cursor_proc_get_extra1_inline_
+
+
+static inline cql_string_ref _Nonnull out_cursor_proc_get_extra1(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+#ifndef _out_cursor_proc_get_extra2_inline_
+#define _out_cursor_proc_get_extra2_inline_
+
+
+static inline cql_string_ref _Nonnull out_cursor_proc_get_extra2(out_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
 extern cql_int32 out_cursor_proc_result_count(out_cursor_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code out_cursor_proc_fetch_results(sqlite3 *_Nonnull _db_, out_cursor_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define out_cursor_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -976,11 +1612,23 @@ extern cql_string_ref _Nonnull thread_theme_info_list_stored_procedure_name;
 
 #define thread_theme_info_list_data_types_count 1
 
+extern uint8_t thread_theme_info_list_data_types[thread_theme_info_list_data_types_count];
+
 #ifndef result_set_type_decl_thread_theme_info_list_result_set
 #define result_set_type_decl_thread_theme_info_list_result_set 1
 cql_result_set_type_decl(thread_theme_info_list_result_set, thread_theme_info_list_result_set_ref);
 #endif
-extern cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _thread_theme_info_list_get_thread_key_inline_
+#define _thread_theme_info_list_get_thread_key_inline_
+
+
+static inline cql_int64 thread_theme_info_list_get_thread_key(thread_theme_info_list_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 thread_theme_info_list_result_count(thread_theme_info_list_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code thread_theme_info_list_fetch_results(sqlite3 *_Nonnull _db_, thread_theme_info_list_result_set_ref _Nullable *_Nonnull result_set, cql_int64 thread_key_);
 #define thread_theme_info_list_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1013,12 +1661,33 @@ extern cql_string_ref _Nonnull out_no_db_stored_procedure_name;
 
 #define out_no_db_data_types_count 2
 
+extern uint8_t out_no_db_data_types[out_no_db_data_types_count];
+
 #ifndef result_set_type_decl_out_no_db_result_set
 #define result_set_type_decl_out_no_db_result_set 1
 cql_result_set_type_decl(out_no_db_result_set, out_no_db_result_set_ref);
 #endif
-extern cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set);
-extern cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set);
+#ifndef _out_no_db_get_A_inline_
+#define _out_no_db_get_A_inline_
+
+
+static inline cql_int32 out_no_db_get_A(out_no_db_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_no_db_get_B_inline_
+#define _out_no_db_get_B_inline_
+
+
+static inline cql_double out_no_db_get_B(out_no_db_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_no_db_result_count(out_no_db_result_set_ref _Nonnull result_set);
 extern void out_no_db_fetch_results( out_no_db_result_set_ref _Nullable *_Nonnull result_set);
 #define out_no_db_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1036,12 +1705,33 @@ extern cql_string_ref _Nonnull declare_cursor_like_cursor_stored_procedure_name;
 
 #define declare_cursor_like_cursor_data_types_count 2
 
+extern uint8_t declare_cursor_like_cursor_data_types[declare_cursor_like_cursor_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_cursor_result_set
 #define result_set_type_decl_declare_cursor_like_cursor_result_set 1
 cql_result_set_type_decl(declare_cursor_like_cursor_result_set, declare_cursor_like_cursor_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
-extern cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_cursor_get_A_inline_
+#define _declare_cursor_like_cursor_get_A_inline_
+
+
+static inline cql_int32 declare_cursor_like_cursor_get_A(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_cursor_get_B_inline_
+#define _declare_cursor_like_cursor_get_B_inline_
+
+
+static inline cql_double declare_cursor_like_cursor_get_B(declare_cursor_like_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_cursor_result_count(declare_cursor_like_cursor_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_cursor_fetch_results( declare_cursor_like_cursor_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_cursor_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1059,13 +1749,43 @@ extern cql_string_ref _Nonnull declare_cursor_like_proc_stored_procedure_name;
 
 #define declare_cursor_like_proc_data_types_count 2
 
+extern uint8_t declare_cursor_like_proc_data_types[declare_cursor_like_proc_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_proc_result_set
 #define result_set_type_decl_declare_cursor_like_proc_result_set 1
 cql_result_set_type_decl(declare_cursor_like_proc_result_set, declare_cursor_like_proc_result_set_ref);
 #endif
-extern cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_proc_get_a_is_null_inline_
+#define _declare_cursor_like_proc_get_a_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_proc_get_a_is_null(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_proc_get_a_value_inline_
+#define _declare_cursor_like_proc_get_a_value_inline_
+
+
+static inline cql_int32 declare_cursor_like_proc_get_a_value(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_proc_get_b_inline_
+#define _declare_cursor_like_proc_get_b_inline_
+
+
+static inline cql_string_ref _Nullable declare_cursor_like_proc_get_b(declare_cursor_like_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_proc_result_count(declare_cursor_like_proc_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_proc_fetch_results( declare_cursor_like_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1083,18 +1803,93 @@ extern cql_string_ref _Nonnull declare_cursor_like_table_stored_procedure_name;
 
 #define declare_cursor_like_table_data_types_count 5
 
+extern uint8_t declare_cursor_like_table_data_types[declare_cursor_like_table_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_table_result_set
 #define result_set_type_decl_declare_cursor_like_table_result_set 1
 cql_result_set_type_decl(declare_cursor_like_table_result_set, declare_cursor_like_table_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set);
-extern cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_table_get_id_inline_
+#define _declare_cursor_like_table_get_id_inline_
+
+
+static inline cql_int32 declare_cursor_like_table_get_id(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_name_inline_
+#define _declare_cursor_like_table_get_name_inline_
+
+
+static inline cql_string_ref _Nullable declare_cursor_like_table_get_name(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_rate_is_null_inline_
+#define _declare_cursor_like_table_get_rate_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_rate_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_rate_value_inline_
+#define _declare_cursor_like_table_get_rate_value_inline_
+
+
+static inline cql_int64 declare_cursor_like_table_get_rate_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_type_is_null_inline_
+#define _declare_cursor_like_table_get_type_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_type_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_type_value_inline_
+#define _declare_cursor_like_table_get_type_value_inline_
+
+
+static inline cql_int32 declare_cursor_like_table_get_type_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_size_is_null_inline_
+#define _declare_cursor_like_table_get_size_is_null_inline_
+
+
+static inline cql_bool declare_cursor_like_table_get_size_is_null(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_table_get_size_value_inline_
+#define _declare_cursor_like_table_get_size_value_inline_
+
+
+static inline cql_double declare_cursor_like_table_get_size_value(declare_cursor_like_table_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_table_result_count(declare_cursor_like_table_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_table_fetch_results( declare_cursor_like_table_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_table_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1112,13 +1907,43 @@ extern cql_string_ref _Nonnull declare_cursor_like_view_stored_procedure_name;
 
 #define declare_cursor_like_view_data_types_count 3
 
+extern uint8_t declare_cursor_like_view_data_types[declare_cursor_like_view_data_types_count];
+
 #ifndef result_set_type_decl_declare_cursor_like_view_result_set
 #define result_set_type_decl_declare_cursor_like_view_result_set 1
 cql_result_set_type_decl(declare_cursor_like_view_result_set, declare_cursor_like_view_result_set_ref);
 #endif
-extern cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set);
-extern cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set);
+#ifndef _declare_cursor_like_view_get_f1_inline_
+#define _declare_cursor_like_view_get_f1_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f1(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_view_get_f2_inline_
+#define _declare_cursor_like_view_get_f2_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f2(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _declare_cursor_like_view_get_f3_inline_
+#define _declare_cursor_like_view_get_f3_inline_
+
+
+static inline cql_int32 declare_cursor_like_view_get_f3(declare_cursor_like_view_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
 extern cql_int32 declare_cursor_like_view_result_count(declare_cursor_like_view_result_set_ref _Nonnull result_set);
 extern void declare_cursor_like_view_fetch_results( declare_cursor_like_view_result_set_ref _Nullable *_Nonnull result_set);
 #define declare_cursor_like_view_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1165,12 +1990,33 @@ extern cql_string_ref _Nonnull fetch_to_cursor_from_cursor_stored_procedure_name
 
 #define fetch_to_cursor_from_cursor_data_types_count 2
 
+extern uint8_t fetch_to_cursor_from_cursor_data_types[fetch_to_cursor_from_cursor_data_types_count];
+
 #ifndef result_set_type_decl_fetch_to_cursor_from_cursor_result_set
 #define result_set_type_decl_fetch_to_cursor_from_cursor_result_set 1
 cql_result_set_type_decl(fetch_to_cursor_from_cursor_result_set, fetch_to_cursor_from_cursor_result_set_ref);
 #endif
-extern cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
+#ifndef _fetch_to_cursor_from_cursor_get_A_inline_
+#define _fetch_to_cursor_from_cursor_get_A_inline_
+
+
+static inline cql_int32 fetch_to_cursor_from_cursor_get_A(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _fetch_to_cursor_from_cursor_get_B_inline_
+#define _fetch_to_cursor_from_cursor_get_B_inline_
+
+
+static inline cql_string_ref _Nonnull fetch_to_cursor_from_cursor_get_B(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_int32 fetch_to_cursor_from_cursor_result_count(fetch_to_cursor_from_cursor_result_set_ref _Nonnull result_set);
 extern void fetch_to_cursor_from_cursor_fetch_results( fetch_to_cursor_from_cursor_result_set_ref _Nullable *_Nonnull result_set);
 #define fetch_to_cursor_from_cursor_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1205,11 +2051,23 @@ extern cql_string_ref _Nonnull out_union_helper_stored_procedure_name;
 
 #define out_union_helper_data_types_count 1
 
+extern uint8_t out_union_helper_data_types[out_union_helper_data_types_count];
+
 #ifndef result_set_type_decl_out_union_helper_result_set
 #define result_set_type_decl_out_union_helper_result_set 1
 cql_result_set_type_decl(out_union_helper_result_set, out_union_helper_result_set_ref);
 #endif
-extern cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_helper_get_x_inline_
+#define _out_union_helper_get_x_inline_
+
+
+static inline cql_int32 out_union_helper_get_x(out_union_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_union_helper_result_count(out_union_helper_result_set_ref _Nonnull result_set);
 #define out_union_helper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_helper_row_equal(rs1, row1, rs2, row2) \
@@ -1227,11 +2085,23 @@ extern cql_string_ref _Nonnull out_union_dml_helper_stored_procedure_name;
 
 #define out_union_dml_helper_data_types_count 1
 
+extern uint8_t out_union_dml_helper_data_types[out_union_dml_helper_data_types_count];
+
 #ifndef result_set_type_decl_out_union_dml_helper_result_set
 #define result_set_type_decl_out_union_dml_helper_result_set 1
 cql_result_set_type_decl(out_union_dml_helper_result_set, out_union_dml_helper_result_set_ref);
 #endif
-extern cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_dml_helper_get_x_inline_
+#define _out_union_dml_helper_get_x_inline_
+
+
+static inline cql_int32 out_union_dml_helper_get_x(out_union_dml_helper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_union_dml_helper_result_count(out_union_dml_helper_result_set_ref _Nonnull result_set);
 #define out_union_dml_helper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_dml_helper_row_equal(rs1, row1, rs2, row2) \
@@ -1252,11 +2122,23 @@ extern cql_string_ref _Nonnull forward_out_union_stored_procedure_name;
 
 #define forward_out_union_data_types_count 1
 
+extern uint8_t forward_out_union_data_types[forward_out_union_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_result_set
 #define result_set_type_decl_forward_out_union_result_set 1
 cql_result_set_type_decl(forward_out_union_result_set, forward_out_union_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_get_x_inline_
+#define _forward_out_union_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_get_x(forward_out_union_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_result_count(forward_out_union_result_set_ref _Nonnull result_set);
 #define forward_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -1280,11 +2162,23 @@ extern cql_string_ref _Nonnull forward_out_union_extern_stored_procedure_name;
 
 #define forward_out_union_extern_data_types_count 1
 
+extern uint8_t forward_out_union_extern_data_types[forward_out_union_extern_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_extern_result_set
 #define result_set_type_decl_forward_out_union_extern_result_set 1
 cql_result_set_type_decl(forward_out_union_extern_result_set, forward_out_union_extern_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_extern_get_x_inline_
+#define _forward_out_union_extern_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_extern_get_x(forward_out_union_extern_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_extern_result_count(forward_out_union_extern_result_set_ref _Nonnull result_set);
 #define forward_out_union_extern_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_extern_row_equal(rs1, row1, rs2, row2) \
@@ -1302,11 +2196,23 @@ extern cql_string_ref _Nonnull forward_out_union_dml_stored_procedure_name;
 
 #define forward_out_union_dml_data_types_count 1
 
+extern uint8_t forward_out_union_dml_data_types[forward_out_union_dml_data_types_count];
+
 #ifndef result_set_type_decl_forward_out_union_dml_result_set
 #define result_set_type_decl_forward_out_union_dml_result_set 1
 cql_result_set_type_decl(forward_out_union_dml_result_set, forward_out_union_dml_result_set_ref);
 #endif
-extern cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _forward_out_union_dml_get_x_inline_
+#define _forward_out_union_dml_get_x_inline_
+
+
+static inline cql_int32 forward_out_union_dml_get_x(forward_out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 forward_out_union_dml_result_count(forward_out_union_dml_result_set_ref _Nonnull result_set);
 #define forward_out_union_dml_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define forward_out_union_dml_row_equal(rs1, row1, rs2, row2) \
@@ -1369,12 +2275,33 @@ extern cql_string_ref _Nonnull simple_identity_stored_procedure_name;
 
 #define simple_identity_data_types_count 2
 
+extern uint8_t simple_identity_data_types[simple_identity_data_types_count];
+
 #ifndef result_set_type_decl_simple_identity_result_set
 #define result_set_type_decl_simple_identity_result_set 1
 cql_result_set_type_decl(simple_identity_result_set, simple_identity_result_set_ref);
 #endif
-extern cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _simple_identity_get_id_inline_
+#define _simple_identity_get_id_inline_
+
+
+static inline cql_int32 simple_identity_get_id(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_identity_get_data_inline_
+#define _simple_identity_get_data_inline_
+
+
+static inline cql_int32 simple_identity_get_data(simple_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_uint16 simple_identity_identity_columns[];
 
 extern cql_int32 simple_identity_result_count(simple_identity_result_set_ref _Nonnull result_set);
@@ -1400,13 +2327,43 @@ extern cql_string_ref _Nonnull complex_identity_stored_procedure_name;
 
 #define complex_identity_data_types_count 3
 
+extern uint8_t complex_identity_data_types[complex_identity_data_types_count];
+
 #ifndef result_set_type_decl_complex_identity_result_set
 #define result_set_type_decl_complex_identity_result_set 1
 cql_result_set_type_decl(complex_identity_result_set, complex_identity_result_set_ref);
 #endif
-extern cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _complex_identity_get_col1_inline_
+#define _complex_identity_get_col1_inline_
+
+
+static inline cql_int32 complex_identity_get_col1(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _complex_identity_get_col2_inline_
+#define _complex_identity_get_col2_inline_
+
+
+static inline cql_int32 complex_identity_get_col2(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _complex_identity_get_data_inline_
+#define _complex_identity_get_data_inline_
+
+
+static inline cql_int32 complex_identity_get_data(complex_identity_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_uint16 complex_identity_identity_columns[];
 
 extern cql_int32 complex_identity_result_count(complex_identity_result_set_ref _Nonnull result_set);
@@ -1432,12 +2389,33 @@ extern cql_string_ref _Nonnull out_cursor_identity_stored_procedure_name;
 
 #define out_cursor_identity_data_types_count 2
 
+extern uint8_t out_cursor_identity_data_types[out_cursor_identity_data_types_count];
+
 #ifndef result_set_type_decl_out_cursor_identity_result_set
 #define result_set_type_decl_out_cursor_identity_result_set 1
 cql_result_set_type_decl(out_cursor_identity_result_set, out_cursor_identity_result_set_ref);
 #endif
-extern cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set);
-extern cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set);
+#ifndef _out_cursor_identity_get_id_inline_
+#define _out_cursor_identity_get_id_inline_
+
+
+static inline cql_int32 out_cursor_identity_get_id(out_cursor_identity_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_cursor_identity_get_data_inline_
+#define _out_cursor_identity_get_data_inline_
+
+
+static inline cql_int32 out_cursor_identity_get_data(out_cursor_identity_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
 extern cql_uint16 out_cursor_identity_identity_columns[];
 
 extern cql_int32 out_cursor_identity_result_count(out_cursor_identity_result_set_ref _Nonnull result_set);
@@ -1463,15 +2441,36 @@ extern cql_string_ref _Nonnull radioactive_proc_stored_procedure_name;
 
 #define radioactive_proc_data_types_count 2
 
+extern uint8_t radioactive_proc_data_types[radioactive_proc_data_types_count];
+
 #ifndef result_set_type_decl_radioactive_proc_result_set
 #define result_set_type_decl_radioactive_proc_result_set 1
 cql_result_set_type_decl(radioactive_proc_result_set, radioactive_proc_result_set_ref);
 #endif
-extern cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _radioactive_proc_get_id_inline_
+#define _radioactive_proc_get_id_inline_
+
+
+static inline cql_int32 radioactive_proc_get_id(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _radioactive_proc_get_data_inline_
+#define _radioactive_proc_get_data_inline_
+
+
+static inline cql_string_ref _Nullable radioactive_proc_get_data(radioactive_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define radioactive_proc_get_data_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
+
 extern cql_int32 radioactive_proc_result_count(radioactive_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code radioactive_proc_fetch_results(sqlite3 *_Nonnull _db_, radioactive_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define radioactive_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1497,12 +2496,33 @@ extern cql_string_ref _Nonnull autodropper_stored_procedure_name;
 
 #define autodropper_data_types_count 2
 
+extern uint8_t autodropper_data_types[autodropper_data_types_count];
+
 #ifndef result_set_type_decl_autodropper_result_set
 #define result_set_type_decl_autodropper_result_set 1
 cql_result_set_type_decl(autodropper_result_set, autodropper_result_set_ref);
 #endif
-extern cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _autodropper_get_a_inline_
+#define _autodropper_get_a_inline_
+
+
+static inline cql_int32 autodropper_get_a(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _autodropper_get_b_inline_
+#define _autodropper_get_b_inline_
+
+
+static inline cql_int32 autodropper_get_b(autodropper_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 autodropper_result_count(autodropper_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code autodropper_fetch_results(sqlite3 *_Nonnull _db_, autodropper_result_set_ref _Nullable *_Nonnull result_set);
 #define autodropper_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1520,11 +2540,23 @@ extern cql_string_ref _Nonnull simple_cursor_proc_stored_procedure_name;
 
 #define simple_cursor_proc_data_types_count 1
 
+extern uint8_t simple_cursor_proc_data_types[simple_cursor_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_cursor_proc_result_set
 #define result_set_type_decl_simple_cursor_proc_result_set 1
 cql_result_set_type_decl(simple_cursor_proc_result_set, simple_cursor_proc_result_set_ref);
 #endif
-extern cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set);
+#ifndef _simple_cursor_proc_get_id_inline_
+#define _simple_cursor_proc_get_id_inline_
+
+
+static inline cql_int32 simple_cursor_proc_get_id(simple_cursor_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 simple_cursor_proc_result_count(simple_cursor_proc_result_set_ref _Nonnull result_set);
 extern void simple_cursor_proc_fetch_results( simple_cursor_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define simple_cursor_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1554,12 +2586,33 @@ extern cql_string_ref _Nonnull redundant_cast_stored_procedure_name;
 
 #define redundant_cast_data_types_count 2
 
+extern uint8_t redundant_cast_data_types[redundant_cast_data_types_count];
+
 #ifndef result_set_type_decl_redundant_cast_result_set
 #define result_set_type_decl_redundant_cast_result_set 1
 cql_result_set_type_decl(redundant_cast_result_set, redundant_cast_result_set_ref);
 #endif
-extern cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _redundant_cast_get_plugh_inline_
+#define _redundant_cast_get_plugh_inline_
+
+
+static inline cql_int32 redundant_cast_get_plugh(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _redundant_cast_get_five_inline_
+#define _redundant_cast_get_five_inline_
+
+
+static inline cql_int32 redundant_cast_get_five(redundant_cast_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 redundant_cast_result_count(redundant_cast_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code redundant_cast_fetch_results(sqlite3 *_Nonnull _db_, redundant_cast_result_set_ref _Nullable *_Nonnull result_set);
 #define redundant_cast_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1585,12 +2638,33 @@ extern cql_string_ref _Nonnull top_level_select_alias_unused_stored_procedure_na
 
 #define top_level_select_alias_unused_data_types_count 2
 
+extern uint8_t top_level_select_alias_unused_data_types[top_level_select_alias_unused_data_types_count];
+
 #ifndef result_set_type_decl_top_level_select_alias_unused_result_set
 #define result_set_type_decl_top_level_select_alias_unused_result_set 1
 cql_result_set_type_decl(top_level_select_alias_unused_result_set, top_level_select_alias_unused_result_set_ref);
 #endif
-extern cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _top_level_select_alias_unused_get_id_inline_
+#define _top_level_select_alias_unused_get_id_inline_
+
+
+static inline cql_int32 top_level_select_alias_unused_get_id(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _top_level_select_alias_unused_get_x_inline_
+#define _top_level_select_alias_unused_get_x_inline_
+
+
+static inline cql_int32 top_level_select_alias_unused_get_x(top_level_select_alias_unused_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 top_level_select_alias_unused_result_count(top_level_select_alias_unused_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code top_level_select_alias_unused_fetch_results(sqlite3 *_Nonnull _db_, top_level_select_alias_unused_result_set_ref _Nullable *_Nonnull result_set);
 #define top_level_select_alias_unused_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1608,12 +2682,33 @@ extern cql_string_ref _Nonnull top_level_select_alias_used_in_orderby_stored_pro
 
 #define top_level_select_alias_used_in_orderby_data_types_count 2
 
+extern uint8_t top_level_select_alias_used_in_orderby_data_types[top_level_select_alias_used_in_orderby_data_types_count];
+
 #ifndef result_set_type_decl_top_level_select_alias_used_in_orderby_result_set
 #define result_set_type_decl_top_level_select_alias_used_in_orderby_result_set 1
 cql_result_set_type_decl(top_level_select_alias_used_in_orderby_result_set, top_level_select_alias_used_in_orderby_result_set_ref);
 #endif
-extern cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _top_level_select_alias_used_in_orderby_get_id_inline_
+#define _top_level_select_alias_used_in_orderby_get_id_inline_
+
+
+static inline cql_int32 top_level_select_alias_used_in_orderby_get_id(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _top_level_select_alias_used_in_orderby_get_x_inline_
+#define _top_level_select_alias_used_in_orderby_get_x_inline_
+
+
+static inline cql_int32 top_level_select_alias_used_in_orderby_get_x(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 top_level_select_alias_used_in_orderby_result_count(top_level_select_alias_used_in_orderby_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code top_level_select_alias_used_in_orderby_fetch_results(sqlite3 *_Nonnull _db_, top_level_select_alias_used_in_orderby_result_set_ref _Nullable *_Nonnull result_set);
 #define top_level_select_alias_used_in_orderby_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1670,12 +2765,33 @@ extern cql_string_ref _Nonnull out_union_two_stored_procedure_name;
 
 #define out_union_two_data_types_count 2
 
+extern uint8_t out_union_two_data_types[out_union_two_data_types_count];
+
 #ifndef result_set_type_decl_out_union_two_result_set
 #define result_set_type_decl_out_union_two_result_set 1
 cql_result_set_type_decl(out_union_two_result_set, out_union_two_result_set_ref);
 #endif
-extern cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_two_get_x_inline_
+#define _out_union_two_get_x_inline_
+
+
+static inline cql_int32 out_union_two_get_x(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_two_get_y_inline_
+#define _out_union_two_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull out_union_two_get_y(out_union_two_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_two_result_count(out_union_two_result_set_ref _Nonnull result_set);
 #define out_union_two_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_two_row_equal(rs1, row1, rs2, row2) \
@@ -1696,12 +2812,33 @@ extern cql_string_ref _Nonnull out_union_from_select_stored_procedure_name;
 
 #define out_union_from_select_data_types_count 2
 
+extern uint8_t out_union_from_select_data_types[out_union_from_select_data_types_count];
+
 #ifndef result_set_type_decl_out_union_from_select_result_set
 #define result_set_type_decl_out_union_from_select_result_set 1
 cql_result_set_type_decl(out_union_from_select_result_set, out_union_from_select_result_set_ref);
 #endif
-extern cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_from_select_get_x_inline_
+#define _out_union_from_select_get_x_inline_
+
+
+static inline cql_int32 out_union_from_select_get_x(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_from_select_get_y_inline_
+#define _out_union_from_select_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull out_union_from_select_get_y(out_union_from_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_from_select_result_count(out_union_from_select_result_set_ref _Nonnull result_set);
 #define out_union_from_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_from_select_row_equal(rs1, row1, rs2, row2) \
@@ -1722,12 +2859,33 @@ extern cql_string_ref _Nonnull out_union_values_stored_procedure_name;
 
 #define out_union_values_data_types_count 2
 
+extern uint8_t out_union_values_data_types[out_union_values_data_types_count];
+
 #ifndef result_set_type_decl_out_union_values_result_set
 #define result_set_type_decl_out_union_values_result_set 1
 cql_result_set_type_decl(out_union_values_result_set, out_union_values_result_set_ref);
 #endif
-extern cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_values_get_x_inline_
+#define _out_union_values_get_x_inline_
+
+
+static inline cql_int32 out_union_values_get_x(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_values_get_y_inline_
+#define _out_union_values_get_y_inline_
+
+
+static inline cql_int32 out_union_values_get_y(out_union_values_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 out_union_values_result_count(out_union_values_result_set_ref _Nonnull result_set);
 #define out_union_values_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_values_row_equal(rs1, row1, rs2, row2) \
@@ -1748,15 +2906,36 @@ extern cql_string_ref _Nonnull out_union_dml_stored_procedure_name;
 
 #define out_union_dml_data_types_count 2
 
+extern uint8_t out_union_dml_data_types[out_union_dml_data_types_count];
+
 #ifndef result_set_type_decl_out_union_dml_result_set
 #define result_set_type_decl_out_union_dml_result_set 1
 cql_result_set_type_decl(out_union_dml_result_set, out_union_dml_result_set_ref);
 #endif
-extern cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _out_union_dml_get_id_inline_
+#define _out_union_dml_get_id_inline_
+
+
+static inline cql_int32 out_union_dml_get_id(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _out_union_dml_get_data_inline_
+#define _out_union_dml_get_data_inline_
+
+
+static inline cql_string_ref _Nullable out_union_dml_get_data(out_union_dml_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define out_union_dml_get_data_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
+
 extern cql_int32 out_union_dml_result_count(out_union_dml_result_set_ref _Nonnull result_set);
 #define out_union_dml_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define out_union_dml_row_equal(rs1, row1, rs2, row2) \
@@ -1782,12 +2961,33 @@ extern cql_string_ref _Nonnull window_function_invocation_stored_procedure_name;
 
 #define window_function_invocation_data_types_count 2
 
+extern uint8_t window_function_invocation_data_types[window_function_invocation_data_types_count];
+
 #ifndef result_set_type_decl_window_function_invocation_result_set
 #define result_set_type_decl_window_function_invocation_result_set 1
 cql_result_set_type_decl(window_function_invocation_result_set, window_function_invocation_result_set_ref);
 #endif
-extern cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window_function_invocation_get_id_inline_
+#define _window_function_invocation_get_id_inline_
+
+
+static inline cql_int32 window_function_invocation_get_id(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window_function_invocation_get_row_num_inline_
+#define _window_function_invocation_get_row_num_inline_
+
+
+static inline cql_int32 window_function_invocation_get_row_num(window_function_invocation_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 window_function_invocation_result_count(window_function_invocation_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window_function_invocation_fetch_results(sqlite3 *_Nonnull _db_, window_function_invocation_result_set_ref _Nullable *_Nonnull result_set);
 #define window_function_invocation_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1820,11 +3020,23 @@ extern cql_string_ref _Nonnull use_return_stored_procedure_name;
 
 #define use_return_data_types_count 1
 
+extern uint8_t use_return_data_types[use_return_data_types_count];
+
 #ifndef result_set_type_decl_use_return_result_set
 #define result_set_type_decl_use_return_result_set 1
 cql_result_set_type_decl(use_return_result_set, use_return_result_set_ref);
 #endif
-extern cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_return_get_x_inline_
+#define _use_return_get_x_inline_
+
+
+static inline cql_int32 use_return_get_x(use_return_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 use_return_result_count(use_return_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_return_fetch_results(sqlite3 *_Nonnull _db_, use_return_result_set_ref _Nullable *_Nonnull result_set);
 #define use_return_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1860,10 +3072,13 @@ extern cql_string_ref _Nonnull lotsa_columns_no_getters_stored_procedure_name;
 
 #define lotsa_columns_no_getters_data_types_count 5
 
+extern uint8_t lotsa_columns_no_getters_data_types[lotsa_columns_no_getters_data_types_count];
+
 #ifndef result_set_type_decl_lotsa_columns_no_getters_result_set
 #define result_set_type_decl_lotsa_columns_no_getters_result_set 1
 cql_result_set_type_decl(lotsa_columns_no_getters_result_set, lotsa_columns_no_getters_result_set_ref);
 #endif
+
 extern cql_int32 lotsa_columns_no_getters_result_count(lotsa_columns_no_getters_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code lotsa_columns_no_getters_fetch_results(sqlite3 *_Nonnull _db_, lotsa_columns_no_getters_result_set_ref _Nullable *_Nonnull result_set);
 #define lotsa_columns_no_getters_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -1881,18 +3096,93 @@ extern cql_string_ref _Nonnull sproc_with_copy_stored_procedure_name;
 
 #define sproc_with_copy_data_types_count 5
 
+extern uint8_t sproc_with_copy_data_types[sproc_with_copy_data_types_count];
+
 #ifndef result_set_type_decl_sproc_with_copy_result_set
 #define result_set_type_decl_sproc_with_copy_result_set 1
 cql_result_set_type_decl(sproc_with_copy_result_set, sproc_with_copy_result_set_ref);
 #endif
-extern cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _sproc_with_copy_get_id_inline_
+#define _sproc_with_copy_get_id_inline_
+
+
+static inline cql_int32 sproc_with_copy_get_id(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_name_inline_
+#define _sproc_with_copy_get_name_inline_
+
+
+static inline cql_string_ref _Nullable sproc_with_copy_get_name(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_rate_is_null_inline_
+#define _sproc_with_copy_get_rate_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_rate_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_rate_value_inline_
+#define _sproc_with_copy_get_rate_value_inline_
+
+
+static inline cql_int64 sproc_with_copy_get_rate_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_type_is_null_inline_
+#define _sproc_with_copy_get_type_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_type_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_type_value_inline_
+#define _sproc_with_copy_get_type_value_inline_
+
+
+static inline cql_int32 sproc_with_copy_get_type_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_size_is_null_inline_
+#define _sproc_with_copy_get_size_is_null_inline_
+
+
+static inline cql_bool sproc_with_copy_get_size_is_null(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _sproc_with_copy_get_size_value_inline_
+#define _sproc_with_copy_get_size_value_inline_
+
+
+static inline cql_double sproc_with_copy_get_size_value(sproc_with_copy_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 sproc_with_copy_result_count(sproc_with_copy_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sproc_with_copy_fetch_results(sqlite3 *_Nonnull _db_, sproc_with_copy_result_set_ref _Nullable *_Nonnull result_set);
 #define sproc_with_copy_copy(result_set, result_set_to, from, count) \
@@ -1916,26 +3206,169 @@ extern cql_string_ref _Nonnull emit_object_with_setters_stored_procedure_name;
 
 #define emit_object_with_setters_data_types_count 8
 
+extern uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data_types_count];
+
 #ifndef result_set_type_decl_emit_object_with_setters_result_set
 #define result_set_type_decl_emit_object_with_setters_result_set 1
 cql_result_set_type_decl(emit_object_with_setters_result_set, emit_object_with_setters_result_set_ref);
 #endif
-extern cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value);
-extern cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value);
-extern cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value);
-extern cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value);
-extern cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value);
-extern cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value);
-extern cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value);
-extern cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set);
-extern void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value);
+#ifndef _emit_object_with_setters_get_o_inline_
+#define _emit_object_with_setters_get_o_inline_
+
+
+static inline cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_o_inline_
+#define _emit_object_with_setters_set_o_inline_
+
+static inline void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_x_inline_
+#define _emit_object_with_setters_get_x_inline_
+
+
+static inline cql_object_ref _Nonnull emit_object_with_setters_get_x(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_x_inline_
+#define _emit_object_with_setters_set_x_inline_
+
+static inline void emit_object_with_setters_set_x(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_i_inline_
+#define _emit_object_with_setters_get_i_inline_
+
+
+static inline cql_int32 emit_object_with_setters_get_i(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_i_inline_
+#define _emit_object_with_setters_set_i_inline_
+
+static inline void emit_object_with_setters_set_i(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_l_inline_
+#define _emit_object_with_setters_get_l_inline_
+
+
+static inline cql_int64 emit_object_with_setters_get_l(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_l_inline_
+#define _emit_object_with_setters_set_l_inline_
+
+static inline void emit_object_with_setters_set_l(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_b_inline_
+#define _emit_object_with_setters_get_b_inline_
+
+
+static inline cql_bool emit_object_with_setters_get_b(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_b_inline_
+#define _emit_object_with_setters_set_b_inline_
+
+static inline void emit_object_with_setters_set_b(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_bool new_value) {
+  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_d_inline_
+#define _emit_object_with_setters_get_d_inline_
+
+
+static inline cql_double emit_object_with_setters_get_d(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_d_inline_
+#define _emit_object_with_setters_set_d_inline_
+
+static inline void emit_object_with_setters_set_d(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_t_inline_
+#define _emit_object_with_setters_get_t_inline_
+
+
+static inline cql_string_ref _Nonnull emit_object_with_setters_get_t(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_t_inline_
+#define _emit_object_with_setters_set_t_inline_
+
+static inline void emit_object_with_setters_set_t(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_string_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
+}
+
+#endif
+#ifndef _emit_object_with_setters_get_bl_inline_
+#define _emit_object_with_setters_get_bl_inline_
+
+
+static inline cql_blob_ref _Nonnull emit_object_with_setters_get_bl(emit_object_with_setters_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_blob_col((cql_result_set_ref)result_set, 0, 7);
+}
+
+#endif
+
+
+#ifndef _emit_object_with_setters_set_bl_inline_
+#define _emit_object_with_setters_set_bl_inline_
+
+static inline void emit_object_with_setters_set_bl(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_blob_ref _Nonnull new_value) {
+  cql_contract_argument_notnull((void *)new_value, 2);
+  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+}
+
+#endif
+
 extern cql_int32 emit_object_with_setters_result_count(emit_object_with_setters_result_set_ref _Nonnull result_set);
 extern void emit_object_with_setters_fetch_results( emit_object_with_setters_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o, cql_object_ref _Nonnull x, cql_int32 i, cql_int64 l, cql_bool b, cql_double d, cql_string_ref _Nonnull t, cql_blob_ref _Nonnull bl);
 #define emit_object_with_setters_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1953,34 +3386,241 @@ extern cql_string_ref _Nonnull emit_setters_with_nullables_stored_procedure_name
 
 #define emit_setters_with_nullables_data_types_count 8
 
+extern uint8_t emit_setters_with_nullables_data_types[emit_setters_with_nullables_data_types_count];
+
 #ifndef result_set_type_decl_emit_setters_with_nullables_result_set
 #define result_set_type_decl_emit_setters_with_nullables_result_set 1
 cql_result_set_type_decl(emit_setters_with_nullables_result_set, emit_setters_with_nullables_result_set_ref);
 #endif
-extern cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value);
-extern cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value);
-extern cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value);
-extern void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value);
-extern void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value);
-extern void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value);
-extern void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value);
-extern cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
-extern void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value);
+#ifndef _emit_setters_with_nullables_get_o_inline_
+#define _emit_setters_with_nullables_get_o_inline_
+
+
+static inline cql_object_ref _Nullable emit_setters_with_nullables_get_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_o_inline_
+#define _emit_setters_with_nullables_set_o_inline_
+
+static inline void emit_setters_with_nullables_set_o(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_x_inline_
+#define _emit_setters_with_nullables_get_x_inline_
+
+
+static inline cql_object_ref _Nullable emit_setters_with_nullables_get_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_x_inline_
+#define _emit_setters_with_nullables_set_x_inline_
+
+static inline void emit_setters_with_nullables_set_x(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_object_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 1, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_i_is_null_inline_
+#define _emit_setters_with_nullables_get_i_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_i_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_i_value_inline_
+#define _emit_setters_with_nullables_get_i_value_inline_
+
+
+static inline cql_int32 emit_setters_with_nullables_get_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_i_value_inline_
+#define _emit_setters_with_nullables_set_i_value_inline_
+
+static inline void emit_setters_with_nullables_set_i_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, 0, 2, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_i_to_null_inline_
+#define _emit_setters_with_nullables_set_i_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_i_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_l_is_null_inline_
+#define _emit_setters_with_nullables_get_l_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_l_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_l_value_inline_
+#define _emit_setters_with_nullables_get_l_value_inline_
+
+
+static inline cql_int64 emit_setters_with_nullables_get_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_l_value_inline_
+#define _emit_setters_with_nullables_set_l_value_inline_
+
+static inline void emit_setters_with_nullables_set_l_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, 0, 3, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_l_to_null_inline_
+#define _emit_setters_with_nullables_set_l_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_l_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_b_is_null_inline_
+#define _emit_setters_with_nullables_get_b_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_b_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_b_value_inline_
+#define _emit_setters_with_nullables_get_b_value_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_b_value_inline_
+#define _emit_setters_with_nullables_set_b_value_inline_
+
+static inline void emit_setters_with_nullables_set_b_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_bool new_value) {
+  cql_result_set_set_bool_col((cql_result_set_ref)result_set, 0, 4, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_b_to_null_inline_
+#define _emit_setters_with_nullables_set_b_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_b_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_d_is_null_inline_
+#define _emit_setters_with_nullables_get_d_is_null_inline_
+
+
+static inline cql_bool emit_setters_with_nullables_get_d_is_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_get_d_value_inline_
+#define _emit_setters_with_nullables_get_d_value_inline_
+
+
+static inline cql_double emit_setters_with_nullables_get_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_d_value_inline_
+#define _emit_setters_with_nullables_set_d_value_inline_
+
+static inline void emit_setters_with_nullables_set_d_value(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, 0, 5, new_value);
+}
+
+#endif
+
+#ifndef _emit_setters_with_nullables_set_d_to_null_inline_
+#define _emit_setters_with_nullables_set_d_to_null_inline_
+
+static inline void emit_setters_with_nullables_set_d_to_null(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, 0, 5);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_t_inline_
+#define _emit_setters_with_nullables_get_t_inline_
+
+
+static inline cql_string_ref _Nullable emit_setters_with_nullables_get_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 6) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 6);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_t_inline_
+#define _emit_setters_with_nullables_set_t_inline_
+
+static inline void emit_setters_with_nullables_set_t(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_string_ref _Nullable new_value) {
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, 0, 6, new_value);
+}
+
+#endif
+#ifndef _emit_setters_with_nullables_get_bl_inline_
+#define _emit_setters_with_nullables_get_bl_inline_
+
+
+static inline cql_blob_ref _Nullable emit_setters_with_nullables_get_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 7) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, 0, 7);
+}
+
+#endif
+
+
+#ifndef _emit_setters_with_nullables_set_bl_inline_
+#define _emit_setters_with_nullables_set_bl_inline_
+
+static inline void emit_setters_with_nullables_set_bl(emit_setters_with_nullables_result_set_ref _Nonnull result_set, cql_blob_ref _Nullable new_value) {
+  cql_result_set_set_blob_col((cql_result_set_ref)result_set, 0, 7, new_value);
+}
+
+#endif
+
 extern cql_int32 emit_setters_with_nullables_result_count(emit_setters_with_nullables_result_set_ref _Nonnull result_set);
 extern void emit_setters_with_nullables_fetch_results( emit_setters_with_nullables_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nullable o, cql_object_ref _Nullable x, cql_nullable_int32 i, cql_nullable_int64 l, cql_nullable_bool b, cql_nullable_double d, cql_string_ref _Nullable t, cql_blob_ref _Nullable bl);
 #define emit_setters_with_nullables_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -1998,26 +3638,165 @@ extern cql_string_ref _Nonnull no_out_with_setters_stored_procedure_name;
 
 #define no_out_with_setters_data_types_count 5
 
+extern uint8_t no_out_with_setters_data_types[no_out_with_setters_data_types_count];
+
 #ifndef result_set_type_decl_no_out_with_setters_result_set
 #define result_set_type_decl_no_out_with_setters_result_set 1
 cql_result_set_type_decl(no_out_with_setters_result_set, no_out_with_setters_result_set_ref);
 #endif
-extern cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value);
-extern cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value);
-extern void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value);
-extern void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _no_out_with_setters_get_id_inline_
+#define _no_out_with_setters_get_id_inline_
+
+
+static inline cql_int32 no_out_with_setters_get_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_id_inline_
+#define _no_out_with_setters_set_id_inline_
+
+static inline void no_out_with_setters_set_id(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_name_inline_
+#define _no_out_with_setters_get_name_inline_
+
+
+static inline cql_string_ref _Nullable no_out_with_setters_get_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_name_inline_
+#define _no_out_with_setters_set_name_inline_
+
+static inline void no_out_with_setters_set_name(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_string_ref _Nullable new_value) {
+  cql_result_set_set_string_col((cql_result_set_ref)result_set, row, 1, new_value);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_rate_is_null_inline_
+#define _no_out_with_setters_get_rate_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_rate_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_rate_value_inline_
+#define _no_out_with_setters_get_rate_value_inline_
+
+
+static inline cql_int64 no_out_with_setters_get_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_rate_value_inline_
+#define _no_out_with_setters_set_rate_value_inline_
+
+static inline void no_out_with_setters_set_rate_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int64 new_value) {
+  cql_result_set_set_int64_col((cql_result_set_ref)result_set, row, 2, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_rate_to_null_inline_
+#define _no_out_with_setters_set_rate_to_null_inline_
+
+static inline void no_out_with_setters_set_rate_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_type_is_null_inline_
+#define _no_out_with_setters_get_type_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_type_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_type_value_inline_
+#define _no_out_with_setters_get_type_value_inline_
+
+
+static inline cql_int32 no_out_with_setters_get_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_type_value_inline_
+#define _no_out_with_setters_set_type_value_inline_
+
+static inline void no_out_with_setters_set_type_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 3, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_type_to_null_inline_
+#define _no_out_with_setters_set_type_to_null_inline_
+
+static inline void no_out_with_setters_set_type_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+#ifndef _no_out_with_setters_get_size_is_null_inline_
+#define _no_out_with_setters_get_size_is_null_inline_
+
+
+static inline cql_bool no_out_with_setters_get_size_is_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_get_size_value_inline_
+#define _no_out_with_setters_get_size_value_inline_
+
+
+static inline cql_double no_out_with_setters_get_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
+#ifndef _no_out_with_setters_set_size_value_inline_
+#define _no_out_with_setters_set_size_value_inline_
+
+static inline void no_out_with_setters_set_size_value(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row, cql_double new_value) {
+  cql_result_set_set_double_col((cql_result_set_ref)result_set, row, 4, new_value);
+}
+
+#endif
+
+#ifndef _no_out_with_setters_set_size_to_null_inline_
+#define _no_out_with_setters_set_size_to_null_inline_
+
+static inline void no_out_with_setters_set_size_to_null(no_out_with_setters_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
 extern cql_int32 no_out_with_setters_result_count(no_out_with_setters_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code no_out_with_setters_fetch_results(sqlite3 *_Nonnull _db_, no_out_with_setters_result_set_ref _Nullable *_Nonnull result_set);
 #define no_out_with_setters_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2040,21 +3819,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_values_proc_stored_procedure
 
 #define vault_sensitive_with_values_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_values_proc_data_types[vault_sensitive_with_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_values_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_values_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_values_proc_result_set, vault_sensitive_with_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_values_proc_get_id_inline_
+#define _vault_sensitive_with_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_values_proc_get_id(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_name_inline_
+#define _vault_sensitive_with_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_values_proc_get_name(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_values_proc_get_title_inline_
+#define _vault_sensitive_with_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_values_proc_get_title(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_values_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_values_proc_get_type_is_null(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_values_proc_get_type_value_inline_
+#define _vault_sensitive_with_values_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_values_proc_get_type_value(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_values_proc_result_count(vault_sensitive_with_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2074,20 +3901,59 @@ extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_sto
 
 #define vault_not_nullable_sensitive_with_values_proc_data_types_count 4
 
+extern uint8_t vault_not_nullable_sensitive_with_values_proc_data_types[vault_not_nullable_sensitive_with_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_not_nullable_sensitive_with_values_proc_result_set
 #define result_set_type_decl_vault_not_nullable_sensitive_with_values_proc_result_set 1
 cql_result_set_type_decl(vault_not_nullable_sensitive_with_values_proc_result_set, vault_not_nullable_sensitive_with_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_id_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_not_nullable_sensitive_with_values_proc_get_id(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_name_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_name(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_not_nullable_sensitive_with_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_title_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nonnull vault_not_nullable_sensitive_with_values_proc_get_title(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_not_nullable_sensitive_with_values_proc_get_type_inline_
+#define _vault_not_nullable_sensitive_with_values_proc_get_type_inline_
+
+
+static inline cql_int64 vault_not_nullable_sensitive_with_values_proc_get_type(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_not_nullable_sensitive_with_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_not_nullable_sensitive_with_values_proc_result_count(vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_not_nullable_sensitive_with_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_not_nullable_sensitive_with_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_not_nullable_sensitive_with_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2107,21 +3973,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_no_values_proc_stored_proced
 
 #define vault_sensitive_with_no_values_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_no_values_proc_data_types[vault_sensitive_with_no_values_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_no_values_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_no_values_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_no_values_proc_result_set, vault_sensitive_with_no_values_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_values_proc_get_id_inline_
+#define _vault_sensitive_with_no_values_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_no_values_proc_get_id(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_name_inline_
+#define _vault_sensitive_with_no_values_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_name(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_values_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_values_proc_get_title_inline_
+#define _vault_sensitive_with_no_values_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_values_proc_get_title(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_no_values_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_no_values_proc_get_type_is_null(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_values_proc_get_type_value_inline_
+#define _vault_sensitive_with_no_values_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_no_values_proc_get_type_value(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_values_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_no_values_proc_result_count(vault_sensitive_with_no_values_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_no_values_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_no_values_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_no_values_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2141,21 +4055,69 @@ extern cql_string_ref _Nonnull vault_union_all_table_proc_stored_procedure_name;
 
 #define vault_union_all_table_proc_data_types_count 4
 
+extern uint8_t vault_union_all_table_proc_data_types[vault_union_all_table_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_union_all_table_proc_result_set
 #define result_set_type_decl_vault_union_all_table_proc_result_set 1
 cql_result_set_type_decl(vault_union_all_table_proc_result_set, vault_union_all_table_proc_result_set_ref);
 #endif
-extern cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_union_all_table_proc_get_id_inline_
+#define _vault_union_all_table_proc_get_id_inline_
+
+
+static inline cql_int32 vault_union_all_table_proc_get_id(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_name_inline_
+#define _vault_union_all_table_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_union_all_table_proc_get_name(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_union_all_table_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_union_all_table_proc_get_title_inline_
+#define _vault_union_all_table_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_union_all_table_proc_get_title(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_type_is_null_inline_
+#define _vault_union_all_table_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_union_all_table_proc_get_type_is_null(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_union_all_table_proc_get_type_value_inline_
+#define _vault_union_all_table_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_union_all_table_proc_get_type_value(vault_union_all_table_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_union_all_table_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_union_all_table_proc_result_count(vault_union_all_table_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_union_all_table_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_union_all_table_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_union_all_table_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2175,14 +4137,26 @@ extern cql_string_ref _Nonnull vault_alias_column_proc_stored_procedure_name;
 
 #define vault_alias_column_proc_data_types_count 1
 
+extern uint8_t vault_alias_column_proc_data_types[vault_alias_column_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_alias_column_proc_result_set
 #define result_set_type_decl_vault_alias_column_proc_result_set 1
 cql_result_set_type_decl(vault_alias_column_proc_result_set, vault_alias_column_proc_result_set_ref);
 #endif
-extern cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_alias_column_proc_get_alias_name_inline_
+#define _vault_alias_column_proc_get_alias_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_alias_column_proc_get_alias_name(vault_alias_column_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
 
 #define vault_alias_column_proc_get_alias_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 0)
+
 extern cql_int32 vault_alias_column_proc_result_count(vault_alias_column_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_alias_column_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_alias_column_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_alias_column_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2202,14 +4176,26 @@ extern cql_string_ref _Nonnull vault_alias_column_name_proc_stored_procedure_nam
 
 #define vault_alias_column_name_proc_data_types_count 1
 
+extern uint8_t vault_alias_column_name_proc_data_types[vault_alias_column_name_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_alias_column_name_proc_result_set
 #define result_set_type_decl_vault_alias_column_name_proc_result_set 1
 cql_result_set_type_decl(vault_alias_column_name_proc_result_set, vault_alias_column_name_proc_result_set_ref);
 #endif
-extern cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_alias_column_name_proc_get_alias_name_inline_
+#define _vault_alias_column_name_proc_get_alias_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_alias_column_name_proc_get_alias_name(vault_alias_column_name_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
 
 #define vault_alias_column_name_proc_get_alias_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 0)
+
 extern cql_int32 vault_alias_column_name_proc_result_count(vault_alias_column_name_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_alias_column_name_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_alias_column_name_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_alias_column_name_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2232,21 +4218,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_context_and_sensitive_column
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_context_and_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_context_and_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_context_and_sensitive_columns_proc_result_set, vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_context_and_sensitive_columns_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_context_and_sensitive_columns_proc_result_count(vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_context_and_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_context_and_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_context_and_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2266,21 +4300,69 @@ extern cql_string_ref _Nonnull vault_sensitive_with_no_context_and_sensitive_col
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types[vault_sensitive_with_no_context_and_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set, vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_id(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_get_name_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 1)
-extern cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_no_context_and_sensitive_columns_proc_get_title(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_value(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
 
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_get_type_is_encoded(rs) \
   cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 3)
+
 extern cql_int32 vault_sensitive_with_no_context_and_sensitive_columns_proc_result_count(vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_no_context_and_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_no_context_and_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_no_context_and_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2300,15 +4382,63 @@ extern cql_string_ref _Nonnull vault_sensitive_with_context_and_no_sensitive_col
 
 #define vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count 4
 
+extern uint8_t vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types[vault_sensitive_with_context_and_no_sensitive_columns_proc_data_types_count];
+
 #ifndef result_set_type_decl_vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set
 #define result_set_type_decl_vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set 1
 cql_result_set_type_decl(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set, vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref);
 #endif
-extern cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id_inline_
+
+
+static inline cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_id(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_name(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title_inline_
+
+
+static inline cql_string_ref _Nullable vault_sensitive_with_context_and_no_sensitive_columns_proc_get_title(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null_inline_
+
+
+static inline cql_bool vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_is_null(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value_inline_
+#define _vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value_inline_
+
+
+static inline cql_int64 vault_sensitive_with_context_and_no_sensitive_columns_proc_get_type_value(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+
 extern cql_int32 vault_sensitive_with_context_and_no_sensitive_columns_proc_result_count(vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code vault_sensitive_with_context_and_no_sensitive_columns_proc_fetch_results(sqlite3 *_Nonnull _db_, vault_sensitive_with_context_and_no_sensitive_columns_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define vault_sensitive_with_context_and_no_sensitive_columns_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2456,16 +4586,73 @@ extern cql_string_ref _Nonnull window1_stored_procedure_name;
 
 #define window1_data_types_count 3
 
+extern uint8_t window1_data_types[window1_data_types_count];
+
 #ifndef result_set_type_decl_window1_result_set
 #define result_set_type_decl_window1_result_set 1
 cql_result_set_type_decl(window1_result_set, window1_result_set_ref);
 #endif
-extern cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window1_get_month_is_null_inline_
+#define _window1_get_month_is_null_inline_
+
+
+static inline cql_bool window1_get_month_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window1_get_month_value_inline_
+#define _window1_get_month_value_inline_
+
+
+static inline cql_int32 window1_get_month_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window1_get_amount_is_null_inline_
+#define _window1_get_amount_is_null_inline_
+
+
+static inline cql_bool window1_get_amount_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window1_get_amount_value_inline_
+#define _window1_get_amount_value_inline_
+
+
+static inline cql_double window1_get_amount_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window1_get_SalesMovingAverage_is_null_inline_
+#define _window1_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window1_get_SalesMovingAverage_is_null(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window1_get_SalesMovingAverage_value_inline_
+#define _window1_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window1_get_SalesMovingAverage_value(window1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window1_result_count(window1_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window1_fetch_results(sqlite3 *_Nonnull _db_, window1_result_set_ref _Nullable *_Nonnull result_set);
 #define window1_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2483,16 +4670,73 @@ extern cql_string_ref _Nonnull window2_stored_procedure_name;
 
 #define window2_data_types_count 3
 
+extern uint8_t window2_data_types[window2_data_types_count];
+
 #ifndef result_set_type_decl_window2_result_set
 #define result_set_type_decl_window2_result_set 1
 cql_result_set_type_decl(window2_result_set, window2_result_set_ref);
 #endif
-extern cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window2_get_month_is_null_inline_
+#define _window2_get_month_is_null_inline_
+
+
+static inline cql_bool window2_get_month_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window2_get_month_value_inline_
+#define _window2_get_month_value_inline_
+
+
+static inline cql_int32 window2_get_month_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window2_get_amount_is_null_inline_
+#define _window2_get_amount_is_null_inline_
+
+
+static inline cql_bool window2_get_amount_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window2_get_amount_value_inline_
+#define _window2_get_amount_value_inline_
+
+
+static inline cql_double window2_get_amount_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window2_get_RunningTotal_is_null_inline_
+#define _window2_get_RunningTotal_is_null_inline_
+
+
+static inline cql_bool window2_get_RunningTotal_is_null(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window2_get_RunningTotal_value_inline_
+#define _window2_get_RunningTotal_value_inline_
+
+
+static inline cql_double window2_get_RunningTotal_value(window2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window2_result_count(window2_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window2_fetch_results(sqlite3 *_Nonnull _db_, window2_result_set_ref _Nullable *_Nonnull result_set);
 #define window2_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2510,16 +4754,73 @@ extern cql_string_ref _Nonnull window3_stored_procedure_name;
 
 #define window3_data_types_count 3
 
+extern uint8_t window3_data_types[window3_data_types_count];
+
 #ifndef result_set_type_decl_window3_result_set
 #define result_set_type_decl_window3_result_set 1
 cql_result_set_type_decl(window3_result_set, window3_result_set_ref);
 #endif
-extern cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window3_get_month_is_null_inline_
+#define _window3_get_month_is_null_inline_
+
+
+static inline cql_bool window3_get_month_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window3_get_month_value_inline_
+#define _window3_get_month_value_inline_
+
+
+static inline cql_int32 window3_get_month_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window3_get_amount_is_null_inline_
+#define _window3_get_amount_is_null_inline_
+
+
+static inline cql_bool window3_get_amount_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window3_get_amount_value_inline_
+#define _window3_get_amount_value_inline_
+
+
+static inline cql_double window3_get_amount_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window3_get_SalesMovingAverage_is_null_inline_
+#define _window3_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window3_get_SalesMovingAverage_is_null(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window3_get_SalesMovingAverage_value_inline_
+#define _window3_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window3_get_SalesMovingAverage_value(window3_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window3_result_count(window3_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window3_fetch_results(sqlite3 *_Nonnull _db_, window3_result_set_ref _Nullable *_Nonnull result_set);
 #define window3_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2537,16 +4838,73 @@ extern cql_string_ref _Nonnull window4_stored_procedure_name;
 
 #define window4_data_types_count 3
 
+extern uint8_t window4_data_types[window4_data_types_count];
+
 #ifndef result_set_type_decl_window4_result_set
 #define result_set_type_decl_window4_result_set 1
 cql_result_set_type_decl(window4_result_set, window4_result_set_ref);
 #endif
-extern cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window4_get_month_is_null_inline_
+#define _window4_get_month_is_null_inline_
+
+
+static inline cql_bool window4_get_month_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window4_get_month_value_inline_
+#define _window4_get_month_value_inline_
+
+
+static inline cql_int32 window4_get_month_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window4_get_amount_is_null_inline_
+#define _window4_get_amount_is_null_inline_
+
+
+static inline cql_bool window4_get_amount_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window4_get_amount_value_inline_
+#define _window4_get_amount_value_inline_
+
+
+static inline cql_double window4_get_amount_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window4_get_SalesMovingAverage_is_null_inline_
+#define _window4_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window4_get_SalesMovingAverage_is_null(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window4_get_SalesMovingAverage_value_inline_
+#define _window4_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window4_get_SalesMovingAverage_value(window4_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window4_result_count(window4_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window4_fetch_results(sqlite3 *_Nonnull _db_, window4_result_set_ref _Nullable *_Nonnull result_set);
 #define window4_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2564,16 +4922,73 @@ extern cql_string_ref _Nonnull window5_stored_procedure_name;
 
 #define window5_data_types_count 3
 
+extern uint8_t window5_data_types[window5_data_types_count];
+
 #ifndef result_set_type_decl_window5_result_set
 #define result_set_type_decl_window5_result_set 1
 cql_result_set_type_decl(window5_result_set, window5_result_set_ref);
 #endif
-extern cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window5_get_month_is_null_inline_
+#define _window5_get_month_is_null_inline_
+
+
+static inline cql_bool window5_get_month_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window5_get_month_value_inline_
+#define _window5_get_month_value_inline_
+
+
+static inline cql_int32 window5_get_month_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window5_get_amount_is_null_inline_
+#define _window5_get_amount_is_null_inline_
+
+
+static inline cql_bool window5_get_amount_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window5_get_amount_value_inline_
+#define _window5_get_amount_value_inline_
+
+
+static inline cql_double window5_get_amount_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window5_get_SalesMovingAverage_is_null_inline_
+#define _window5_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window5_get_SalesMovingAverage_is_null(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window5_get_SalesMovingAverage_value_inline_
+#define _window5_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window5_get_SalesMovingAverage_value(window5_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window5_result_count(window5_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window5_fetch_results(sqlite3 *_Nonnull _db_, window5_result_set_ref _Nullable *_Nonnull result_set);
 #define window5_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2591,16 +5006,73 @@ extern cql_string_ref _Nonnull window6_stored_procedure_name;
 
 #define window6_data_types_count 3
 
+extern uint8_t window6_data_types[window6_data_types_count];
+
 #ifndef result_set_type_decl_window6_result_set
 #define result_set_type_decl_window6_result_set 1
 cql_result_set_type_decl(window6_result_set, window6_result_set_ref);
 #endif
-extern cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window6_get_month_is_null_inline_
+#define _window6_get_month_is_null_inline_
+
+
+static inline cql_bool window6_get_month_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window6_get_month_value_inline_
+#define _window6_get_month_value_inline_
+
+
+static inline cql_int32 window6_get_month_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window6_get_amount_is_null_inline_
+#define _window6_get_amount_is_null_inline_
+
+
+static inline cql_bool window6_get_amount_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window6_get_amount_value_inline_
+#define _window6_get_amount_value_inline_
+
+
+static inline cql_double window6_get_amount_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window6_get_SalesMovingAverage_is_null_inline_
+#define _window6_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window6_get_SalesMovingAverage_is_null(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window6_get_SalesMovingAverage_value_inline_
+#define _window6_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window6_get_SalesMovingAverage_value(window6_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window6_result_count(window6_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window6_fetch_results(sqlite3 *_Nonnull _db_, window6_result_set_ref _Nullable *_Nonnull result_set);
 #define window6_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2618,16 +5090,73 @@ extern cql_string_ref _Nonnull window7_stored_procedure_name;
 
 #define window7_data_types_count 3
 
+extern uint8_t window7_data_types[window7_data_types_count];
+
 #ifndef result_set_type_decl_window7_result_set
 #define result_set_type_decl_window7_result_set 1
 cql_result_set_type_decl(window7_result_set, window7_result_set_ref);
 #endif
-extern cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window7_get_month_is_null_inline_
+#define _window7_get_month_is_null_inline_
+
+
+static inline cql_bool window7_get_month_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window7_get_month_value_inline_
+#define _window7_get_month_value_inline_
+
+
+static inline cql_int32 window7_get_month_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window7_get_amount_is_null_inline_
+#define _window7_get_amount_is_null_inline_
+
+
+static inline cql_bool window7_get_amount_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window7_get_amount_value_inline_
+#define _window7_get_amount_value_inline_
+
+
+static inline cql_double window7_get_amount_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window7_get_SalesMovingAverage_is_null_inline_
+#define _window7_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window7_get_SalesMovingAverage_is_null(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window7_get_SalesMovingAverage_value_inline_
+#define _window7_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window7_get_SalesMovingAverage_value(window7_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window7_result_count(window7_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window7_fetch_results(sqlite3 *_Nonnull _db_, window7_result_set_ref _Nullable *_Nonnull result_set);
 #define window7_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2645,16 +5174,73 @@ extern cql_string_ref _Nonnull window8_stored_procedure_name;
 
 #define window8_data_types_count 3
 
+extern uint8_t window8_data_types[window8_data_types_count];
+
 #ifndef result_set_type_decl_window8_result_set
 #define result_set_type_decl_window8_result_set 1
 cql_result_set_type_decl(window8_result_set, window8_result_set_ref);
 #endif
-extern cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window8_get_month_is_null_inline_
+#define _window8_get_month_is_null_inline_
+
+
+static inline cql_bool window8_get_month_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window8_get_month_value_inline_
+#define _window8_get_month_value_inline_
+
+
+static inline cql_int32 window8_get_month_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window8_get_amount_is_null_inline_
+#define _window8_get_amount_is_null_inline_
+
+
+static inline cql_bool window8_get_amount_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window8_get_amount_value_inline_
+#define _window8_get_amount_value_inline_
+
+
+static inline cql_double window8_get_amount_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window8_get_SalesMovingAverage_is_null_inline_
+#define _window8_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window8_get_SalesMovingAverage_is_null(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window8_get_SalesMovingAverage_value_inline_
+#define _window8_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window8_get_SalesMovingAverage_value(window8_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window8_result_count(window8_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window8_fetch_results(sqlite3 *_Nonnull _db_, window8_result_set_ref _Nullable *_Nonnull result_set);
 #define window8_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2672,16 +5258,73 @@ extern cql_string_ref _Nonnull window9_stored_procedure_name;
 
 #define window9_data_types_count 3
 
+extern uint8_t window9_data_types[window9_data_types_count];
+
 #ifndef result_set_type_decl_window9_result_set
 #define result_set_type_decl_window9_result_set 1
 cql_result_set_type_decl(window9_result_set, window9_result_set_ref);
 #endif
-extern cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window9_get_month_is_null_inline_
+#define _window9_get_month_is_null_inline_
+
+
+static inline cql_bool window9_get_month_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window9_get_month_value_inline_
+#define _window9_get_month_value_inline_
+
+
+static inline cql_int32 window9_get_month_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window9_get_amount_is_null_inline_
+#define _window9_get_amount_is_null_inline_
+
+
+static inline cql_bool window9_get_amount_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window9_get_amount_value_inline_
+#define _window9_get_amount_value_inline_
+
+
+static inline cql_double window9_get_amount_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window9_get_SalesMovingAverage_is_null_inline_
+#define _window9_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window9_get_SalesMovingAverage_is_null(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window9_get_SalesMovingAverage_value_inline_
+#define _window9_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window9_get_SalesMovingAverage_value(window9_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window9_result_count(window9_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window9_fetch_results(sqlite3 *_Nonnull _db_, window9_result_set_ref _Nullable *_Nonnull result_set);
 #define window9_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2699,16 +5342,73 @@ extern cql_string_ref _Nonnull window10_stored_procedure_name;
 
 #define window10_data_types_count 3
 
+extern uint8_t window10_data_types[window10_data_types_count];
+
 #ifndef result_set_type_decl_window10_result_set
 #define result_set_type_decl_window10_result_set 1
 cql_result_set_type_decl(window10_result_set, window10_result_set_ref);
 #endif
-extern cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window10_get_month_is_null_inline_
+#define _window10_get_month_is_null_inline_
+
+
+static inline cql_bool window10_get_month_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window10_get_month_value_inline_
+#define _window10_get_month_value_inline_
+
+
+static inline cql_int32 window10_get_month_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window10_get_amount_is_null_inline_
+#define _window10_get_amount_is_null_inline_
+
+
+static inline cql_bool window10_get_amount_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window10_get_amount_value_inline_
+#define _window10_get_amount_value_inline_
+
+
+static inline cql_double window10_get_amount_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window10_get_SalesMovingAverage_is_null_inline_
+#define _window10_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window10_get_SalesMovingAverage_is_null(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window10_get_SalesMovingAverage_value_inline_
+#define _window10_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window10_get_SalesMovingAverage_value(window10_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window10_result_count(window10_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window10_fetch_results(sqlite3 *_Nonnull _db_, window10_result_set_ref _Nullable *_Nonnull result_set);
 #define window10_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2726,16 +5426,73 @@ extern cql_string_ref _Nonnull window11_stored_procedure_name;
 
 #define window11_data_types_count 3
 
+extern uint8_t window11_data_types[window11_data_types_count];
+
 #ifndef result_set_type_decl_window11_result_set
 #define result_set_type_decl_window11_result_set 1
 cql_result_set_type_decl(window11_result_set, window11_result_set_ref);
 #endif
-extern cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window11_get_month_is_null_inline_
+#define _window11_get_month_is_null_inline_
+
+
+static inline cql_bool window11_get_month_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window11_get_month_value_inline_
+#define _window11_get_month_value_inline_
+
+
+static inline cql_int32 window11_get_month_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window11_get_amount_is_null_inline_
+#define _window11_get_amount_is_null_inline_
+
+
+static inline cql_bool window11_get_amount_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window11_get_amount_value_inline_
+#define _window11_get_amount_value_inline_
+
+
+static inline cql_double window11_get_amount_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window11_get_SalesMovingAverage_is_null_inline_
+#define _window11_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window11_get_SalesMovingAverage_is_null(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window11_get_SalesMovingAverage_value_inline_
+#define _window11_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window11_get_SalesMovingAverage_value(window11_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window11_result_count(window11_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window11_fetch_results(sqlite3 *_Nonnull _db_, window11_result_set_ref _Nullable *_Nonnull result_set);
 #define window11_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2753,16 +5510,73 @@ extern cql_string_ref _Nonnull window12_stored_procedure_name;
 
 #define window12_data_types_count 3
 
+extern uint8_t window12_data_types[window12_data_types_count];
+
 #ifndef result_set_type_decl_window12_result_set
 #define result_set_type_decl_window12_result_set 1
 cql_result_set_type_decl(window12_result_set, window12_result_set_ref);
 #endif
-extern cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window12_get_month_is_null_inline_
+#define _window12_get_month_is_null_inline_
+
+
+static inline cql_bool window12_get_month_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window12_get_month_value_inline_
+#define _window12_get_month_value_inline_
+
+
+static inline cql_int32 window12_get_month_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window12_get_amount_is_null_inline_
+#define _window12_get_amount_is_null_inline_
+
+
+static inline cql_bool window12_get_amount_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window12_get_amount_value_inline_
+#define _window12_get_amount_value_inline_
+
+
+static inline cql_double window12_get_amount_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window12_get_SalesMovingAverage_is_null_inline_
+#define _window12_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window12_get_SalesMovingAverage_is_null(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window12_get_SalesMovingAverage_value_inline_
+#define _window12_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window12_get_SalesMovingAverage_value(window12_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window12_result_count(window12_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window12_fetch_results(sqlite3 *_Nonnull _db_, window12_result_set_ref _Nullable *_Nonnull result_set);
 #define window12_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2780,16 +5594,73 @@ extern cql_string_ref _Nonnull window13_stored_procedure_name;
 
 #define window13_data_types_count 3
 
+extern uint8_t window13_data_types[window13_data_types_count];
+
 #ifndef result_set_type_decl_window13_result_set
 #define result_set_type_decl_window13_result_set 1
 cql_result_set_type_decl(window13_result_set, window13_result_set_ref);
 #endif
-extern cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window13_get_month_is_null_inline_
+#define _window13_get_month_is_null_inline_
+
+
+static inline cql_bool window13_get_month_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window13_get_month_value_inline_
+#define _window13_get_month_value_inline_
+
+
+static inline cql_int32 window13_get_month_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window13_get_amount_is_null_inline_
+#define _window13_get_amount_is_null_inline_
+
+
+static inline cql_bool window13_get_amount_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window13_get_amount_value_inline_
+#define _window13_get_amount_value_inline_
+
+
+static inline cql_double window13_get_amount_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window13_get_SalesMovingAverage_is_null_inline_
+#define _window13_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window13_get_SalesMovingAverage_is_null(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window13_get_SalesMovingAverage_value_inline_
+#define _window13_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window13_get_SalesMovingAverage_value(window13_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window13_result_count(window13_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window13_fetch_results(sqlite3 *_Nonnull _db_, window13_result_set_ref _Nullable *_Nonnull result_set);
 #define window13_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2807,16 +5678,73 @@ extern cql_string_ref _Nonnull window14_stored_procedure_name;
 
 #define window14_data_types_count 3
 
+extern uint8_t window14_data_types[window14_data_types_count];
+
 #ifndef result_set_type_decl_window14_result_set
 #define result_set_type_decl_window14_result_set 1
 cql_result_set_type_decl(window14_result_set, window14_result_set_ref);
 #endif
-extern cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window14_get_month_is_null_inline_
+#define _window14_get_month_is_null_inline_
+
+
+static inline cql_bool window14_get_month_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window14_get_month_value_inline_
+#define _window14_get_month_value_inline_
+
+
+static inline cql_int32 window14_get_month_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window14_get_amount_is_null_inline_
+#define _window14_get_amount_is_null_inline_
+
+
+static inline cql_bool window14_get_amount_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window14_get_amount_value_inline_
+#define _window14_get_amount_value_inline_
+
+
+static inline cql_double window14_get_amount_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window14_get_SalesMovingAverage_is_null_inline_
+#define _window14_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window14_get_SalesMovingAverage_is_null(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window14_get_SalesMovingAverage_value_inline_
+#define _window14_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window14_get_SalesMovingAverage_value(window14_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window14_result_count(window14_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window14_fetch_results(sqlite3 *_Nonnull _db_, window14_result_set_ref _Nullable *_Nonnull result_set);
 #define window14_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2834,16 +5762,73 @@ extern cql_string_ref _Nonnull window15_stored_procedure_name;
 
 #define window15_data_types_count 3
 
+extern uint8_t window15_data_types[window15_data_types_count];
+
 #ifndef result_set_type_decl_window15_result_set
 #define result_set_type_decl_window15_result_set 1
 cql_result_set_type_decl(window15_result_set, window15_result_set_ref);
 #endif
-extern cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window15_get_month_is_null_inline_
+#define _window15_get_month_is_null_inline_
+
+
+static inline cql_bool window15_get_month_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window15_get_month_value_inline_
+#define _window15_get_month_value_inline_
+
+
+static inline cql_int32 window15_get_month_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window15_get_amount_is_null_inline_
+#define _window15_get_amount_is_null_inline_
+
+
+static inline cql_bool window15_get_amount_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window15_get_amount_value_inline_
+#define _window15_get_amount_value_inline_
+
+
+static inline cql_double window15_get_amount_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window15_get_SalesMovingAverage_is_null_inline_
+#define _window15_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window15_get_SalesMovingAverage_is_null(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window15_get_SalesMovingAverage_value_inline_
+#define _window15_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window15_get_SalesMovingAverage_value(window15_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window15_result_count(window15_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window15_fetch_results(sqlite3 *_Nonnull _db_, window15_result_set_ref _Nullable *_Nonnull result_set);
 #define window15_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2861,16 +5846,73 @@ extern cql_string_ref _Nonnull window16_stored_procedure_name;
 
 #define window16_data_types_count 3
 
+extern uint8_t window16_data_types[window16_data_types_count];
+
 #ifndef result_set_type_decl_window16_result_set
 #define result_set_type_decl_window16_result_set 1
 cql_result_set_type_decl(window16_result_set, window16_result_set_ref);
 #endif
-extern cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _window16_get_month_is_null_inline_
+#define _window16_get_month_is_null_inline_
+
+
+static inline cql_bool window16_get_month_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window16_get_month_value_inline_
+#define _window16_get_month_value_inline_
+
+
+static inline cql_int32 window16_get_month_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _window16_get_amount_is_null_inline_
+#define _window16_get_amount_is_null_inline_
+
+
+static inline cql_bool window16_get_amount_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window16_get_amount_value_inline_
+#define _window16_get_amount_value_inline_
+
+
+static inline cql_double window16_get_amount_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _window16_get_SalesMovingAverage_is_null_inline_
+#define _window16_get_SalesMovingAverage_is_null_inline_
+
+
+static inline cql_bool window16_get_SalesMovingAverage_is_null(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _window16_get_SalesMovingAverage_value_inline_
+#define _window16_get_SalesMovingAverage_value_inline_
+
+
+static inline cql_double window16_get_SalesMovingAverage_value(window16_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 window16_result_count(window16_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code window16_fetch_results(sqlite3 *_Nonnull _db_, window16_result_set_ref _Nullable *_Nonnull result_set);
 #define window16_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2971,14 +6013,53 @@ extern cql_string_ref _Nonnull virtual1_stored_procedure_name;
 
 #define virtual1_data_types_count 3
 
+extern uint8_t virtual1_data_types[virtual1_data_types_count];
+
 #ifndef result_set_type_decl_virtual1_result_set
 #define result_set_type_decl_virtual1_result_set 1
 cql_result_set_type_decl(virtual1_result_set, virtual1_result_set_ref);
 #endif
-extern cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _virtual1_get_vx_inline_
+#define _virtual1_get_vx_inline_
+
+
+static inline cql_int32 virtual1_get_vx(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _virtual1_get_vy_is_null_inline_
+#define _virtual1_get_vy_is_null_inline_
+
+
+static inline cql_bool virtual1_get_vy_is_null(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual1_get_vy_value_inline_
+#define _virtual1_get_vy_value_inline_
+
+
+static inline cql_int32 virtual1_get_vy_value(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual1_get_vz_inline_
+#define _virtual1_get_vz_inline_
+
+
+static inline cql_int32 virtual1_get_vz(virtual1_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 virtual1_result_count(virtual1_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code virtual1_fetch_results(sqlite3 *_Nonnull _db_, virtual1_result_set_ref _Nullable *_Nonnull result_set);
 #define virtual1_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -2996,14 +6077,53 @@ extern cql_string_ref _Nonnull virtual2_stored_procedure_name;
 
 #define virtual2_data_types_count 3
 
+extern uint8_t virtual2_data_types[virtual2_data_types_count];
+
 #ifndef result_set_type_decl_virtual2_result_set
 #define result_set_type_decl_virtual2_result_set 1
 cql_result_set_type_decl(virtual2_result_set, virtual2_result_set_ref);
 #endif
-extern cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _virtual2_get_vx_inline_
+#define _virtual2_get_vx_inline_
+
+
+static inline cql_int32 virtual2_get_vx(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _virtual2_get_vy_is_null_inline_
+#define _virtual2_get_vy_is_null_inline_
+
+
+static inline cql_bool virtual2_get_vy_is_null(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual2_get_vy_value_inline_
+#define _virtual2_get_vy_value_inline_
+
+
+static inline cql_int32 virtual2_get_vy_value(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _virtual2_get_vz_inline_
+#define _virtual2_get_vz_inline_
+
+
+static inline cql_int32 virtual2_get_vz(virtual2_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+
 extern cql_int32 virtual2_result_count(virtual2_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code virtual2_fetch_results(sqlite3 *_Nonnull _db_, virtual2_result_set_ref _Nullable *_Nonnull result_set);
 #define virtual2_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3038,10 +6158,13 @@ extern cql_string_ref _Nonnull private_out_union_stored_procedure_name;
 
 #define private_out_union_data_types_count 1
 
+extern uint8_t private_out_union_data_types[private_out_union_data_types_count];
+
 #ifndef result_set_type_decl_private_out_union_result_set
 #define result_set_type_decl_private_out_union_result_set 1
 cql_result_set_type_decl(private_out_union_result_set, private_out_union_result_set_ref);
 #endif
+
 extern cql_int32 private_out_union_result_count(private_out_union_result_set_ref _Nonnull result_set);
 #define private_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define private_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3065,10 +6188,13 @@ extern cql_string_ref _Nonnull no_getters_out_union_stored_procedure_name;
 
 #define no_getters_out_union_data_types_count 1
 
+extern uint8_t no_getters_out_union_data_types[no_getters_out_union_data_types_count];
+
 #ifndef result_set_type_decl_no_getters_out_union_result_set
 #define result_set_type_decl_no_getters_out_union_result_set 1
 cql_result_set_type_decl(no_getters_out_union_result_set, no_getters_out_union_result_set_ref);
 #endif
+
 extern cql_int32 no_getters_out_union_result_count(no_getters_out_union_result_set_ref _Nonnull result_set);
 #define no_getters_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define no_getters_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3089,10 +6215,13 @@ extern cql_string_ref _Nonnull suppress_results_out_union_stored_procedure_name;
 
 #define suppress_results_out_union_data_types_count 1
 
+extern uint8_t suppress_results_out_union_data_types[suppress_results_out_union_data_types_count];
+
 #ifndef result_set_type_decl_suppress_results_out_union_result_set
 #define result_set_type_decl_suppress_results_out_union_result_set 1
 cql_result_set_type_decl(suppress_results_out_union_result_set, suppress_results_out_union_result_set_ref);
 #endif
+
 extern cql_int32 suppress_results_out_union_result_count(suppress_results_out_union_result_set_ref _Nonnull result_set);
 #define suppress_results_out_union_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define suppress_results_out_union_row_equal(rs1, row1, rs2, row2) \
@@ -3164,11 +6293,23 @@ extern cql_string_ref _Nonnull out_object_stored_procedure_name;
 
 #define out_object_data_types_count 1
 
+extern uint8_t out_object_data_types[out_object_data_types_count];
+
 #ifndef result_set_type_decl_out_object_result_set
 #define result_set_type_decl_out_object_result_set 1
 cql_result_set_type_decl(out_object_result_set, out_object_result_set_ref);
 #endif
-extern cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set);
+#ifndef _out_object_get_o_inline_
+#define _out_object_get_o_inline_
+
+
+static inline cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set);
 extern void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o);
 #define out_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3195,18 +6336,93 @@ extern cql_string_ref _Nonnull result_set_proc_with_contract_in_fetch_results_st
 
 #define result_set_proc_with_contract_in_fetch_results_data_types_count 5
 
+extern uint8_t result_set_proc_with_contract_in_fetch_results_data_types[result_set_proc_with_contract_in_fetch_results_data_types_count];
+
 #ifndef result_set_type_decl_result_set_proc_with_contract_in_fetch_results_result_set
 #define result_set_type_decl_result_set_proc_with_contract_in_fetch_results_result_set 1
 cql_result_set_type_decl(result_set_proc_with_contract_in_fetch_results_result_set, result_set_proc_with_contract_in_fetch_results_result_set_ref);
 #endif
-extern cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_id_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_id_inline_
+
+
+static inline cql_int32 result_set_proc_with_contract_in_fetch_results_get_id(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_name_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_name_inline_
+
+
+static inline cql_string_ref _Nullable result_set_proc_with_contract_in_fetch_results_get_name(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_rate_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_rate_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_rate_value_inline_
+
+
+static inline cql_int64 result_set_proc_with_contract_in_fetch_results_get_rate_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_type_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_type_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_type_value_inline_
+
+
+static inline cql_int32 result_set_proc_with_contract_in_fetch_results_get_type_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+
+
+static inline cql_bool result_set_proc_with_contract_in_fetch_results_get_size_is_null(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _result_set_proc_with_contract_in_fetch_results_get_size_value_inline_
+#define _result_set_proc_with_contract_in_fetch_results_get_size_value_inline_
+
+
+static inline cql_double result_set_proc_with_contract_in_fetch_results_get_size_value(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 result_set_proc_with_contract_in_fetch_results_result_count(result_set_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code result_set_proc_with_contract_in_fetch_results_fetch_results(sqlite3 *_Nonnull _db_, result_set_proc_with_contract_in_fetch_results_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull t);
 #define result_set_proc_with_contract_in_fetch_results_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3224,18 +6440,93 @@ extern cql_string_ref _Nonnull out_proc_with_contract_in_fetch_results_stored_pr
 
 #define out_proc_with_contract_in_fetch_results_data_types_count 5
 
+extern uint8_t out_proc_with_contract_in_fetch_results_data_types[out_proc_with_contract_in_fetch_results_data_types_count];
+
 #ifndef result_set_type_decl_out_proc_with_contract_in_fetch_results_result_set
 #define result_set_type_decl_out_proc_with_contract_in_fetch_results_result_set 1
 cql_result_set_type_decl(out_proc_with_contract_in_fetch_results_result_set, out_proc_with_contract_in_fetch_results_result_set_ref);
 #endif
-extern cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
-extern cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
+#ifndef _out_proc_with_contract_in_fetch_results_get_id_inline_
+#define _out_proc_with_contract_in_fetch_results_get_id_inline_
+
+
+static inline cql_int32 out_proc_with_contract_in_fetch_results_get_id(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_name_inline_
+#define _out_proc_with_contract_in_fetch_results_get_name_inline_
+
+
+static inline cql_string_ref _Nullable out_proc_with_contract_in_fetch_results_get_name(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, 0, 1);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_rate_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_rate_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_rate_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_rate_value_inline_
+
+
+static inline cql_int64 out_proc_with_contract_in_fetch_results_get_rate_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, 0, 2);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_type_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_type_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_type_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_type_value_inline_
+
+
+static inline cql_int32 out_proc_with_contract_in_fetch_results_get_type_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 3);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+#define _out_proc_with_contract_in_fetch_results_get_size_is_null_inline_
+
+
+static inline cql_bool out_proc_with_contract_in_fetch_results_get_size_is_null(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+#ifndef _out_proc_with_contract_in_fetch_results_get_size_value_inline_
+#define _out_proc_with_contract_in_fetch_results_get_size_value_inline_
+
+
+static inline cql_double out_proc_with_contract_in_fetch_results_get_size_value(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, 0, 4);
+}
+
+#endif
+
+
 extern cql_int32 out_proc_with_contract_in_fetch_results_result_count(out_proc_with_contract_in_fetch_results_result_set_ref _Nonnull result_set);
 extern void out_proc_with_contract_in_fetch_results_fetch_results( out_proc_with_contract_in_fetch_results_result_set_ref _Nullable *_Nonnull result_set, cql_string_ref _Nonnull t);
 #define out_proc_with_contract_in_fetch_results_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3253,11 +6544,23 @@ extern cql_string_ref _Nonnull nullability_improvements_are_erased_for_sql_store
 
 #define nullability_improvements_are_erased_for_sql_data_types_count 1
 
+extern uint8_t nullability_improvements_are_erased_for_sql_data_types[nullability_improvements_are_erased_for_sql_data_types_count];
+
 #ifndef result_set_type_decl_nullability_improvements_are_erased_for_sql_result_set
 #define result_set_type_decl_nullability_improvements_are_erased_for_sql_result_set 1
 cql_result_set_type_decl(nullability_improvements_are_erased_for_sql_result_set, nullability_improvements_are_erased_for_sql_result_set_ref);
 #endif
-extern cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _nullability_improvements_are_erased_for_sql_get_b_inline_
+#define _nullability_improvements_are_erased_for_sql_get_b_inline_
+
+
+static inline cql_int32 nullability_improvements_are_erased_for_sql_get_b(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 nullability_improvements_are_erased_for_sql_result_count(nullability_improvements_are_erased_for_sql_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code nullability_improvements_are_erased_for_sql_fetch_results(sqlite3 *_Nonnull _db_, nullability_improvements_are_erased_for_sql_result_set_ref _Nullable *_Nonnull result_set);
 #define nullability_improvements_are_erased_for_sql_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3357,11 +6660,23 @@ extern cql_string_ref _Nonnull sensitive_function_is_a_no_op_stored_procedure_na
 
 #define sensitive_function_is_a_no_op_data_types_count 1
 
+extern uint8_t sensitive_function_is_a_no_op_data_types[sensitive_function_is_a_no_op_data_types_count];
+
 #ifndef result_set_type_decl_sensitive_function_is_a_no_op_result_set
 #define result_set_type_decl_sensitive_function_is_a_no_op_result_set 1
 cql_result_set_type_decl(sensitive_function_is_a_no_op_result_set, sensitive_function_is_a_no_op_result_set_ref);
 #endif
-extern cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _sensitive_function_is_a_no_op_get_y_inline_
+#define _sensitive_function_is_a_no_op_get_y_inline_
+
+
+static inline cql_string_ref _Nonnull sensitive_function_is_a_no_op_get_y(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 sensitive_function_is_a_no_op_result_count(sensitive_function_is_a_no_op_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sensitive_function_is_a_no_op_fetch_results(sqlite3 *_Nonnull _db_, sensitive_function_is_a_no_op_result_set_ref _Nullable *_Nonnull result_set);
 #define sensitive_function_is_a_no_op_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3390,11 +6705,23 @@ extern cql_string_ref _Nonnull foo_stored_procedure_name;
 
 #define foo_data_types_count 1
 
+extern uint8_t foo_data_types[foo_data_types_count];
+
 #ifndef result_set_type_decl_foo_result_set
 #define result_set_type_decl_foo_result_set 1
 cql_result_set_type_decl(foo_result_set, foo_result_set_ref);
 #endif
-extern cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _foo_get_shared_something_inline_
+#define _foo_get_shared_something_inline_
+
+
+static inline cql_int32 foo_get_shared_something(foo_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 foo_result_count(foo_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code foo_fetch_results(sqlite3 *_Nonnull _db_, foo_result_set_ref _Nullable *_Nonnull result_set);
 #define foo_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3417,18 +6744,93 @@ extern cql_string_ref _Nonnull shared_conditional_user_stored_procedure_name;
 
 #define shared_conditional_user_data_types_count 5
 
+extern uint8_t shared_conditional_user_data_types[shared_conditional_user_data_types_count];
+
 #ifndef result_set_type_decl_shared_conditional_user_result_set
 #define result_set_type_decl_shared_conditional_user_result_set 1
 cql_result_set_type_decl(shared_conditional_user_result_set, shared_conditional_user_result_set_ref);
 #endif
-extern cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_conditional_user_get_id_inline_
+#define _shared_conditional_user_get_id_inline_
+
+
+static inline cql_int32 shared_conditional_user_get_id(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_name_inline_
+#define _shared_conditional_user_get_name_inline_
+
+
+static inline cql_string_ref _Nullable shared_conditional_user_get_name(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_rate_is_null_inline_
+#define _shared_conditional_user_get_rate_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_rate_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_rate_value_inline_
+#define _shared_conditional_user_get_rate_value_inline_
+
+
+static inline cql_int64 shared_conditional_user_get_rate_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_type_is_null_inline_
+#define _shared_conditional_user_get_type_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_type_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_type_value_inline_
+#define _shared_conditional_user_get_type_value_inline_
+
+
+static inline cql_int32 shared_conditional_user_get_type_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_size_is_null_inline_
+#define _shared_conditional_user_get_size_is_null_inline_
+
+
+static inline cql_bool shared_conditional_user_get_size_is_null(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _shared_conditional_user_get_size_value_inline_
+#define _shared_conditional_user_get_size_value_inline_
+
+
+static inline cql_double shared_conditional_user_get_size_value(shared_conditional_user_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+
 extern cql_int32 shared_conditional_user_result_count(shared_conditional_user_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_conditional_user_fetch_results(sqlite3 *_Nonnull _db_, shared_conditional_user_result_set_ref _Nullable *_Nonnull result_set, cql_int32 x);
 #define shared_conditional_user_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3451,11 +6853,23 @@ extern cql_string_ref _Nonnull nested_shared_stuff_stored_procedure_name;
 
 #define nested_shared_stuff_data_types_count 1
 
+extern uint8_t nested_shared_stuff_data_types[nested_shared_stuff_data_types_count];
+
 #ifndef result_set_type_decl_nested_shared_stuff_result_set
 #define result_set_type_decl_nested_shared_stuff_result_set 1
 cql_result_set_type_decl(nested_shared_stuff_result_set, nested_shared_stuff_result_set_ref);
 #endif
-extern cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _nested_shared_stuff_get_x_inline_
+#define _nested_shared_stuff_get_x_inline_
+
+
+static inline cql_int32 nested_shared_stuff_get_x(nested_shared_stuff_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 nested_shared_stuff_result_count(nested_shared_stuff_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code nested_shared_stuff_fetch_results(sqlite3 *_Nonnull _db_, nested_shared_stuff_result_set_ref _Nullable *_Nonnull result_set);
 #define nested_shared_stuff_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3473,11 +6887,23 @@ extern cql_string_ref _Nonnull use_nested_select_shared_frag_form_stored_procedu
 
 #define use_nested_select_shared_frag_form_data_types_count 1
 
+extern uint8_t use_nested_select_shared_frag_form_data_types[use_nested_select_shared_frag_form_data_types_count];
+
 #ifndef result_set_type_decl_use_nested_select_shared_frag_form_result_set
 #define result_set_type_decl_use_nested_select_shared_frag_form_result_set 1
 cql_result_set_type_decl(use_nested_select_shared_frag_form_result_set, use_nested_select_shared_frag_form_result_set_ref);
 #endif
-extern cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_nested_select_shared_frag_form_get_x_inline_
+#define _use_nested_select_shared_frag_form_get_x_inline_
+
+
+static inline cql_int32 use_nested_select_shared_frag_form_get_x(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 use_nested_select_shared_frag_form_result_count(use_nested_select_shared_frag_form_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_nested_select_shared_frag_form_fetch_results(sqlite3 *_Nonnull _db_, use_nested_select_shared_frag_form_result_set_ref _Nullable *_Nonnull result_set);
 #define use_nested_select_shared_frag_form_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3502,11 +6928,23 @@ extern cql_string_ref _Nonnull shared_frag_else_nothing_test_stored_procedure_na
 
 #define shared_frag_else_nothing_test_data_types_count 1
 
+extern uint8_t shared_frag_else_nothing_test_data_types[shared_frag_else_nothing_test_data_types_count];
+
 #ifndef result_set_type_decl_shared_frag_else_nothing_test_result_set
 #define result_set_type_decl_shared_frag_else_nothing_test_result_set 1
 cql_result_set_type_decl(shared_frag_else_nothing_test_result_set, shared_frag_else_nothing_test_result_set_ref);
 #endif
-extern cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_frag_else_nothing_test_get_id_inline_
+#define _shared_frag_else_nothing_test_get_id_inline_
+
+
+static inline cql_int32 shared_frag_else_nothing_test_get_id(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 shared_frag_else_nothing_test_result_count(shared_frag_else_nothing_test_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_test_result_set_ref _Nullable *_Nonnull result_set);
 #define shared_frag_else_nothing_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3524,13 +6962,43 @@ extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_stor
 
 #define shared_frag_else_nothing_in_from_clause_test_data_types_count 2
 
+extern uint8_t shared_frag_else_nothing_in_from_clause_test_data_types[shared_frag_else_nothing_in_from_clause_test_data_types_count];
+
 #ifndef result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set
 #define result_set_type_decl_shared_frag_else_nothing_in_from_clause_test_result_set 1
 cql_result_set_type_decl(shared_frag_else_nothing_in_from_clause_test_result_set, shared_frag_else_nothing_in_from_clause_test_result_set_ref);
 #endif
-extern cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_id1_is_null_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_id1_is_null_inline_
+
+
+static inline cql_bool shared_frag_else_nothing_in_from_clause_test_get_id1_is_null(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_id1_value_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_id1_value_inline_
+
+
+static inline cql_int32 shared_frag_else_nothing_in_from_clause_test_get_id1_value(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _shared_frag_else_nothing_in_from_clause_test_get_text1_inline_
+#define _shared_frag_else_nothing_in_from_clause_test_get_text1_inline_
+
+
+static inline cql_string_ref _Nonnull shared_frag_else_nothing_in_from_clause_test_get_text1(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 shared_frag_else_nothing_in_from_clause_test_result_count(shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code shared_frag_else_nothing_in_from_clause_test_fetch_results(sqlite3 *_Nonnull _db_, shared_frag_else_nothing_in_from_clause_test_result_set_ref _Nullable *_Nonnull result_set);
 #define shared_frag_else_nothing_in_from_clause_test_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3635,12 +7103,33 @@ extern cql_string_ref _Nonnull some_redeclared_out_proc_stored_procedure_name;
 
 #define some_redeclared_out_proc_data_types_count 1
 
+extern uint8_t some_redeclared_out_proc_data_types[some_redeclared_out_proc_data_types_count];
+
 #ifndef result_set_type_decl_some_redeclared_out_proc_result_set
 #define result_set_type_decl_some_redeclared_out_proc_result_set 1
 cql_result_set_type_decl(some_redeclared_out_proc_result_set, some_redeclared_out_proc_result_set_ref);
 #endif
-extern cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
-extern cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
+#ifndef _some_redeclared_out_proc_get_x_is_null_inline_
+#define _some_redeclared_out_proc_get_x_is_null_inline_
+
+
+static inline cql_bool some_redeclared_out_proc_get_x_is_null(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+#ifndef _some_redeclared_out_proc_get_x_value_inline_
+#define _some_redeclared_out_proc_get_x_value_inline_
+
+
+static inline cql_int32 some_redeclared_out_proc_get_x_value(some_redeclared_out_proc_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, 0, 0);
+}
+
+#endif
+
+
 extern cql_int32 some_redeclared_out_proc_result_count(some_redeclared_out_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code some_redeclared_out_proc_fetch_results(sqlite3 *_Nonnull _db_, some_redeclared_out_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define some_redeclared_out_proc_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
@@ -3670,12 +7159,33 @@ extern cql_string_ref _Nonnull some_redeclared_out_union_proc_stored_procedure_n
 
 #define some_redeclared_out_union_proc_data_types_count 1
 
+extern uint8_t some_redeclared_out_union_proc_data_types[some_redeclared_out_union_proc_data_types_count];
+
 #ifndef result_set_type_decl_some_redeclared_out_union_proc_result_set
 #define result_set_type_decl_some_redeclared_out_union_proc_result_set 1
 cql_result_set_type_decl(some_redeclared_out_union_proc_result_set, some_redeclared_out_union_proc_result_set_ref);
 #endif
-extern cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _some_redeclared_out_union_proc_get_x_is_null_inline_
+#define _some_redeclared_out_union_proc_get_x_is_null_inline_
+
+
+static inline cql_bool some_redeclared_out_union_proc_get_x_is_null(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _some_redeclared_out_union_proc_get_x_value_inline_
+#define _some_redeclared_out_union_proc_get_x_value_inline_
+
+
+static inline cql_int32 some_redeclared_out_union_proc_get_x_value(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
 extern cql_int32 some_redeclared_out_union_proc_result_count(some_redeclared_out_union_proc_result_set_ref _Nonnull result_set);
 #define some_redeclared_out_union_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define some_redeclared_out_union_proc_row_equal(rs1, row1, rs2, row2) \
@@ -3726,12 +7236,33 @@ extern cql_string_ref _Nonnull a_proc_that_needs_dependents_stored_procedure_nam
 
 #define a_proc_that_needs_dependents_data_types_count 2
 
+extern uint8_t a_proc_that_needs_dependents_data_types[a_proc_that_needs_dependents_data_types_count];
+
 #ifndef result_set_type_decl_a_proc_that_needs_dependents_result_set
 #define result_set_type_decl_a_proc_that_needs_dependents_result_set 1
 cql_result_set_type_decl(a_proc_that_needs_dependents_result_set, a_proc_that_needs_dependents_result_set_ref);
 #endif
-extern a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row);
-extern a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _a_proc_that_needs_dependents_get_a_foo_inline_
+#define _a_proc_that_needs_dependents_get_a_foo_inline_
+
+
+static inline a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_a_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (a_proc_we_need_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 0));
+}
+
+#endif
+
+#ifndef _a_proc_that_needs_dependents_get_another_foo_inline_
+#define _a_proc_that_needs_dependents_get_another_foo_inline_
+
+
+static inline a_proc_we_need_result_set_ref _Nullable a_proc_that_needs_dependents_get_another_foo(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (a_proc_we_need_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 1) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 1));
+}
+
+#endif
+
+
 extern cql_int32 a_proc_that_needs_dependents_result_count(a_proc_that_needs_dependents_result_set_ref _Nonnull result_set);
 #define a_proc_that_needs_dependents_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define a_proc_that_needs_dependents_row_equal(rs1, row1, rs2, row2) \
@@ -3752,12 +7283,33 @@ extern cql_string_ref _Nonnull simple_child_proc_stored_procedure_name;
 
 #define simple_child_proc_data_types_count 2
 
+extern uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_child_proc_result_set
 #define result_set_type_decl_simple_child_proc_result_set 1
 cql_result_set_type_decl(simple_child_proc_result_set, simple_child_proc_result_set_ref);
 #endif
-extern cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _simple_child_proc_get_x_inline_
+#define _simple_child_proc_get_x_inline_
+
+
+static inline cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_child_proc_get_y_inline_
+#define _simple_child_proc_get_y_inline_
+
+
+static inline cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
 extern cql_int32 simple_child_proc_result_count(simple_child_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code simple_child_proc_fetch_results(sqlite3 *_Nonnull _db_, simple_child_proc_result_set_ref _Nullable *_Nonnull result_set);
 #define simple_child_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3775,18 +7327,89 @@ extern cql_string_ref _Nonnull simple_container_proc_stored_procedure_name;
 
 #define simple_container_proc_data_types_count 3
 
+extern uint8_t simple_container_proc_data_types[simple_container_proc_data_types_count];
+
 #ifndef result_set_type_decl_simple_container_proc_result_set
 #define result_set_type_decl_simple_container_proc_result_set 1
 cql_result_set_type_decl(simple_container_proc_result_set, simple_container_proc_result_set_ref);
 #endif
-extern cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value);
-extern simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row);
-extern void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value);
+#ifndef _simple_container_proc_get_a_is_null_inline_
+#define _simple_container_proc_get_a_is_null_inline_
+
+
+static inline cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _simple_container_proc_get_a_value_inline_
+#define _simple_container_proc_get_a_value_inline_
+
+
+static inline cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_a_value_inline_
+#define _simple_container_proc_set_a_value_inline_
+
+static inline void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
+}
+
+#endif
+
+#ifndef _simple_container_proc_set_a_to_null_inline_
+#define _simple_container_proc_set_a_to_null_inline_
+
+static inline void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+#ifndef _simple_container_proc_get_b_inline_
+#define _simple_container_proc_get_b_inline_
+
+
+static inline cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_b_inline_
+#define _simple_container_proc_set_b_inline_
+
+static inline void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
+  cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
+}
+
+#endif
+#ifndef _simple_container_proc_get_c_inline_
+#define _simple_container_proc_get_c_inline_
+
+
+static inline simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return (simple_child_proc_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 2));
+}
+
+#endif
+
+
+#ifndef _simple_container_proc_set_c_inline_
+#define _simple_container_proc_set_c_inline_
+
+static inline void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
+  cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
+}
+
+#endif
+
 extern cql_int32 simple_container_proc_result_count(simple_container_proc_result_set_ref _Nonnull result_set);
 #define simple_container_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
 #define simple_container_proc_row_equal(rs1, row1, rs2, row2) \
@@ -3832,19 +7455,103 @@ extern cql_string_ref _Nonnull use_generated_fragment_stored_procedure_name;
 
 #define use_generated_fragment_data_types_count 7
 
+extern uint8_t use_generated_fragment_data_types[use_generated_fragment_data_types_count];
+
 #ifndef result_set_type_decl_use_generated_fragment_result_set
 #define result_set_type_decl_use_generated_fragment_result_set 1
 cql_result_set_type_decl(use_generated_fragment_result_set, use_generated_fragment_result_set_ref);
 #endif
-extern cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_generated_fragment_get_rowid_inline_
+#define _use_generated_fragment_get_rowid_inline_
+
+
+static inline cql_int64 use_generated_fragment_get_rowid(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_flag_inline_
+#define _use_generated_fragment_get_flag_inline_
+
+
+static inline cql_bool use_generated_fragment_get_flag(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_id_is_null_inline_
+#define _use_generated_fragment_get_id_is_null_inline_
+
+
+static inline cql_bool use_generated_fragment_get_id_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_id_value_inline_
+#define _use_generated_fragment_get_id_value_inline_
+
+
+static inline cql_int64 use_generated_fragment_get_id_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_name_inline_
+#define _use_generated_fragment_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_generated_fragment_get_name(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_age_is_null_inline_
+#define _use_generated_fragment_get_age_is_null_inline_
+
+
+static inline cql_bool use_generated_fragment_get_age_is_null(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_age_value_inline_
+#define _use_generated_fragment_get_age_value_inline_
+
+
+static inline cql_double use_generated_fragment_get_age_value(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_storage_inline_
+#define _use_generated_fragment_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_generated_fragment_get_storage(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_generated_fragment_get_pk_inline_
+#define _use_generated_fragment_get_pk_inline_
+
+
+static inline cql_int32 use_generated_fragment_get_pk(use_generated_fragment_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_generated_fragment_result_count(use_generated_fragment_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_generated_fragment_fetch_results(sqlite3 *_Nonnull _db_, use_generated_fragment_result_set_ref _Nullable *_Nonnull result_set);
 #define use_generated_fragment_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3862,19 +7569,103 @@ extern cql_string_ref _Nonnull use_backed_table_directly_stored_procedure_name;
 
 #define use_backed_table_directly_data_types_count 7
 
+extern uint8_t use_backed_table_directly_data_types[use_backed_table_directly_data_types_count];
+
 #ifndef result_set_type_decl_use_backed_table_directly_result_set
 #define result_set_type_decl_use_backed_table_directly_result_set 1
 cql_result_set_type_decl(use_backed_table_directly_result_set, use_backed_table_directly_result_set_ref);
 #endif
-extern cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_backed_table_directly_get_rowid_inline_
+#define _use_backed_table_directly_get_rowid_inline_
+
+
+static inline cql_int64 use_backed_table_directly_get_rowid(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_flag_inline_
+#define _use_backed_table_directly_get_flag_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_flag(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_id_is_null_inline_
+#define _use_backed_table_directly_get_id_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_id_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_id_value_inline_
+#define _use_backed_table_directly_get_id_value_inline_
+
+
+static inline cql_int64 use_backed_table_directly_get_id_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_name_inline_
+#define _use_backed_table_directly_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_backed_table_directly_get_name(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_age_is_null_inline_
+#define _use_backed_table_directly_get_age_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_get_age_is_null(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_age_value_inline_
+#define _use_backed_table_directly_get_age_value_inline_
+
+
+static inline cql_double use_backed_table_directly_get_age_value(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_storage_inline_
+#define _use_backed_table_directly_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_backed_table_directly_get_storage(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_get_pk_inline_
+#define _use_backed_table_directly_get_pk_inline_
+
+
+static inline cql_int32 use_backed_table_directly_get_pk(use_backed_table_directly_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_backed_table_directly_result_count(use_backed_table_directly_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_backed_table_directly_fetch_results(sqlite3 *_Nonnull _db_, use_backed_table_directly_result_set_ref _Nullable *_Nonnull result_set);
 #define use_backed_table_directly_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -3895,19 +7686,103 @@ extern cql_string_ref _Nonnull use_backed_table_directly_in_with_select_stored_p
 
 #define use_backed_table_directly_in_with_select_data_types_count 7
 
+extern uint8_t use_backed_table_directly_in_with_select_data_types[use_backed_table_directly_in_with_select_data_types_count];
+
 #ifndef result_set_type_decl_use_backed_table_directly_in_with_select_result_set
 #define result_set_type_decl_use_backed_table_directly_in_with_select_result_set 1
 cql_result_set_type_decl(use_backed_table_directly_in_with_select_result_set, use_backed_table_directly_in_with_select_result_set_ref);
 #endif
-extern cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
-extern cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row);
+#ifndef _use_backed_table_directly_in_with_select_get_rowid_inline_
+#define _use_backed_table_directly_in_with_select_get_rowid_inline_
+
+
+static inline cql_int64 use_backed_table_directly_in_with_select_get_rowid(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 0);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_flag_inline_
+#define _use_backed_table_directly_in_with_select_get_flag_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_flag(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 1);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_id_is_null_inline_
+#define _use_backed_table_directly_in_with_select_get_id_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_id_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_id_value_inline_
+#define _use_backed_table_directly_in_with_select_get_id_value_inline_
+
+
+static inline cql_int64 use_backed_table_directly_in_with_select_get_id_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 2);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_name_inline_
+#define _use_backed_table_directly_in_with_select_get_name_inline_
+
+
+static inline cql_string_ref _Nullable use_backed_table_directly_in_with_select_get_name(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 3) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 3);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_age_is_null_inline_
+#define _use_backed_table_directly_in_with_select_get_age_is_null_inline_
+
+
+static inline cql_bool use_backed_table_directly_in_with_select_get_age_is_null(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_age_value_inline_
+#define _use_backed_table_directly_in_with_select_get_age_value_inline_
+
+
+static inline cql_double use_backed_table_directly_in_with_select_get_age_value(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 4);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_storage_inline_
+#define _use_backed_table_directly_in_with_select_get_storage_inline_
+
+
+static inline cql_blob_ref _Nullable use_backed_table_directly_in_with_select_get_storage(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 5) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
+}
+
+#endif
+
+#ifndef _use_backed_table_directly_in_with_select_get_pk_inline_
+#define _use_backed_table_directly_in_with_select_get_pk_inline_
+
+
+static inline cql_int32 use_backed_table_directly_in_with_select_get_pk(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
+}
+
+#endif
+
+
 extern cql_int32 use_backed_table_directly_in_with_select_result_count(use_backed_table_directly_in_with_select_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code use_backed_table_directly_in_with_select_fetch_results(sqlite3 *_Nonnull _db_, use_backed_table_directly_in_with_select_result_set_ref _Nullable *_Nonnull result_set);
 #define use_backed_table_directly_in_with_select_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)

--- a/sources/test/cg_test_c_with_type_getters.h.ref
+++ b/sources/test/cg_test_c_with_type_getters.h.ref
@@ -60,70 +60,166 @@ extern uint8_t selector_data_types[selector_data_types_count];
 #define result_set_type_decl_selector_result_set 1
 cql_result_set_type_decl(selector_result_set, selector_result_set_ref);
 #endif
+#ifndef _selector_get_f1_inline_
+#define _selector_get_f1_inline_
+
 
 static inline cql_int32 selector_get_f1(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
 }
 
+#endif
+
+#ifndef _selector_get_f2_inline_
+#define _selector_get_f2_inline_
+
+
 static inline cql_string_ref _Nonnull selector_get_f2(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
 }
+
+#endif
+
+#ifndef _selector_get_f3_inline_
+#define _selector_get_f3_inline_
+
 
 static inline cql_double selector_get_f3(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
 }
 
+#endif
+
+#ifndef _selector_get_f4_inline_
+#define _selector_get_f4_inline_
+
+
 static inline cql_bool selector_get_f4(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 3);
 }
+
+#endif
+
+#ifndef _selector_get_f5_inline_
+#define _selector_get_f5_inline_
+
 
 static inline cql_int64 selector_get_f5(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 4);
 }
 
+#endif
+
+#ifndef _selector_get_f6_inline_
+#define _selector_get_f6_inline_
+
+
 static inline cql_blob_ref _Nonnull selector_get_f6(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
 }
+
+#endif
+
+#ifndef _selector_get_g1_is_null_inline_
+#define _selector_get_g1_is_null_inline_
+
 
 static inline cql_bool selector_get_g1_is_null(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 6);
 }
 
+#endif
+
+#ifndef _selector_get_g1_value_inline_
+#define _selector_get_g1_value_inline_
+
+
 static inline cql_int32 selector_get_g1_value(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
 }
+
+#endif
+
+#ifndef _selector_get_g2_inline_
+#define _selector_get_g2_inline_
+
 
 static inline cql_string_ref _Nullable selector_get_g2(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 7) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 7);
 }
 
+#endif
+
+#ifndef _selector_get_g3_is_null_inline_
+#define _selector_get_g3_is_null_inline_
+
+
 static inline cql_bool selector_get_g3_is_null(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 8);
 }
+
+#endif
+
+#ifndef _selector_get_g3_value_inline_
+#define _selector_get_g3_value_inline_
+
 
 static inline cql_double selector_get_g3_value(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 8);
 }
 
+#endif
+
+#ifndef _selector_get_g4_is_null_inline_
+#define _selector_get_g4_is_null_inline_
+
+
 static inline cql_bool selector_get_g4_is_null(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 9);
 }
+
+#endif
+
+#ifndef _selector_get_g4_value_inline_
+#define _selector_get_g4_value_inline_
+
 
 static inline cql_bool selector_get_g4_value(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 9);
 }
 
+#endif
+
+#ifndef _selector_get_g5_is_null_inline_
+#define _selector_get_g5_is_null_inline_
+
+
 static inline cql_bool selector_get_g5_is_null(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 10);
 }
+
+#endif
+
+#ifndef _selector_get_g5_value_inline_
+#define _selector_get_g5_value_inline_
+
 
 static inline cql_int64 selector_get_g5_value(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 10);
 }
 
+#endif
+
+#ifndef _selector_get_g6_inline_
+#define _selector_get_g6_inline_
+
+
 static inline cql_blob_ref _Nullable selector_get_g6(selector_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 11) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 11);
 }
+
+#endif
+
 
 extern cql_int32 selector_result_count(selector_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code selector_fetch_results(sqlite3 *_Nonnull _db_, selector_result_set_ref _Nullable *_Nonnull result_set);
@@ -148,10 +244,16 @@ extern uint8_t emit_object_result_set_data_types[emit_object_result_set_data_typ
 #define result_set_type_decl_emit_object_result_set_result_set 1
 cql_result_set_type_decl(emit_object_result_set_result_set, emit_object_result_set_result_set_ref);
 #endif
+#ifndef _emit_object_result_set_get_o_inline_
+#define _emit_object_result_set_get_o_inline_
+
 
 static inline cql_object_ref _Nonnull emit_object_result_set_get_o(emit_object_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 0);
 }
+
+#endif
+
 
 extern cql_int32 emit_object_result_set_result_count(emit_object_result_set_result_set_ref _Nonnull result_set);
 #define emit_object_result_set_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
@@ -176,70 +278,166 @@ extern uint8_t sproc_copy_func_data_types[sproc_copy_func_data_types_count];
 #define result_set_type_decl_sproc_copy_func_result_set 1
 cql_result_set_type_decl(sproc_copy_func_result_set, sproc_copy_func_result_set_ref);
 #endif
+#ifndef _sproc_copy_func_get_f1_inline_
+#define _sproc_copy_func_get_f1_inline_
+
 
 static inline cql_int32 sproc_copy_func_get_f1(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_f2_inline_
+#define _sproc_copy_func_get_f2_inline_
+
+
 static inline cql_string_ref _Nonnull sproc_copy_func_get_f2(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 1);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_f3_inline_
+#define _sproc_copy_func_get_f3_inline_
+
 
 static inline cql_double sproc_copy_func_get_f3(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 2);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_f4_inline_
+#define _sproc_copy_func_get_f4_inline_
+
+
 static inline cql_bool sproc_copy_func_get_f4(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 3);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_f5_inline_
+#define _sproc_copy_func_get_f5_inline_
+
 
 static inline cql_int64 sproc_copy_func_get_f5(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 4);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_f6_inline_
+#define _sproc_copy_func_get_f6_inline_
+
+
 static inline cql_blob_ref _Nonnull sproc_copy_func_get_f6(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 5);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_g1_is_null_inline_
+#define _sproc_copy_func_get_g1_is_null_inline_
+
 
 static inline cql_bool sproc_copy_func_get_g1_is_null(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 6);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_g1_value_inline_
+#define _sproc_copy_func_get_g1_value_inline_
+
+
 static inline cql_int32 sproc_copy_func_get_g1_value(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 6);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_g2_inline_
+#define _sproc_copy_func_get_g2_inline_
+
 
 static inline cql_string_ref _Nullable sproc_copy_func_get_g2(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 7) ? NULL : cql_result_set_get_string_col((cql_result_set_ref)result_set, row, 7);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_g3_is_null_inline_
+#define _sproc_copy_func_get_g3_is_null_inline_
+
+
 static inline cql_bool sproc_copy_func_get_g3_is_null(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 8);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_g3_value_inline_
+#define _sproc_copy_func_get_g3_value_inline_
+
 
 static inline cql_double sproc_copy_func_get_g3_value(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_double_col((cql_result_set_ref)result_set, row, 8);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_g4_is_null_inline_
+#define _sproc_copy_func_get_g4_is_null_inline_
+
+
 static inline cql_bool sproc_copy_func_get_g4_is_null(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 9);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_g4_value_inline_
+#define _sproc_copy_func_get_g4_value_inline_
+
 
 static inline cql_bool sproc_copy_func_get_g4_value(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_bool_col((cql_result_set_ref)result_set, row, 9);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_g5_is_null_inline_
+#define _sproc_copy_func_get_g5_is_null_inline_
+
+
 static inline cql_bool sproc_copy_func_get_g5_is_null(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 10);
 }
+
+#endif
+
+#ifndef _sproc_copy_func_get_g5_value_inline_
+#define _sproc_copy_func_get_g5_value_inline_
+
 
 static inline cql_int64 sproc_copy_func_get_g5_value(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int64_col((cql_result_set_ref)result_set, row, 10);
 }
 
+#endif
+
+#ifndef _sproc_copy_func_get_g6_inline_
+#define _sproc_copy_func_get_g6_inline_
+
+
 static inline cql_blob_ref _Nullable sproc_copy_func_get_g6(sproc_copy_func_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 11) ? NULL : cql_result_set_get_blob_col((cql_result_set_ref)result_set, row, 11);
 }
+
+#endif
+
 
 extern cql_int32 sproc_copy_func_result_count(sproc_copy_func_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code sproc_copy_func_fetch_results(sqlite3 *_Nonnull _db_, sproc_copy_func_result_set_ref _Nullable *_Nonnull result_set);
@@ -270,15 +468,26 @@ extern uint8_t emit_object_with_setters_data_types[emit_object_with_setters_data
 #define result_set_type_decl_emit_object_with_setters_result_set 1
 cql_result_set_type_decl(emit_object_with_setters_result_set, emit_object_with_setters_result_set_ref);
 #endif
+#ifndef _emit_object_with_setters_get_o_inline_
+#define _emit_object_with_setters_get_o_inline_
+
 
 static inline cql_object_ref _Nonnull emit_object_with_setters_get_o(emit_object_with_setters_result_set_ref _Nonnull result_set) {
   return cql_result_set_get_object_col((cql_result_set_ref)result_set, 0, 0);
 }
 
+#endif
+
+
+#ifndef _emit_object_with_setters_set_o_inline_
+#define _emit_object_with_setters_set_o_inline_
+
 static inline void emit_object_with_setters_set_o(emit_object_with_setters_result_set_ref _Nonnull result_set, cql_object_ref _Nonnull new_value) {
   cql_contract_argument_notnull((void *)new_value, 2);
   cql_result_set_set_object_col((cql_result_set_ref)result_set, 0, 0, new_value);
 }
+
+#endif
 
 extern cql_int32 emit_object_with_setters_result_count(emit_object_with_setters_result_set_ref _Nonnull result_set);
 extern void emit_object_with_setters_fetch_results( emit_object_with_setters_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o);
@@ -303,14 +512,26 @@ extern uint8_t simple_child_proc_data_types[simple_child_proc_data_types_count];
 #define result_set_type_decl_simple_child_proc_result_set 1
 cql_result_set_type_decl(simple_child_proc_result_set, simple_child_proc_result_set_ref);
 #endif
+#ifndef _simple_child_proc_get_x_inline_
+#define _simple_child_proc_get_x_inline_
+
 
 static inline cql_int32 simple_child_proc_get_x(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
 }
 
+#endif
+
+#ifndef _simple_child_proc_get_y_inline_
+#define _simple_child_proc_get_y_inline_
+
+
 static inline cql_int32 simple_child_proc_get_y(simple_child_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
 }
+
+#endif
+
 
 extern cql_int32 simple_child_proc_result_count(simple_child_proc_result_set_ref _Nonnull result_set);
 extern CQL_WARN_UNUSED cql_code simple_child_proc_fetch_results(sqlite3 *_Nonnull _db_, simple_child_proc_result_set_ref _Nullable *_Nonnull result_set);
@@ -335,38 +556,82 @@ extern uint8_t simple_container_proc_data_types[simple_container_proc_data_types
 #define result_set_type_decl_simple_container_proc_result_set 1
 cql_result_set_type_decl(simple_container_proc_result_set, simple_container_proc_result_set_ref);
 #endif
+#ifndef _simple_container_proc_get_a_is_null_inline_
+#define _simple_container_proc_get_a_is_null_inline_
+
 
 static inline cql_bool simple_container_proc_get_a_is_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 0);
 }
 
+#endif
+
+#ifndef _simple_container_proc_get_a_value_inline_
+#define _simple_container_proc_get_a_value_inline_
+
+
 static inline cql_int32 simple_container_proc_get_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 0);
 }
+
+#endif
+
+
+#ifndef _simple_container_proc_set_a_value_inline_
+#define _simple_container_proc_set_a_value_inline_
 
 static inline void simple_container_proc_set_a_value(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
   cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 0, new_value);
 }
 
+#endif
+
+#ifndef _simple_container_proc_set_a_to_null_inline_
+#define _simple_container_proc_set_a_to_null_inline_
+
 static inline void simple_container_proc_set_a_to_null(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   cql_result_set_set_to_null_col((cql_result_set_ref)result_set, row, 0);
 }
+
+#endif
+#ifndef _simple_container_proc_get_b_inline_
+#define _simple_container_proc_get_b_inline_
+
 
 static inline cql_int32 simple_container_proc_get_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   return cql_result_set_get_int32_col((cql_result_set_ref)result_set, row, 1);
 }
 
+#endif
+
+
+#ifndef _simple_container_proc_set_b_inline_
+#define _simple_container_proc_set_b_inline_
+
 static inline void simple_container_proc_set_b(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, cql_int32 new_value) {
   cql_result_set_set_int32_col((cql_result_set_ref)result_set, row, 1, new_value);
 }
+
+#endif
+#ifndef _simple_container_proc_get_c_inline_
+#define _simple_container_proc_get_c_inline_
+
 
 static inline simple_child_proc_result_set_ref _Nullable simple_container_proc_get_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row) {
   return (simple_child_proc_result_set_ref _Nullable )(cql_result_set_get_is_null_col((cql_result_set_ref)result_set, row, 2) ? NULL : cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 2));
 }
 
+#endif
+
+
+#ifndef _simple_container_proc_set_c_inline_
+#define _simple_container_proc_set_c_inline_
+
 static inline void simple_container_proc_set_c(simple_container_proc_result_set_ref _Nonnull result_set, cql_int32 row, simple_child_proc_result_set_ref _Nullable new_value) {
   cql_result_set_set_object_col((cql_result_set_ref)result_set, row, 2, (cql_object_ref)new_value);
 }
+
+#endif
 
 extern cql_int32 simple_container_proc_result_count(simple_container_proc_result_set_ref _Nonnull result_set);
 #define simple_container_proc_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)

--- a/sources/test/usage.out.ref
+++ b/sources/test/usage.out.ref
@@ -74,7 +74,3 @@ Result Types (--rt *) These are the various outputs the compiler can produce.
 --generate_exports
   requires another output file to --cg; it contains the procedure declarations for the input
   used with --rt c
---generate_type_getters
-  emits rowset accessors using shared type getters instead of individual functions
-  this makes them more interoperable if they share columns
-  used with --rt c


### PR DESCRIPTION
Responding to the issue discussed here: https://github.com/ricomariani/CG-SQL-author/discussions/73

It seems like the `--generate_type_getters` option is the best way to go forward.  The alternative is to fatten all result sets which seems far worse.  This way we get to delete code instead of complicating code and we get a more flexible ABI.

The optional path becomes the new default and only option.  I've removed the option entirely and deleted the other code.