### PR TITLE
Allow FROM shape syntax sugar in update statements

### DIFF
--- a/docs/user_guide/appendices/04_error_codes.md
+++ b/docs/user_guide/appendices/04_error_codes.md
@@ -4665,3 +4665,19 @@ Consequently, the CASE statement will default to the ELSE clause, provided it is
 ### CQL0502: Cannot re-assign value to constant variable.
 
 When you declare variables with the `const` syntax, they cannot be re-assigned a new value (e.g. with a `set` statement, are being passed to an out argument). Declare these variables with a `let` statement instead if you would like to mutate them.
+
+### CQL0503: Cannot use an empty column list for an UPDATE statement
+
+When you use an UPDATE statement with a shape like this:
+```sql
+update some_table
+set () = (from my_cursor)
+where some_table.id = my_cursor.id
+```
+
+The column list after the `set` cannot be empty. A list of columns, or a shape, must be provided:
+```sql
+update some_table
+set (like my_cursor) = (from my_cursor)
+where some_table.id = my_cursor.id
+```

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -1942,6 +1942,14 @@ update_stmt:
     struct ast_node *from = new_ast_update_from($opt_from_query_parts, where);
     struct ast_node *list = new_ast_update_set($update_list, from);
     $update_stmt = new_ast_update_stmt($sql_name, list); }
+  | UPDATE sql_name opt_column_spec from_shape opt_where opt_orderby opt_limit  {
+    struct ast_node *limit = $opt_limit;
+    struct ast_node *orderby = new_ast_update_orderby($opt_orderby, limit);
+    struct ast_node *where = new_ast_update_where($opt_where, orderby);
+    struct ast_node *from = new_ast_update_from(NULL, where);
+    struct ast_node *columns_values = new_ast_columns_values($opt_column_spec, $from_shape);
+    struct ast_node *list = new_ast_update_set(columns_values, from);
+    $update_stmt = new_ast_update_stmt($sql_name, list); }
   ;
 
 update_entry:

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -1942,12 +1942,12 @@ update_stmt:
     struct ast_node *from = new_ast_update_from($opt_from_query_parts, where);
     struct ast_node *list = new_ast_update_set($update_list, from);
     $update_stmt = new_ast_update_stmt($sql_name, list); }
-  | UPDATE sql_name opt_column_spec from_shape opt_where opt_orderby opt_limit  {
+  | UPDATE sql_name SET opt_column_spec '=' '(' insert_list ')' opt_from_query_parts opt_where opt_orderby opt_limit  {
     struct ast_node *limit = $opt_limit;
     struct ast_node *orderby = new_ast_update_orderby($opt_orderby, limit);
     struct ast_node *where = new_ast_update_where($opt_where, orderby);
-    struct ast_node *from = new_ast_update_from(NULL, where);
-    struct ast_node *columns_values = new_ast_columns_values($opt_column_spec, $from_shape);
+    struct ast_node *from = new_ast_update_from($opt_from_query_parts, where);
+    struct ast_node *columns_values = new_ast_columns_values($opt_column_spec, $insert_list);
     struct ast_node *list = new_ast_update_set(columns_values, from);
     $update_stmt = new_ast_update_stmt($sql_name, list); }
   ;

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -3528,20 +3528,20 @@ static void gen_update_stmt(ast_node *ast) {
   }
   GEN_BEGIN_INDENT(up, 2);
 
+  gen_printf("\nSET ");
   if (is_ast_columns_values(update_list)) {
-    // UPDATE table_name[opt_column_spec] [from_shape]
+    // UPDATE table_name SET ([opt_column_spec]) = ([from_shape])
     EXTRACT(column_spec, update_list->left);
     EXTRACT_ANY_NOTNULL(from_shape_or_insert_list, update_list->right);
+
     gen_column_spec(column_spec);
-    gen_printf(" ");
-    if (is_ast_from_shape(from_shape_or_insert_list)) {
-      gen_from_shape(from_shape_or_insert_list);
-    } else {
-      gen_insert_list(from_shape_or_insert_list);
-    }
+    gen_printf(" = ");
+
+    gen_printf("(");
+    gen_insert_list(from_shape_or_insert_list);
+    gen_printf(")");
   } else {
     // UPDATE table_name SET [update_list] FROM [query_parts]
-    gen_printf("\nSET ");
     gen_update_list(update_list);
   }
 

--- a/sources/rewrite.h
+++ b/sources/rewrite.h
@@ -59,4 +59,5 @@ cql_noexport void rewrite_op_equals_assignment_if_needed(ast_node *_Nonnull expr
 cql_noexport void rewrite_append_arg(ast_node *_Nonnull call, ast_node *_Nonnull arg);
 cql_noexport CSTR _Nonnull rewrite_type_suffix(sem_t sem_type);
 cql_noexport void rewrite_dot_as_call(ast_node *_Nonnull dot, CSTR _Nonnull new_name);
+cql_noexport ast_node *_Nonnull rewrite_column_values_as_update_list(ast_node *_Nonnull columns_values);
 #endif

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -16395,6 +16395,16 @@ static void sem_update_cursor_stmt(ast_node *ast) {
     return;
   }
 
+  sem_t sem_type = cursor->sem->sem_type;
+
+  // We can't do this if the cursor was not used with the auto syntax
+  if (!is_auto_cursor(sem_type)) {
+    report_error(cursor, "CQL0067: cursor was not used with 'fetch [cursor]'", name);
+    record_error(cursor);
+    record_error(ast);
+    return;
+  }
+
   // expr_names node is a sugar syntax we need to rewrite [USING ...] part to [FROM VALUES(...)]
   if (is_ast_expr_names(columns_values)) {
     rewrite_expr_names_to_columns_values(columns_values);
@@ -16420,16 +16430,6 @@ static void sem_update_cursor_stmt(ast_node *ast) {
 
   // if there are any FROM C(like shape) thing in the values list, expand them
   if (!rewrite_shape_forms_in_list_if_needed(insert_list)) {
-    record_error(ast);
-    return;
-  }
-
-  sem_t sem_type = cursor->sem->sem_type;
-
-  // We can't do this if the cursor was not used with the auto syntax
-  if (!is_auto_cursor(sem_type)) {
-    report_error(cursor, "CQL0067: cursor was not used with 'fetch [cursor]'", name);
-    record_error(cursor);
     record_error(ast);
     return;
   }

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1666,6 +1666,8 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0421: first argument must be a str
 test/sem_test.sql:XXXX:1: error: in table_or_subquery : CQL0095: table/view not defined 'table_does_not_exist'
 test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0497: FROM clause not supported when updating backed table 'simple_backed_table'
 test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
+test/sem_test.sql:XXXX:1: error: in dot : CQL0009: incompatible types in expression 'name'
+test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'cursor_not_exist'
 test/sem_test.sql:XXXX:1: error: in misc_attrs : CQL0499: alias_of attribute may only be added to a declare function or declare proc statement
 test/sem_test.sql:XXXX:1: error: in misc_attrs : CQL0500: alias_of attribute must be a non-empty string argument.
 test/sem_test.sql:XXXX:1: error: in type_object : CQL0091: object<T SET> has a T that is not a public procedure with a result set 'invalid_child_proc SET'

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1668,6 +1668,9 @@ test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0497: FROM clause not suppo
 test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
 test/sem_test.sql:XXXX:1: error: in dot : CQL0009: incompatible types in expression 'name'
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'cursor_not_exist'
+test/sem_test.sql:XXXX:1: error: in like : CQL0202: must be a cursor, proc, table, or view 'cursor_not_exist'
+test/sem_test.sql:XXXX:1: error: in columns_values : CQL0503: Cannot use an empty column list for an UPDATE statement
+test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0157: count of columns differs from count of values
 test/sem_test.sql:XXXX:1: error: in misc_attrs : CQL0499: alias_of attribute may only be added to a declare function or declare proc statement
 test/sem_test.sql:XXXX:1: error: in misc_attrs : CQL0500: alias_of attribute must be a non-empty string argument.
 test/sem_test.sql:XXXX:1: error: in type_object : CQL0091: object<T SET> has a T that is not a public procedure with a result set 'invalid_child_proc SET'

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -87076,6 +87076,183 @@ test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FRO
 
 The statement ending at line XXXX
 
+CREATE PROC test_update_from_shape (id_ INTEGER NOT NULL, name_ TEXT)
+BEGIN
+  UPDATE update_test_1
+    SET id = id_, name = name_
+    WHERE id = locals.id
+    ORDER BY update_test_1.id
+      LIMIT 1;
+  DECLARE C CURSOR LIKE update_test_1;
+  FETCH C(id, name) FROM VALUES(1, "foo");
+  UPDATE update_test_1
+    SET id = C.id, name = C.name
+    WHERE id = locals.id
+    ORDER BY update_test_1.id
+      LIMIT 1;
+END;
+
+  {create_proc_stmt}: ok dml_proc
+  | {name test_update_from_shape}: ok dml_proc
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: id_: integer notnull variable in
+    | | | {param_detail}: id_: integer notnull variable in
+    | |   | {name id_}: id_: integer notnull variable in
+    | |   | {notnull}: integer notnull
+    | |     | {type_int}: integer
+    | | {params}
+    |   | {param}: name_: text variable in
+    |     | {param_detail}: name_: text variable in
+    |       | {name name_}: name_: text variable in
+    |       | {type_text}: text
+    | {stmt_list}: ok
+      | {update_stmt}: ok
+      | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+      | | {update_set}
+      |   | {update_list}: ok
+      |   | | {update_entry}: id: integer notnull
+      |   | | | {name id}: id: integer notnull
+      |   | | | {dot}: id_: integer notnull variable in
+      |   | |   | {name ARGUMENTS}
+      |   | |   | {name id}
+      |   | | {update_list}
+      |   |   | {update_entry}: name: text
+      |   |     | {name name}: name: text
+      |   |     | {dot}: name_: text variable in
+      |   |       | {name ARGUMENTS}
+      |   |       | {name name}
+      |   | {update_from}
+      |     | {update_where}
+      |       | {opt_where}: bool notnull
+      |       | | {eq}: bool notnull
+      |       |   | {name id}: id: integer notnull
+      |       |   | {dot}: id_: integer notnull variable in
+      |       |     | {name locals}
+      |       |     | {name id}
+      |       | {update_orderby}
+      |         | {opt_orderby}: ok
+      |         | | {orderby_list}: ok
+      |         |   | {orderby_item}
+      |         |     | {dot}: id: integer notnull
+      |         |       | {name update_test_1}
+      |         |       | {name id}
+      |         | {opt_limit}: integer notnull
+      |           | {int 1}: integer notnull
+      | {declare_cursor_like_name}: C: update_test_1: { id: integer notnull primary_key, name: text } variable shape_storage value_cursor
+      | | {name C}: C: update_test_1: { id: integer notnull primary_key, name: text } variable shape_storage value_cursor
+      | | {shape_def}: update_test_1: { id: integer notnull primary_key, name: text }
+      |   | {like}: ok
+      |     | {name update_test_1}
+      | {fetch_values_stmt}: ok
+      | | {name_columns_values}
+      |   | {name C}: C: update_test_1: { id: integer notnull primary_key, name: text } variable shape_storage value_cursor
+      |   | {columns_values}: ok
+      |     | {column_spec}
+      |     | | {name_list}
+      |     |   | {name id}: id: integer notnull
+      |     |   | {name_list}
+      |     |     | {name name}: name: text
+      |     | {insert_list}: ok
+      |       | {int 1}: integer notnull
+      |       | {insert_list}
+      |         | {strlit 'foo'}: text notnull
+      | {update_stmt}: ok
+        | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+        | {update_set}
+          | {update_list}: ok
+          | | {update_entry}: id: integer notnull
+          | | | {name id}: id: integer notnull
+          | | | {dot}: C.id: integer notnull variable primary_key
+          | |   | {name C}
+          | |   | {name id}
+          | | {update_list}
+          |   | {update_entry}: name: text
+          |     | {name name}: name: text
+          |     | {dot}: C.name: text variable
+          |       | {name C}
+          |       | {name name}
+          | {update_from}
+            | {update_where}
+              | {opt_where}: bool notnull
+              | | {eq}: bool notnull
+              |   | {name id}: id: integer notnull
+              |   | {dot}: id_: integer notnull variable in
+              |     | {name locals}
+              |     | {name id}
+              | {update_orderby}
+                | {opt_orderby}: ok
+                | | {orderby_list}: ok
+                |   | {orderby_item}
+                |     | {dot}: id: integer notnull
+                |       | {name update_test_1}
+                |       | {name id}
+                | {opt_limit}: integer notnull
+                  | {int 1}: integer notnull
+
+The statement ending at line XXXX
+
+CREATE PROC test_update_from_shape_errors (id_ INTEGER NOT NULL, name_ TEXT)
+BEGIN
+  UPDATE update_test_1    (name, id) ARGUMENTS.id, ARGUMENTS.name;
+  UPDATE update_test_1    (id, name) FROM cursor_not_exist;
+END;
+
+test/sem_test.sql:XXXX:1: error: in dot : CQL0009: incompatible types in expression 'name'
+test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'cursor_not_exist'
+
+  {create_proc_stmt}: err
+  | {name test_update_from_shape_errors}: err
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: id_: integer notnull variable in
+    | | | {param_detail}: id_: integer notnull variable in
+    | |   | {name id_}: id_: integer notnull variable in
+    | |   | {notnull}: integer notnull
+    | |     | {type_int}: integer
+    | | {params}
+    |   | {param}: name_: text variable in
+    |     | {param_detail}: name_: text variable in
+    |       | {name name_}: name_: text variable in
+    |       | {type_text}: text
+    | {stmt_list}: err
+      | {update_stmt}: err
+      | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+      | | {update_set}
+      |   | {columns_values}: ok
+      |   | | {column_spec}
+      |   | | | {name_list}
+      |   | |   | {name name}: name: text
+      |   | |   | {name_list}
+      |   | |     | {name id}: id: integer notnull
+      |   | | {insert_list}: ok
+      |   |   | {dot}: err
+      |   |   | | {name ARGUMENTS}
+      |   |   | | {name id}
+      |   |   | {insert_list}
+      |   |     | {dot}
+      |   |       | {name ARGUMENTS}
+      |   |       | {name name}
+      |   | {update_from}
+      |     | {update_where}
+      |       | {update_orderby}
+      | {update_stmt}: err
+        | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+        | {update_set}
+          | {columns_values}: ok
+          | | {column_spec}
+          | | | {name_list}
+          | |   | {name id}
+          | |   | {name_list}
+          | |     | {name name}
+          | | {from_shape}
+          |   | {name cursor_not_exist}: err
+          | {update_from}
+            | {update_where}
+              | {update_orderby}
+
+The statement ending at line XXXX
+
 @ATTRIBUTE(cql:alias_of=some_native_func)
 DECLARE FUNC an_alias_func (x INTEGER NOT NULL) INTEGER NOT NULL;
 

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -46490,21 +46490,21 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fet
 
   {update_cursor_stmt}: err
   | {name my_cursor}: err
-  | {columns_values}: ok
+  | {columns_values}
     | {column_spec}
     | | {name_list}
     |   | {name one}
-    | {insert_list}: ok
+    | {insert_list}
       | {int 2}
 
 The statement ending at line XXXX
 
-UPDATE CURSOR my_cursor(LIKE not_a_symbol) FROM VALUES(1);
+UPDATE CURSOR small_cursor(LIKE not_a_symbol) FROM VALUES(1);
 
 test/sem_test.sql:XXXX:1: error: in like : CQL0202: must be a cursor, proc, table, or view 'not_a_symbol'
 
   {update_cursor_stmt}: err
-  | {name my_cursor}: my_cursor: select: { one: integer notnull, two: integer notnull } variable dml_proc fetch_into
+  | {name small_cursor}: small_cursor: select: { x: integer notnull } variable shape_storage value_cursor
   | {columns_values}: err
     | {column_spec}
     | | {shape_def}: err

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -46490,11 +46490,11 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fet
 
   {update_cursor_stmt}: err
   | {name my_cursor}: err
-  | {columns_values}
+  | {columns_values}: ok
     | {column_spec}
     | | {name_list}
     |   | {name one}
-    | {insert_list}
+    | {insert_list}: ok
       | {int 2}
 
 The statement ending at line XXXX
@@ -87076,6 +87076,13 @@ test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FRO
 
 The statement ending at line XXXX
 
+@ENFORCE_NORMAL UPDATE FROM;
+
+  {enforce_normal_stmt}: ok
+  | {int 22}
+
+The statement ending at line XXXX
+
 CREATE PROC test_update_from_shape (id_ INTEGER NOT NULL, name_ TEXT)
 BEGIN
   UPDATE update_test_1
@@ -87107,7 +87114,7 @@ END;
     |       | {name name_}: name_: text variable in
     |       | {type_text}: text
     | {stmt_list}: ok
-      | {update_stmt}: ok
+      | {update_stmt}: update_test_1: { id: integer notnull primary_key, name: text }
       | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
       | | {update_set}
       |   | {update_list}: ok
@@ -87157,7 +87164,7 @@ END;
       |       | {int 1}: integer notnull
       |       | {insert_list}
       |         | {strlit 'foo'}: text notnull
-      | {update_stmt}: ok
+      | {update_stmt}: update_test_1: { id: integer notnull primary_key, name: text }
         | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
         | {update_set}
           | {update_list}: ok
@@ -87192,14 +87199,361 @@ END;
 
 The statement ending at line XXXX
 
+CREATE TABLE update_stmt_table(
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  a TEXT,
+  b TEXT,
+  c TEXT,
+  x INTEGER,
+  y INTEGER,
+  z INTEGER
+);
+
+  {create_table_stmt}: update_stmt_table: { id: integer notnull primary_key, name: text, a: text, b: text, c: text, x: integer, y: integer, z: integer }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name update_stmt_table}
+  | {col_key_list}
+    | {col_def}: id: integer notnull primary_key
+    | | {col_def_type_attrs}: ok
+    |   | {col_def_name_type}
+    |   | | {name id}
+    |   | | {type_int}: integer
+    |   | {col_attrs_pk}: ok
+    |     | {autoinc_and_conflict_clause}
+    | {col_key_list}
+      | {col_def}: name: text
+      | | {col_def_type_attrs}: ok
+      |   | {col_def_name_type}
+      |     | {name name}
+      |     | {type_text}: text
+      | {col_key_list}
+        | {col_def}: a: text
+        | | {col_def_type_attrs}: ok
+        |   | {col_def_name_type}
+        |     | {name a}
+        |     | {type_text}: text
+        | {col_key_list}
+          | {col_def}: b: text
+          | | {col_def_type_attrs}: ok
+          |   | {col_def_name_type}
+          |     | {name b}
+          |     | {type_text}: text
+          | {col_key_list}
+            | {col_def}: c: text
+            | | {col_def_type_attrs}: ok
+            |   | {col_def_name_type}
+            |     | {name c}
+            |     | {type_text}: text
+            | {col_key_list}
+              | {col_def}: x: integer
+              | | {col_def_type_attrs}: ok
+              |   | {col_def_name_type}
+              |     | {name x}
+              |     | {type_int}: integer
+              | {col_key_list}
+                | {col_def}: y: integer
+                | | {col_def_type_attrs}: ok
+                |   | {col_def_name_type}
+                |     | {name y}
+                |     | {type_int}: integer
+                | {col_key_list}
+                  | {col_def}: z: integer
+                    | {col_def_type_attrs}: ok
+                      | {col_def_name_type}
+                        | {name z}
+                        | {type_int}: integer
+
+The statement ending at line XXXX
+
+CREATE PROC test_update_from_insert_list (id_ INTEGER NOT NULL, name_ TEXT)
+BEGIN
+  DECLARE cur CURSOR LIKE update_stmt_table(a, b, c);
+  FETCH cur(a, b, c) FROM VALUES("a", "b", "c");
+  UPDATE update_stmt_table
+    SET name = locals.name, a = cur.a, b = cur.b, c = cur.c, x = 1, y = 2, z = 3
+    WHERE id = locals.id
+    ORDER BY update_stmt_table.id
+      LIMIT 1;
+END;
+
+  {create_proc_stmt}: ok dml_proc
+  | {name test_update_from_insert_list}: ok dml_proc
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: id_: integer notnull variable in
+    | | | {param_detail}: id_: integer notnull variable in
+    | |   | {name id_}: id_: integer notnull variable in
+    | |   | {notnull}: integer notnull
+    | |     | {type_int}: integer
+    | | {params}
+    |   | {param}: name_: text variable in
+    |     | {param_detail}: name_: text variable in
+    |       | {name name_}: name_: text variable in
+    |       | {type_text}: text
+    | {stmt_list}: ok
+      | {declare_cursor_like_name}: cur: select: { a: text, b: text, c: text } variable shape_storage value_cursor
+      | | {name cur}: cur: select: { a: text, b: text, c: text } variable shape_storage value_cursor
+      | | {shape_def}: select: { a: text, b: text, c: text }
+      |   | {like}: ok
+      |   | | {name update_stmt_table}
+      |   | {shape_exprs}
+      |     | {shape_expr}
+      |     | | {name a}
+      |     | | {name a}
+      |     | {shape_exprs}
+      |       | {shape_expr}
+      |       | | {name b}
+      |       | | {name b}
+      |       | {shape_exprs}
+      |         | {shape_expr}
+      |           | {name c}
+      |           | {name c}
+      | {fetch_values_stmt}: ok
+      | | {name_columns_values}
+      |   | {name cur}: cur: select: { a: text, b: text, c: text } variable shape_storage value_cursor
+      |   | {columns_values}: ok
+      |     | {column_spec}
+      |     | | {name_list}
+      |     |   | {name a}: a: text
+      |     |   | {name_list}
+      |     |     | {name b}: b: text
+      |     |     | {name_list}
+      |     |       | {name c}: c: text
+      |     | {insert_list}: ok
+      |       | {strlit 'a'}: text notnull
+      |       | {insert_list}
+      |         | {strlit 'b'}: text notnull
+      |         | {insert_list}
+      |           | {strlit 'c'}: text notnull
+      | {update_stmt}: update_stmt_table: { id: integer notnull primary_key, name: text, a: text, b: text, c: text, x: integer, y: integer, z: integer }
+        | {name update_stmt_table}: update_stmt_table: { id: integer notnull primary_key, name: text, a: text, b: text, c: text, x: integer, y: integer, z: integer }
+        | {update_set}
+          | {update_list}: ok
+          | | {update_entry}: name: text
+          | | | {name name}: name: text
+          | | | {dot}: name_: text variable in
+          | |   | {name locals}
+          | |   | {name name}
+          | | {update_list}
+          |   | {update_entry}: a: text
+          |   | | {name a}: a: text
+          |   | | {dot}: cur.a: text variable
+          |   |   | {name cur}
+          |   |   | {name a}
+          |   | {update_list}
+          |     | {update_entry}: b: text
+          |     | | {name b}: b: text
+          |     | | {dot}: cur.b: text variable
+          |     |   | {name cur}
+          |     |   | {name b}
+          |     | {update_list}
+          |       | {update_entry}: c: text
+          |       | | {name c}: c: text
+          |       | | {dot}: cur.c: text variable
+          |       |   | {name cur}
+          |       |   | {name c}
+          |       | {update_list}
+          |         | {update_entry}: x: integer
+          |         | | {name x}: x: integer
+          |         | | {int 1}: integer notnull
+          |         | {update_list}
+          |           | {update_entry}: y: integer
+          |           | | {name y}: y: integer
+          |           | | {int 2}: integer notnull
+          |           | {update_list}
+          |             | {update_entry}: z: integer
+          |               | {name z}: z: integer
+          |               | {int 3}: integer notnull
+          | {update_from}
+            | {update_where}
+              | {opt_where}: bool notnull
+              | | {eq}: bool notnull
+              |   | {name id}: id: integer notnull
+              |   | {dot}: id_: integer notnull variable in
+              |     | {name locals}
+              |     | {name id}
+              | {update_orderby}
+                | {opt_orderby}: ok
+                | | {orderby_list}: ok
+                |   | {orderby_item}
+                |     | {dot}: id: integer notnull
+                |       | {name update_stmt_table}
+                |       | {name id}
+                | {opt_limit}: integer notnull
+                  | {int 1}: integer notnull
+
+The statement ending at line XXXX
+
+CREATE TABLE aux_table(
+  id INTEGER PRIMARY KEY,
+  x INTEGER,
+  y INTEGER,
+  z INTEGER
+);
+
+  {create_table_stmt}: aux_table: { id: integer notnull primary_key, x: integer, y: integer, z: integer }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name aux_table}
+  | {col_key_list}
+    | {col_def}: id: integer notnull primary_key
+    | | {col_def_type_attrs}: ok
+    |   | {col_def_name_type}
+    |   | | {name id}
+    |   | | {type_int}: integer
+    |   | {col_attrs_pk}: ok
+    |     | {autoinc_and_conflict_clause}
+    | {col_key_list}
+      | {col_def}: x: integer
+      | | {col_def_type_attrs}: ok
+      |   | {col_def_name_type}
+      |     | {name x}
+      |     | {type_int}: integer
+      | {col_key_list}
+        | {col_def}: y: integer
+        | | {col_def_type_attrs}: ok
+        |   | {col_def_name_type}
+        |     | {name y}
+        |     | {type_int}: integer
+        | {col_key_list}
+          | {col_def}: z: integer
+            | {col_def_type_attrs}: ok
+              | {col_def_name_type}
+                | {name z}
+                | {type_int}: integer
+
+The statement ending at line XXXX
+
+CREATE PROC test_update_with_shape_and_from_clause (id INTEGER, updates_name TEXT, updates_a TEXT, updates_b TEXT, updates_c TEXT)
+BEGIN
+  UPDATE update_stmt_table
+    SET name = updates.name, a = updates.a, b = updates.b, c = updates.c, x = aux_table.x, y = aux_table.y, z = aux_table.z
+    FROM aux_table
+    WHERE aux_table.id = update_stmt_table.id AND update_stmt_table.id = locals.id;
+END;
+
+  {create_proc_stmt}: ok dml_proc
+  | {name test_update_with_shape_and_from_clause}: ok dml_proc
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: id: integer variable in
+    | | | {param_detail}: id: integer variable in
+    | |   | {name id}: id: integer variable in
+    | |   | {type_int}: integer
+    | | {params}
+    |   | {param}: updates_name: text variable in
+    |   | | {param_detail}: updates_name: text variable in
+    |   |   | {name updates_name}: updates_name: text variable in
+    |   |   | {type_text}: text
+    |   | {params}
+    |     | {param}: updates_a: text variable in
+    |     | | {param_detail}: updates_a: text variable in
+    |     |   | {name updates_a}: updates_a: text variable in
+    |     |   | {type_text}: text
+    |     | {params}
+    |       | {param}: updates_b: text variable in
+    |       | | {param_detail}: updates_b: text variable in
+    |       |   | {name updates_b}: updates_b: text variable in
+    |       |   | {type_text}: text
+    |       | {params}
+    |         | {param}: updates_c: text variable in
+    |           | {param_detail}: updates_c: text variable in
+    |             | {name updates_c}: updates_c: text variable in
+    |             | {type_text}: text
+    | {stmt_list}: ok
+      | {update_stmt}: update_stmt_table: { id: integer notnull primary_key, name: text, a: text, b: text, c: text, x: integer, y: integer, z: integer }
+        | {name update_stmt_table}: update_stmt_table: { id: integer notnull primary_key, name: text, a: text, b: text, c: text, x: integer, y: integer, z: integer }
+        | {update_set}
+          | {update_list}: ok
+          | | {update_entry}: name: text
+          | | | {name name}: name: text
+          | | | {dot}: updates_name: text variable in
+          | |   | {name updates}
+          | |   | {name name}
+          | | {update_list}
+          |   | {update_entry}: a: text
+          |   | | {name a}: a: text
+          |   | | {dot}: updates_a: text variable in
+          |   |   | {name updates}
+          |   |   | {name a}
+          |   | {update_list}
+          |     | {update_entry}: b: text
+          |     | | {name b}: b: text
+          |     | | {dot}: updates_b: text variable in
+          |     |   | {name updates}
+          |     |   | {name b}
+          |     | {update_list}
+          |       | {update_entry}: c: text
+          |       | | {name c}: c: text
+          |       | | {dot}: updates_c: text variable in
+          |       |   | {name updates}
+          |       |   | {name c}
+          |       | {update_list}
+          |         | {update_entry}: x: integer
+          |         | | {name x}: x: integer
+          |         | | {dot}: x: integer
+          |         |   | {name aux_table}
+          |         |   | {name x}
+          |         | {update_list}
+          |           | {update_entry}: y: integer
+          |           | | {name y}: y: integer
+          |           | | {dot}: y: integer
+          |           |   | {name aux_table}
+          |           |   | {name y}
+          |           | {update_list}
+          |             | {update_entry}: z: integer
+          |               | {name z}: z: integer
+          |               | {dot}: z: integer
+          |                 | {name aux_table}
+          |                 | {name z}
+          | {update_from}
+            | {table_or_subquery_list}: TABLE { aux_table: aux_table }
+            | | {table_or_subquery}: TABLE { aux_table: aux_table }
+            |   | {name aux_table}: TABLE { aux_table: aux_table }
+            | {update_where}
+              | {opt_where}: bool
+              | | {and}: bool
+              |   | {eq}: bool notnull
+              |   | | {dot}: id: integer notnull
+              |   | | | {name aux_table}
+              |   | | | {name id}
+              |   | | {dot}: id: integer notnull
+              |   |   | {name update_stmt_table}
+              |   |   | {name id}
+              |   | {eq}: bool
+              |     | {dot}: id: integer notnull
+              |     | | {name update_stmt_table}
+              |     | | {name id}
+              |     | {dot}: id: integer variable in
+              |       | {name locals}
+              |       | {name id}
+              | {update_orderby}
+
+The statement ending at line XXXX
+
 CREATE PROC test_update_from_shape_errors (id_ INTEGER NOT NULL, name_ TEXT)
 BEGIN
-  UPDATE update_test_1    (name, id) ARGUMENTS.id, ARGUMENTS.name;
-  UPDATE update_test_1    (id, name) FROM cursor_not_exist;
+  UPDATE update_test_1
+    SET name = ARGUMENTS.id, id = ARGUMENTS.name;
+  UPDATE update_test_1
+    SET (id, name) = (FROM cursor_not_exist);
+  UPDATE update_test_1
+    SET (LIKE cursor_not_exist) = (FROM ARGUMENTS);
+  UPDATE update_test_1
+    SET () = (FROM ARGUMENTS);
+  UPDATE update_test_1
+    SET id = id_;
 END;
 
 test/sem_test.sql:XXXX:1: error: in dot : CQL0009: incompatible types in expression 'name'
 test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'cursor_not_exist'
+test/sem_test.sql:XXXX:1: error: in like : CQL0202: must be a cursor, proc, table, or view 'cursor_not_exist'
+test/sem_test.sql:XXXX:1: error: in columns_values : CQL0503: Cannot use an empty column list for an UPDATE statement
+test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0157: count of columns differs from count of values
 
   {create_proc_stmt}: err
   | {name test_update_from_shape_errors}: err
@@ -87219,17 +87573,15 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'cursor_not_ex
       | {update_stmt}: err
       | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
       | | {update_set}
-      |   | {columns_values}: ok
-      |   | | {column_spec}
-      |   | | | {name_list}
-      |   | |   | {name name}: name: text
-      |   | |   | {name_list}
-      |   | |     | {name id}: id: integer notnull
-      |   | | {insert_list}: ok
-      |   |   | {dot}: err
-      |   |   | | {name ARGUMENTS}
-      |   |   | | {name id}
-      |   |   | {insert_list}
+      |   | {update_list}: err
+      |   | | {update_entry}: err
+      |   | | | {name name}: name: text
+      |   | | | {dot}: err
+      |   | |   | {name ARGUMENTS}
+      |   | |   | {name id}
+      |   | | {update_list}
+      |   |   | {update_entry}
+      |   |     | {name id}
       |   |     | {dot}
       |   |       | {name ARGUMENTS}
       |   |       | {name name}
@@ -87237,16 +87589,54 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'cursor_not_ex
       |     | {update_where}
       |       | {update_orderby}
       | {update_stmt}: err
+      | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+      | | {update_set}
+      |   | {columns_values}: ok
+      |   | | {column_spec}
+      |   | | | {name_list}
+      |   | |   | {name id}
+      |   | |   | {name_list}
+      |   | |     | {name name}
+      |   | | {insert_list}: err
+      |   |   | {from_shape}
+      |   |     | {name cursor_not_exist}: err
+      |   | {update_from}
+      |     | {update_where}
+      |       | {update_orderby}
+      | {update_stmt}: err
+      | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+      | | {update_set}
+      |   | {columns_values}: err
+      |   | | {column_spec}
+      |   | | | {shape_def}: err
+      |   | |   | {like}: err
+      |   | |     | {name cursor_not_exist}: err
+      |   | | {insert_list}
+      |   |   | {from_shape}
+      |   |     | {name ARGUMENTS}
+      |   | {update_from}
+      |     | {update_where}
+      |       | {update_orderby}
+      | {update_stmt}: err
+      | | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
+      | | {update_set}
+      |   | {columns_values}
+      |   | | {column_spec}
+      |   | | {insert_list}
+      |   |   | {from_shape}
+      |   |     | {name ARGUMENTS}
+      |   | {update_from}
+      |     | {update_where}
+      |       | {update_orderby}
+      | {update_stmt}: update_test_1: { id: integer notnull primary_key, name: text }
         | {name update_test_1}: update_test_1: { id: integer notnull primary_key, name: text }
         | {update_set}
-          | {columns_values}: ok
-          | | {column_spec}
-          | | | {name_list}
-          | |   | {name id}
-          | |   | {name_list}
-          | |     | {name name}
-          | | {from_shape}
-          |   | {name cursor_not_exist}: err
+          | {update_list}: ok
+          | | {update_entry}: id: integer notnull
+          |   | {name id}: id: integer notnull
+          |   | {dot}: id_: integer notnull variable in
+          |     | {name ARGUMENTS}
+          |     | {name id}
           | {update_from}
             | {update_where}
               | {update_orderby}

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -23152,6 +23152,8 @@ update simple_backed_table set id = 5 from update_test_1;
 -- +1 error:
 UPDATE update_from_target SET name = update_test_2.name FROM update_test_1;
 
+@ENFORCE_NORMAL UPDATE FROM;
+
 -- TEST: update with from shape sugar
 -- Validate first update statement codegen
 -- + {update_set}
@@ -23185,8 +23187,8 @@ UPDATE update_from_target SET name = update_test_2.name FROM update_test_1;
 proc test_update_from_shape(like update_test_1)
 begin
   -- Update statement from arguments
-  update update_test_1(like update_test_1)
-  from arguments
+  update update_test_1
+  set (like update_test_1) = (from arguments)
   where id = locals.id
   order by update_test_1.id
   limit 1;
@@ -23194,30 +23196,163 @@ begin
   -- Update statement from a cursor
   declare C cursor like update_test_1;
   fetch C from values(1, "foo");
-  update update_test_1(like update_test_1)
-  from C
+  update update_test_1
+  set (like update_test_1) = (from C)
   where id = locals.id
   order by update_test_1.id
   limit 1;
 end;
 
+-- Test table for next test.
+create table update_stmt_table(
+  id integer primary key,
+  name text,
+  a text,
+  b text,
+  c text,
+  x integer,
+  y integer,
+  z integer
+);
+
+-- TEST: update from an insert list
+-- + {update_list}: ok
+-- + {update_entry}: name: text
+-- + {name name}: name: text
+-- + {dot}: name_: text variable in
+-- + {name locals}
+-- + {name name}
+-- + {update_list}
+-- + {update_entry}: a: text
+-- + {name a}: a: text
+-- + {dot}: cur.a: text variable
+-- + {name cur}
+-- + {name a}
+-- + {update_list}
+-- + {update_entry}: b: text
+-- + {name b}: b: text
+-- + {dot}: cur.b: text variable
+-- + {name cur}
+-- + {name b}
+-- + {update_list}
+-- + {update_entry}: c: text
+-- + {name c}: c: text
+-- + {dot}: cur.c: text variable
+-- + {name cur}
+-- + {name c}
+-- + {update_list}
+-- + {update_entry}: x: integer
+-- + {name x}: x: integer
+-- + {int 1}: integer notnull
+-- + {update_list}
+-- + {update_entry}: y: integer
+-- + {name y}: y: integer
+-- + {int 2}: integer notnull
+-- + {update_list}
+-- + {update_entry}: z: integer
+-- + {name z}: z: integer
+-- + {int 3}: integer notnull
+-- - error:
+proc test_update_from_insert_list(like update_stmt_table(id, name))
+begin
+  declare cur cursor like update_stmt_table(a, b, c);
+  fetch cur from values("a", "b", "c");
+  
+  update update_stmt_table
+  set (like update_stmt_table(-id)) = (locals.name, from cur, 1, 2, 3)
+  where id = locals.id
+  order by update_stmt_table.id
+  limit 1;
+end;
+
+-- Test table for next test.
+create table aux_table(
+  id integer primary key,
+  x integer,
+  y integer,
+  z integer
+);
+
+-- TEST: Update with a shape and a FROM clause
+-- + {update_list}: ok
+-- + {update_entry}: name: text
+-- + {name name}: name: text
+-- + {dot}: updates_name: text variable in
+-- + {name updates}
+-- + {name name}
+-- + {update_list}
+-- + {update_entry}: a: text
+-- + {name a}: a: text
+-- + {dot}: updates_a: text variable in
+-- + {name updates}
+-- + {name a}
+-- + {update_list}
+-- + {update_entry}: b: text
+-- + {name b}: b: text
+-- + {dot}: updates_b: text variable in
+-- + {name updates}
+-- + {name b}
+-- + {update_list}
+-- + {update_entry}: c: text
+-- + {name c}: c: text
+-- + {dot}: updates_c: text variable in
+-- + {name updates}
+-- + {name c}
+-- + {update_list}
+-- + {update_entry}: x: integer
+-- + {name x}: x: integer
+-- + {dot}: x: integer
+-- + {name aux_table}
+-- + {name x}
+-- + {update_list}
+-- + {update_entry}: y: integer
+-- + {name y}: y: integer
+-- + {dot}: y: integer
+-- + {name aux_table}
+-- + {name y}
+-- + {update_list}
+-- + {update_entry}: z: integer
+-- + {name z}: z: integer
+-- + {dot}: z: integer
+-- + {name aux_table}
+-- + {name z}
+-- - error:
+proc test_update_with_shape_and_from_clause(id integer, updates like update_stmt_table(name, a, b, c))
+begin
+  update update_stmt_table
+  set (like update_stmt_table(-id)) = (from updates, aux_table.x, aux_table.y, aux_table.z)
+  from aux_table
+  where aux_table.id = update_stmt_table.id and update_stmt_table.id = locals.id;
+end;
+
 -- TEST: update from_shape sugar error handling
 -- + error: % incompatible types in expression 'name'
 -- + error: % name not found 'cursor_not_exist'
+-- + error: % must be a cursor, proc, table, or view 'cursor_not_exist'
+-- + error: % Cannot use an empty column list for an UPDATE statement
+-- + error: % count of columns differs from count of values
 -- + {dot}: err
 -- + {name ARGUMENTS}
 -- + {name id}
 -- + {name cursor_not_exist}: err
--- +2 error:
+-- +5 error:
 proc test_update_from_shape_errors(like update_test_1)
 begin
   -- Swapped ordering of columns lead to incompatible types.
-  update update_test_1(name, id)
-  from arguments;
-
-  -- Use of non existent shape
   update update_test_1
-  from cursor_not_exist;
+  set (name, id) = (from arguments);
+
+  -- Use of non existent shape in values
+  update update_test_1 set (id, name) = (from cursor_not_exist);
+
+  -- Use of non existent shape in column spec
+  update update_test_1 set (like cursor_not_exist) = (from arguments);
+
+  -- Empty column list is not allowed
+  update update_test_1 set () = (from arguments);
+
+  -- Count of columns differ from count of values
+  update update_test_1 set (id) = (from arguments);
 end;
 
 -- TEST: cql:alias_of attribution on declare_func_stmt

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -12481,7 +12481,7 @@ update cursor my_cursor(one) from values (2);
 -- TEST -- like statement can't be resolved in an update statement
 -- * error: % must be a cursor, proc, table, or view 'not_a_symbol'
 -- +1 error:
-update cursor my_cursor(like not_a_symbol) from values(1);
+update cursor small_cursor(like not_a_symbol) from values(1);
 
 -- TEST -- not a cursor
 -- + {update_cursor_stmt}: err

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -2337,7 +2337,9 @@ DECLARE @ID("foo") @ID("int");
 
 CONST a_const_variable := 1;
 
-UPDATE some_table  (LIKE bar) FROM ARGUMENTS(LIKE bar)
-  WHERE id = locals.id
+UPDATE some_table
+  SET (LIKE some_table(-id)) = (FROM ARGUMENTS LIKE bar, baz.one, baz.two, baz.three)
+  FROM baz
+  WHERE some_table.id = locals.id AND some_table.id = baz.id
   ORDER BY some_table.id
     LIMIT 1;

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -2336,3 +2336,8 @@ DECLARE @ID("foo") @ID("int");
 @ENFORCE_STRICT AND OR NOT NULL CHECK;
 
 CONST a_const_variable := 1;
+
+UPDATE some_table  (LIKE bar) FROM ARGUMENTS(LIKE bar)
+  WHERE id = locals.id
+  ORDER BY some_table.id
+    LIMIT 1;

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1793,8 +1793,9 @@ declare @id("foo") @id("int");
 
 const a_const_variable := 1;
 
-update some_table(like bar)
-from arguments (like bar)
-where id = locals.id
+update some_table
+set (like some_table(-id)) = (from arguments like bar, baz.one, baz.two, baz.three)
+from baz
+where some_table.id = locals.id and some_table.id = baz.id
 order by some_table.id
 limit 1;

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1792,3 +1792,9 @@ declare @id("foo") @id("int");
 @enforce_strict and or not null check;
 
 const a_const_variable := 1;
+
+update some_table(like bar)
+from arguments (like bar)
+where id = locals.id
+order by some_table.id
+limit 1;

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -2355,7 +2355,9 @@ DECLARE foo int;
 
 CONST a_const_variable := 1;
 
-UPDATE some_table  (LIKE bar) FROM ARGUMENTS(LIKE bar)
-  WHERE id = locals.id
+UPDATE some_table
+  SET (LIKE some_table(-id)) = (FROM ARGUMENTS LIKE bar, baz.one, baz.two, baz.three)
+  FROM baz
+  WHERE some_table.id = locals.id AND some_table.id = baz.id
   ORDER BY some_table.id
     LIMIT 1;

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -2354,3 +2354,8 @@ DECLARE foo int;
 @ENFORCE_STRICT AND OR NOT NULL CHECK;
 
 CONST a_const_variable := 1;
+
+UPDATE some_table  (LIKE bar) FROM ARGUMENTS(LIKE bar)
+  WHERE id = locals.id
+  ORDER BY some_table.id
+    LIMIT 1;


### PR DESCRIPTION
Allow this sugar in update statements (same way as it exists in insert and update cursor statements):
```
update my_table(like some_shape) from arguments;
```
This gets rewritten into a SET update_list behind the scenes. Note that the ordering of `columns_spec` needs to match the shape of the `insert_list` (so `like some_shape` and `arguments` in the above example need to have matching elements in order).