### PR TITLE
remove all uses of begin try end try begin catch end catch

### DIFF
--- a/docs/developer_guide/03_c_code_generation.md
+++ b/docs/developer_guide/03_c_code_generation.md
@@ -1045,13 +1045,12 @@ Let's generalize this example a tiny bit:
 CREATE PROC p (OUT success BOOL NOT NULL)
 BEGIN
   LET arg := "test";
-  BEGIN TRY
+  TRY
     CALL something_that_might_fail(arg);
     SET success := 1;
-  END TRY;
-  BEGIN CATCH
+  CATCH
     SET success := 0;
-  END CATCH;
+  END;
 END;
 ```
 

--- a/docs/developer_guide/06_schema_management.md
+++ b/docs/developer_guide/06_schema_management.md
@@ -383,17 +383,16 @@ so we'll include this one in full.
   bprintf(&preamble, "@attribute(cql:private)\n");
   bprintf(&preamble, "CREATE PROCEDURE %s_setup_facets()\n", global_proc_name);
   bprintf(&preamble, "BEGIN\n");
-  bprintf(&preamble, "  BEGIN TRY\n");
+  bprintf(&preamble, "  TRY\n");
   bprintf(&preamble, "    SET %s_facets := cql_facets_new();\n", global_proc_name);
   bprintf(&preamble, "    DECLARE C CURSOR FOR SELECT * from %s_cql_schema_facets;\n", global_proc_name);
   bprintf(&preamble, "    LOOP FETCH C\n");
   bprintf(&preamble, "    BEGIN\n");
   bprintf(&preamble, "      LET added := cql_facet_add(%s_facets, C.facet, C.version);\n", global_proc_name);
   bprintf(&preamble, "    END;\n");
-  bprintf(&preamble, "  END TRY;\n");
-  bprintf(&preamble, "  BEGIN CATCH\n");
+  bprintf(&preamble, "  CATCH\n");
   bprintf(&preamble, "   -- if table doesn't exist we just have empty facets, that's ok\n");
-  bprintf(&preamble, "  END CATCH;\n");
+  bprintf(&preamble, "  END;\n");
   bprintf(&preamble, "END;\n\n");
 ```
 

--- a/docs/user_guide/04_procedures_functions_control_flow.md
+++ b/docs/user_guide/04_procedures_functions_control_flow.md
@@ -274,37 +274,35 @@ declare procedure printf no check;
 
 create procedure upsert_foo(id_ integer, t_ text)
 begin
-  begin try
+  try
     insert into foo(id, t) values(id_, t_)
-  end try;
-  begin catch
-    begin try
-      update foo set t = t_ where id = id_;
-    end try;
-    begin catch
+  catch
+    try
+      update foo set t = t_ where id = id_;   
+    catch
       call printf("Error code %d!\n", @rc);
       throw;
-    end catch;
-  end catch;
+    end;
+  end;
 end;
 ```
 
 Once again, let's go over this section by section:
 
 ```sql
-  begin try
+  try
     insert into foo(id, t) values(id_, t_)
-  end try;
+  catch
 ```
 
 Normally if the `insert` statement fails, the procedure will exit with a failure result code.  Here, instead,
 we prepare to catch that error.
 
 ```sql
-  begin catch
-    begin try
+  catch
+    try
       update foo set t = t_ where id = id_;
-    end try;
+    catch
 ```
 
 Now, having failed to insert, presumably because a row with the provided
@@ -313,10 +311,10 @@ might also fail, so we  wrap it in another try.  If the update fails,
 then there is a final catch block:
 
 ```sql
-    begin catch
+    catch
       call printf("Error code %d!\n", @rc);
       throw;
-    end catch;
+    end;
 ```
 
 Here we see a usage of the `@rc` variable to observe the failed error
@@ -331,7 +329,7 @@ statement will become the result code of the current procedure.
 This leaves only the closing markers:
 
 ```sql
-  end catch;
+  end;
 end;
 ```
 

--- a/docs/user_guide/09_statements_summary_and_error_checking.md
+++ b/docs/user_guide/09_statements_summary_and_error_checking.md
@@ -375,15 +375,14 @@ becomes:
 create procedure foo()
 begin
   savepoint @proc;  -- @proc is always the name of the current procedure
-  begin try
+  try
     -- your code
     release savepoint @proc;
-  end try;
-  begin catch
+  catch
     rollback transaction to savepoint @proc;
     release savepoint @proc;
     throw;
-  end catch;
+  end;
 end;
 ```
 

--- a/docs/user_guide/10_schema_management.md
+++ b/docs/user_guide/10_schema_management.md
@@ -434,13 +434,12 @@ END;
 CREATE PROCEDURE test_cql_get_facet_version(_facet TEXT NOT NULL,
                                             out _version LONG INTEGER NOT NULL)
 BEGIN
-  BEGIN TRY
+  TRY
     SET _version := (SELECT version FROM test_cql_schema_facets
                        WHERE facet = _facet LIMIT 1 IF NOTHING -1);
-  END TRY;
-  BEGIN CATCH
+  CATCH
     SET _version := -1;
-  END CATCH;
+  END;
 END;
 ```
 The two procedures `cql_get_facet_version` and `cql_set_facet_version`
@@ -628,17 +627,16 @@ code above.
 ```sql
 CREATE PROCEDURE test_setup_facets()
 BEGIN
-  BEGIN TRY
+  TRY
     SET test_facets := cql_facets_new();
     DECLARE C CURSOR FOR SELECT * from test_cql_schema_facets;
     LOOP FETCH C
     BEGIN
       LET added := cql_facet_add(test_facets, C.facet, C.version);
     END;
-  END TRY;
-  BEGIN CATCH
-   -- if table doesn't exist we just have empty facets, that's ok
-  END CATCH;
+  CATCH
+    -- if table doesn't exist we just have empty facets, that's ok
+  END;
 END;
 ```
 
@@ -874,15 +872,14 @@ BEGIN
   CALL test_cql_get_facet_version('cql_schema_crc', schema_crc);
 
   IF schema_crc <> -7714030317354747478 THEN
-    BEGIN TRY
+    TRY
       CALL test_setup_facets();
       CALL test_perform_needed_upgrades();
-    END TRY;
-    BEGIN CATCH
+    CATCH
       CALL cql_facets_delete(test_facets);
       SET test_facets := 0;
       THROW;
-    END CATCH;
+    END;
     CALL cql_facets_delete(test_facets);
     SET test_facets := 0;
   ELSE

--- a/docs/user_guide/18_pre_processing.md
+++ b/docs/user_guide/18_pre_processing.md
@@ -370,13 +370,12 @@ end;
 begin
   create procedure @ID("test_", name!)()
   begin
-    begin try
+    try
       body!;
-    end try;
-    begin catch
+    catch
       call printf("Test failed %s\n", @TEXT(name!));
       throw;
-    end catch;
+    end;
   end;
 end;
 
@@ -389,15 +388,14 @@ END);
 
 CREATE PROC test_try_something ()
 BEGIN
-  BEGIN TRY
+  TRY
     IF NOT 1 = 1 THEN
       THROW;
     END IF;
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("Test failed %s\n", "try_something");
     THROW;
-  END CATCH;
+  END;
 END;
 ```
 

--- a/docs/user_guide/appendices/06_cql_in_20_minutes.md
+++ b/docs/user_guide/appendices/06_cql_in_20_minutes.md
@@ -499,14 +499,13 @@ create proc upsert_t1(
   r_ real
 )
 begin
-  begin try
+  try
     -- try to insert
     insert into T1(id, t, r) values (id_, t_, r_);
-  end try;
-  begin catch
+  catch
     -- if the insert fails, try to update
     update T1 set t = t_, r = r_ where id = id_;
-  end catch;
+  end;
 end;
 
 -- Shapes can be very useful in avoiding boilerplate code
@@ -514,12 +513,11 @@ end;
 -- More on shapes later.
 create proc upsert_t1(LIKE t1) -- my args are the same as the columns of T1
 begin
-  begin try
+  try
     insert into T1 from arguments
-  end try;
-  begin catch
+  catch
     update T1 set t = t_, r = r_ where id = id_;
-  end catch;
+  end;
 end;
 
 -- You can (re)throw an error explicitly.
@@ -562,16 +560,15 @@ select * from T1 where case hi_not_low then T1.r >= r_ else T1.r <= r_ end;
 -- This upsert is a bit better than the first:
 create proc upsert_t1(LIKE t1) -- my args are the same as the columns of T1
 begin
-  begin try
+  try
     insert into T1 from arguments
-  end try;
-  begin catch;
+  catch
     if @rc == 19 /* SQLITE_CONSTRAINT */ then
       update T1 set t = t_, r = r_ where id = id_;
     else
       throw;  -- rethrow, something bad happened.
     end if;
-  end catch;
+  end;
 end;
 
 -- By convention, you can call a procedure that has an OUT argument

--- a/playground/examples/cql_in_20_minutes.sql
+++ b/playground/examples/cql_in_20_minutes.sql
@@ -440,12 +440,11 @@ begin
 
 
   _!('### You can "throw" out of the current procedure (see exceptions below)');
-  begin try
+  try
     let y := ifnull_throw(_null);
-  end try;
-  begin catch
+  catch
     call printf("CATCH: _null is null\n");
-  end catch;
+  end;
   _!("");
 
 

--- a/sources/cg_query_plan.c
+++ b/sources/cg_query_plan.c
@@ -979,22 +979,20 @@ cql_noexport void cg_query_plan_main(ast_node *head) {
   bprintf(&output_buf, "CREATE PROC query_plan()\n");
   bprintf(&output_buf, "BEGIN\n");
   bprintf(&output_buf, "  CALL create_schema();\n");
-  bprintf(&output_buf, "  BEGIN TRY\n");
+  bprintf(&output_buf, "  TRY\n");
   bprintf(&output_buf, "    CALL populate_no_table_scan();\n");
-  bprintf(&output_buf, "  END TRY;\n");
-  bprintf(&output_buf, "  BEGIN CATCH\n");
+  bprintf(&output_buf, "  CATCH\n");
   bprintf(&output_buf, "    CALL printf(\"failed populating no_table_scan table\\n\");\n");
   bprintf(&output_buf, "    THROW;\n");
-  bprintf(&output_buf, "  END CATCH;\n");
+  bprintf(&output_buf, "  END;\n");
   
   for (uint32_t i = 1; i <= sql_stmt_count; i++) {
-    bprintf(&output_buf, "  BEGIN TRY\n");
+    bprintf(&output_buf, "  TRY\n");
     bprintf(&output_buf, "    CALL populate_query_plan_%d();\n", i);
-    bprintf(&output_buf, "  END TRY;\n");
-    bprintf(&output_buf, "  BEGIN CATCH\n");
+    bprintf(&output_buf, "  CATCH\n");
     bprintf(&output_buf, "    CALL printf(\"failed populating query %d\\n\");\n", i);
     bprintf(&output_buf, "    THROW;\n");
-    bprintf(&output_buf, "  END CATCH;\n");
+    bprintf(&output_buf, "  END;\n");
   }
 
   bprintf(&output_buf, "  CALL printf(\"{\\n\");\n");

--- a/sources/cql-verify/cql-verify.c
+++ b/sources/cql-verify/cql-verify.c
@@ -159,26 +159,25 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:86
+// Generated from cql-verify.sql:85
 
 /*
 @ATTRIBUTE(cql:private)
 CREATE PROC find_test_output_line (expectation_line INTEGER NOT NULL, OUT test_output_line INTEGER NOT NULL)
 BEGIN
-  BEGIN TRY
+  TRY
     SET test_output_line := ( SELECT line
       FROM test_results
       WHERE line >= expectation_line
       LIMIT 1 );
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("no lines come after %d\n", expectation_line);
     CALL printf("available test output lines: %d\n", ( SELECT count(*)
       FROM test_results ));
     CALL printf("max line number: %d\n", ( SELECT max(line)
       FROM test_results ));
     THROW;
-  END CATCH;
+  END;
 END;
 */
 
@@ -242,7 +241,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:105
+// Generated from cql-verify.sql:104
 
 /*
 @ATTRIBUTE(cql:private)
@@ -258,7 +257,7 @@ BEGIN
     SET found := 1;
   ELSE
     SET found := 0;
-  END IF;
+  END;
 END;
 */
 
@@ -307,7 +306,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:116
+// Generated from cql-verify.sql:115
 
 /*
 @ATTRIBUTE(cql:private)
@@ -356,7 +355,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:126
+// Generated from cql-verify.sql:125
 
 /*
 @ATTRIBUTE(cql:private)
@@ -396,7 +395,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:143
+// Generated from cql-verify.sql:142
 
 /*
 @ATTRIBUTE(cql:private)
@@ -446,7 +445,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:161
+// Generated from cql-verify.sql:160
 
 /*
 @ATTRIBUTE(cql:private)
@@ -458,8 +457,9 @@ BEGIN
       WHERE line > line1 AND line <= line2;
   LOOP FETCH C
   BEGIN
-    CALL printf("%5s %05d: %s\n", CASE WHEN C.line = current_line THEN "FAIL"
-    ELSE ""
+    CALL printf("%5s %05d: %s\n", CASE
+      WHEN C.line = current_line THEN "FAIL"
+      ELSE ""
     END, C.line, C.data);
   END;
 END;
@@ -523,7 +523,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:184
+// Generated from cql-verify.sql:183
 
 /*
 @ATTRIBUTE(cql:private)
@@ -536,9 +536,10 @@ BEGIN
       WHERE line = test_output_line;
   LOOP FETCH C
   BEGIN
-    CALL printf("%3s%s\n", CASE WHEN last_rowid = C.rowid THEN ">  "
-    WHEN C.data LIKE p THEN "!  "
-    ELSE ""
+    CALL printf("%3s%s\n", CASE
+      WHEN last_rowid = C.rowid THEN ">  "
+      WHEN C.data LIKE p THEN "!  "
+      ELSE ""
     END, C.data);
   END;
 END;
@@ -620,20 +621,23 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:213
+// Generated from cql-verify.sql:212
 
 /*
 @ATTRIBUTE(cql:private)
 CREATE PROC print_fail_details (pat TEXT NOT NULL, test_output_line INTEGER NOT NULL, expected INTEGER NOT NULL)
 BEGIN
   LET found := find_count(pat, test_output_line);
-  LET details := CASE WHEN expected = -2 THEN CASE WHEN found > 0 THEN "pattern found but not on the same line (see lines marked with !)"
-  ELSE "pattern exists nowhere in test output"
-  END
-  WHEN expected = -1 THEN CASE WHEN found > 0 THEN "pattern exists but only earlier in the results where + doesn't match it"
-  ELSE "pattern exists nowhere in test output"
-  END
-  ELSE printf("pattern occurrences found: %d, expecting: %d (see lines marked with !)", found, expected)
+  LET details := CASE
+    WHEN expected = -2 THEN CASE
+      WHEN found > 0 THEN "pattern found but not on the same line (see lines marked with !)"
+      ELSE "pattern exists nowhere in test output"
+    END
+    WHEN expected = -1 THEN CASE
+      WHEN found > 0 THEN "pattern exists but only earlier in the results where + doesn't match it"
+      ELSE "pattern exists nowhere in test output"
+    END
+    ELSE printf("pattern occurrences found: %d, expecting: %d (see lines marked with !)", found, expected)
   END;
   CALL printf("\n%s\n\n", details);
 END;
@@ -693,7 +697,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:242
+// Generated from cql-verify.sql:241
 
 /*
 @ATTRIBUTE(cql:private)
@@ -738,7 +742,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:258
+// Generated from cql-verify.sql:257
 
 /*
 @ATTRIBUTE(cql:private)
@@ -747,18 +751,18 @@ BEGIN
   SET result := FALSE;
   IF len_text(buffer) < 7 THEN
     RETURN;
-  END IF;
+  END;
   IF NOT starts_with_text(buffer, "-- +") THEN
     RETURN;
-  END IF;
+  END;
   LET digit := octet_text(buffer, 4);
   LET space := octet_text(buffer, 5);
   IF space <> 32 THEN
     RETURN;
-  END IF;
+  END;
   IF digit < 48 OR digit > 48 + 9 THEN
     RETURN;
-  END IF;
+  END;
   SET result := TRUE;
 END;
 */
@@ -795,7 +799,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:341
+// Generated from cql-verify.sql:340
 
 /*
 CREATE PROC match_actual (buffer TEXT NOT NULL, expectation_line INTEGER NOT NULL)
@@ -806,10 +810,10 @@ BEGIN
   IF NOT starts_with_text(buffer, "-- ") THEN
     SET last_rowid := 0;
     RETURN;
-  END IF;
+  END;
   IF starts_with_text(buffer, "-- TEST:") THEN
     SET tests := tests + 1;
-  END IF;
+  END;
   IF starts_with_text(buffer, "-- - ") THEN
     SET pattern := after_text(buffer, 5);
     SET expected := 0;
@@ -827,7 +831,7 @@ BEGIN
     SET expected := octet_text(buffer, 4) - 48;
   ELSE
     RETURN;
-  END IF;
+  END;
   SET attempts := attempts + 1;
   LET pat := ifnull_throw(pattern);
   LET test_output_line := find_test_output_line(expectation_line);
@@ -835,18 +839,18 @@ BEGIN
     SET found := find_next(pat, test_output_line);
     IF found = 1 THEN
       RETURN;
-    END IF;
+    END;
   ELSE IF expected = -2 THEN
     SET found := find_same(pat);
     IF found = 1 THEN
       RETURN;
-    END IF;
+    END;
   ELSE
     SET found := find_count(pat, test_output_line);
     IF expected = found THEN
       RETURN;
-    END IF;
-  END IF;
+    END;
+  END;
   SET errors := errors + 1;
   CALL print_error_block(test_output_line, pat, expectation_line, expected);
   CALL printf("test file %s:%d\n", sql_name, expectation_line);
@@ -978,19 +982,18 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:353
+// Generated from cql-verify.sql:351
 
 /*
 @ATTRIBUTE(cql:private)
 CREATE PROC do_match (buffer TEXT NOT NULL, expectation_line INTEGER NOT NULL)
 BEGIN
-  BEGIN TRY
+  TRY
     CALL match_actual(buffer, expectation_line);
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("unexpected sqlite error\n");
     THROW;
-  END CATCH;
+  END;
 END;
 */
 
@@ -1021,7 +1024,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:368
+// Generated from cql-verify.sql:366
 
 /*
 @ATTRIBUTE(cql:private)
@@ -1081,7 +1084,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:406
+// Generated from cql-verify.sql:404
 
 /*
 @ATTRIBUTE(cql:private)
@@ -1091,7 +1094,7 @@ BEGIN
   IF result_file IS NULL THEN
     CALL printf("unable to open file '%s'\n", result_name);
     THROW;
-  END IF;
+  END;
   LET line := 0;
   LET key_string := "The statement ending at line ";
   LET len := len_text(key_string);
@@ -1100,11 +1103,11 @@ BEGIN
     LET data := readline_object_file(result_file);
     IF data IS NULL THEN
       LEAVE;
-    END IF;
+    END;
     LET loc := index_of_text(data, key_string);
     IF loc >= 0 THEN
       SET line := atoi_at_text(data, loc + len);
-    END IF;
+    END;
     INSERT INTO test_results(line, data)
       VALUES(line, data);
   END;
@@ -1175,7 +1178,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:431
+// Generated from cql-verify.sql:429
 
 /*
 @ATTRIBUTE(cql:private)
@@ -1185,14 +1188,14 @@ BEGIN
   IF sql_file IS NULL THEN
     CALL printf("unable to open file '%s'\n", sql_name);
     THROW;
-  END IF;
+  END;
   LET line := 1;
   WHILE TRUE
   BEGIN
     LET data := readline_object_file(sql_file);
     IF data IS NULL THEN
       LEAVE;
-    END IF;
+    END;
     INSERT INTO test_input(line, data)
       VALUES(line, data);
     SET line := line + 1;
@@ -1255,7 +1258,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:438
+// Generated from cql-verify.sql:436
 
 /*
 @ATTRIBUTE(cql:private)
@@ -1283,7 +1286,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:455
+// Generated from cql-verify.sql:453
 
 /*
 @ATTRIBUTE(cql:private)
@@ -1295,7 +1298,7 @@ BEGIN
     CALL printf("cql-verify is a test tool.  It processes the input foo.sql\n");
     CALL printf("looking for patterns to match in the CQL output foo.out\n");
     RETURN;
-  END IF;
+  END;
   SET sql_name := ifnull_throw(get_from_object_cql_string_list(args, 1));
   SET result_name := ifnull_throw(get_from_object_cql_string_list(args, 2));
 END;
@@ -1339,7 +1342,7 @@ cql_cleanup:
 }
 #undef _PROC_
 
-// Generated from cql-verify.sql:467
+// Generated from cql-verify.sql:465
 
 /*
 CREATE PROC dbhelp_main (args OBJECT<cql_string_list> NOT NULL)
@@ -1349,7 +1352,7 @@ BEGIN
   IF sql_name IS NOT NULL AND result_name IS NOT NULL THEN
     CALL load_data(sql_name, result_name);
     CALL process();
-  END IF;
+  END;
 END;
 */
 

--- a/sources/cql-verify/cql-verify.h
+++ b/sources/cql-verify/cql-verify.h
@@ -30,56 +30,56 @@ extern cql_int64 last_rowid;
 // Generated from cql-verify.sql:61
 // static CQL_WARN_UNUSED cql_code setup(sqlite3 *_Nonnull _db_);
 
-// Generated from cql-verify.sql:86
+// Generated from cql-verify.sql:85
 // static CQL_WARN_UNUSED cql_code find_test_output_line(sqlite3 *_Nonnull _db_, cql_int32 expectation_line, cql_int32 *_Nonnull test_output_line);
 
-// Generated from cql-verify.sql:105
+// Generated from cql-verify.sql:104
 // static CQL_WARN_UNUSED cql_code find_next(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull pattern, cql_int32 test_output_line, cql_int32 *_Nonnull found);
 
-// Generated from cql-verify.sql:116
+// Generated from cql-verify.sql:115
 // static CQL_WARN_UNUSED cql_code find_same(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull pattern, cql_int32 *_Nonnull found);
 
-// Generated from cql-verify.sql:126
+// Generated from cql-verify.sql:125
 // static CQL_WARN_UNUSED cql_code find_count(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull pattern, cql_int32 test_output_line, cql_int32 *_Nonnull found);
 
-// Generated from cql-verify.sql:143
+// Generated from cql-verify.sql:142
 // static CQL_WARN_UNUSED cql_code prev_line(sqlite3 *_Nonnull _db_, cql_int32 test_output_line, cql_int32 *_Nonnull prev);
 
-// Generated from cql-verify.sql:161
+// Generated from cql-verify.sql:160
 // static CQL_WARN_UNUSED cql_code dump_source(sqlite3 *_Nonnull _db_, cql_int32 line1, cql_int32 line2, cql_int32 current_line);
 
-// Generated from cql-verify.sql:184
+// Generated from cql-verify.sql:183
 // static CQL_WARN_UNUSED cql_code dump_output(sqlite3 *_Nonnull _db_, cql_int32 test_output_line, cql_string_ref _Nonnull pat);
 
-// Generated from cql-verify.sql:213
+// Generated from cql-verify.sql:212
 // static CQL_WARN_UNUSED cql_code print_fail_details(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull pat, cql_int32 test_output_line, cql_int32 expected);
 
-// Generated from cql-verify.sql:242
+// Generated from cql-verify.sql:241
 // static CQL_WARN_UNUSED cql_code print_error_block(sqlite3 *_Nonnull _db_, cql_int32 test_output_line, cql_string_ref _Nonnull pat, cql_int32 expectation_line, cql_int32 expected);
 
-// Generated from cql-verify.sql:258
+// Generated from cql-verify.sql:257
 // static void match_multiline(cql_string_ref _Nonnull buffer, cql_bool *_Nonnull result);
 
-// Generated from cql-verify.sql:341
+// Generated from cql-verify.sql:340
 extern CQL_WARN_UNUSED cql_code match_actual(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull buffer, cql_int32 expectation_line);
 
-// Generated from cql-verify.sql:353
+// Generated from cql-verify.sql:351
 // static CQL_WARN_UNUSED cql_code do_match(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull buffer, cql_int32 expectation_line);
 
-// Generated from cql-verify.sql:368
+// Generated from cql-verify.sql:366
 // static CQL_WARN_UNUSED cql_code process(sqlite3 *_Nonnull _db_);
 
-// Generated from cql-verify.sql:406
+// Generated from cql-verify.sql:404
 // static CQL_WARN_UNUSED cql_code read_test_results(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull result_name);
 
-// Generated from cql-verify.sql:431
+// Generated from cql-verify.sql:429
 // static CQL_WARN_UNUSED cql_code read_test_file(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull sql_name);
 
-// Generated from cql-verify.sql:438
+// Generated from cql-verify.sql:436
 // static CQL_WARN_UNUSED cql_code load_data(sqlite3 *_Nonnull _db_, cql_string_ref _Nonnull sql_name, cql_string_ref _Nonnull result_name);
 
-// Generated from cql-verify.sql:455
+// Generated from cql-verify.sql:453
 // static CQL_WARN_UNUSED cql_code parse_args(sqlite3 *_Nonnull _db_, cql_object_ref _Nonnull args);
 
-// Generated from cql-verify.sql:467
+// Generated from cql-verify.sql:465
 extern CQL_WARN_UNUSED cql_code dbhelp_main(sqlite3 *_Nonnull _db_, cql_object_ref _Nonnull args);

--- a/sources/cql-verify/cql-verify.sql
+++ b/sources/cql-verify/cql-verify.sql
@@ -74,15 +74,14 @@ begin
      We need to find the number of a line in the test output that has been charged
      to an input line greater than the one we are on.
   */
-  begin try
+  try
     set test_output_line := (select line from test_results where line >= expectation_line limit 1);
-  end try;
-  begin catch
+  catch
     printf("no lines come after %d\n", expectation_line);
     printf("available test output lines: %d\n", (select count(*) from test_results));
     printf("max line number: %d\n", (select max(line) from test_results));
     throw;
-  end catch;
+  end;
 end;
 
 -- find the next match, the matches have to be in order
@@ -343,13 +342,12 @@ end;
 [[private]]
 proc do_match(buffer text!, expectation_line int!)
 begin
-  begin try
+  try
      match_actual(buffer, expectation_line);
-  end try;
-  begin catch
+  catch
     printf("unexpected sqlite error\n");
     throw;
-  end catch;
+  end;
 end;
 
 [[private]]

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -22516,13 +22516,12 @@ static void sem_proc_savepoint_stmt(ast_node *ast)
 //     BEGIN \
 //       LET error_in_try := FALSE; \
 //       @attribute(cql:try_is_proc_body) \
-//       BEGIN TRY
+//       TRY
 //
 //   #define LOGGING_PROC_END \
-//       END TRY; \
-//       BEGIN CATCH \
+//       CATCH \
 //         SET error_in_try := TRUE; \
-//       END CATCH; \
+//       END; \
 //       IF error_in_try THEN \
 //         CALL some_proc_that_logs_and_rethrows(__FILE__, __LINE__); \
 //       END IF; \
@@ -22608,7 +22607,7 @@ static void sem_trycatch_stmt(ast_node *ast) {
   //
   //   DECLARE x INT;
   //   SET x := 42;
-  //   BEGIN TRY
+  //   TRY
   //     IF some_condition THEN
   //       SET x := NULL;
   //       IF another_condition THEN
@@ -22619,10 +22618,9 @@ static void sem_trycatch_stmt(ast_node *ast) {
   //       -- do nothing; neutral for x
   //     END IF;
   //     -- x is still nonnull here as the outer IF was neutral for x
-  //   END TRY;
-  //   BEGIN CATCH
+  //   CATCH
   //     -- x must be nullable here as the final SET may have not occurred
-  //   END CATCH;
+  //   END;
   //   -- x must also be nullable here
   //
   // If we did not use a jump context, x would be nonnull after the TRY because

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -538,13 +538,12 @@ end;
 -- + cql_cleanup:
 create procedure throwing()
 begin
-  begin try
+  try
    delete from bar;
-  end try;
-  begin catch
+  catch
    call printf("error\n");
    throw;
-  end catch;
+  end;
 end;
 
 -- TEST: a simple case expression
@@ -1661,28 +1660,26 @@ end;
 -- + catch_start%:
 create proc no_cleanup_label_needed_proc()
 begin
-  begin try
+  try
     declare C cursor for select 1 as N;
     fetch C;
-  end try;
-  begin catch
+  catch
     declare x integer;
-  end catch;
+  end;
 end;
 
 -- TEST: no code after the last label
--- begin try and begin catch implyl dml proc
+-- try and catch implyl dml proc
 -- + cql_code no_code_after_catch(sqlite3 *_Nonnull _db_)
 create proc no_code_after_catch()
 begin
-  begin try
+  try
     @attribute(foo) -- just messing with the tree
     declare x integer;
-  end try;
-  begin catch
+  catch
     @attribute(bar) -- just messing with the tree
     declare y integer;
-  end catch;
+  end;
 end;
 
 -- TEST: void cursor fetcher
@@ -2748,12 +2745,11 @@ declare proc out_union_no_dml(id integer) out union (id integer not null);
 -- + cql_cleanup:
 create proc use_return()
 begin
-  begin try
+  try
     select 1 x;
-  end try;
-  begin catch
+  catch
     return;
-  end catch;
+  end;
 end;
 
 -- TEST: emit goto cql_cleanup in case of return, force the label even if not
@@ -2807,10 +2803,9 @@ begin
   begin
   end;
 
-  begin try
-  end try;
-  begin catch
-  end catch;
+  try
+  catch
+  end;
 end;
 
 -- This proc illustrates a case where we need to put the ;
@@ -2828,14 +2823,12 @@ end;
 -- + catch_end_6:;
 create proc tail_catch()
 begin
-   begin try
-   end try;
-   begin catch
-     begin try
-     end try;
-     begin catch
-     end catch;
-   end catch;
+   try
+   catch
+     try
+     catch
+     end;
+   end;
 end;
 
 -- TEST: the SQL output will include an escaped quote ''
@@ -3587,29 +3580,26 @@ create proc rc_test()
 begin
   LET err := @rc;
   let e0 := @rc;
-  begin try
-  begin try
+  try
+  try
     create table whatever_anything(id integer);
-  end try;
-  begin catch
+  catch
     set err := @rc;
     let e1 := @rc;
-    begin try
+    try
        let e2 := @rc;
        create table whatever_anything(id integer);
-    end try;
-    begin catch
+    catch
        let e3 := @rc;
        set err := @rc;
        throw;
-    end catch;
+    end;
     let e4 := @rc;
-  end catch;
-  end try;
-  begin catch
+  end;
+  catch
     let e5 := @rc;
     call printf("Error %d\n", err);
-  end catch;
+  end;
   let e6 := @rc;
 end;
 
@@ -3619,17 +3609,15 @@ end;
 -- +  _rc_ = cql_best_error(_rc_thrown_2);
 create proc rc_test_lazy1()
 begin
-  begin try
+  try
     create table whatever_anything(id integer);
-  end try;
-  begin catch
-    begin try
+  catch
+    try
        create table whatever_anything(id integer);
-    end try;
-    begin catch
+    catch
        throw;
-    end catch;
-  end catch;
+    end;
+  end;
 end;
 
 -- TEST: lazy decl of rcthrown variables (via @rc)
@@ -3638,17 +3626,15 @@ end;
 -- +  err = _rc_thrown_2;
 create proc rc_test_lazy2()
 begin
-  begin try
+  try
     create table whatever_anything(id integer);
-  end try;
-  begin catch
-    begin try
+  catch
+    try
        create table whatever_anything(id integer);
-    end try;
-    begin catch
+    catch
        let err := @rc;
-    end catch;
-  end catch;
+    end;
+  end;
 end;
 
 -- TEST: make an integer enum
@@ -4009,11 +3995,10 @@ end;
 create proc try_catch_rc()
 begin
   declare C cursor for select 'foo' extra2 from bar;
-  begin try
+  try
     fetch C;
-  end try;
-  begin catch
-  end catch;
+  catch
+  end;
 end;
 
 -- TEST: basic code gen for the switch

--- a/sources/test/cg_test_json_schema.out.ref
+++ b/sources/test/cg_test_json_schema.out.ref
@@ -3810,7 +3810,7 @@
     {
       "name" : "json_escapes",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1173,
+      "definedOnLine" : 1172,
       "args" : [
       ],
       "usesTables" : [  ],
@@ -3836,7 +3836,7 @@
     {
       "name" : "use_view",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1217,
+      "definedOnLine" : 1216,
       "args" : [
       ],
       "fromTables" : [ "Foo" ],
@@ -3871,7 +3871,7 @@
     {
       "name" : "null_attribute",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1225,
+      "definedOnLine" : 1224,
       "args" : [
       ],
       "fromTables" : [ "Foo" ],
@@ -3909,7 +3909,7 @@
     {
       "name" : "shared_frag_user_function_style",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1451,
+      "definedOnLine" : 1450,
       "args" : [
       ],
       "fromTables" : [ "T2" ],
@@ -3936,7 +3936,7 @@
     {
       "name" : "high_bit_escapes",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1460,
+      "definedOnLine" : 1459,
       "args" : [
       ],
       "usesTables" : [  ],
@@ -3962,7 +3962,7 @@
     {
       "name" : "potato",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1479,
+      "definedOnLine" : 1478,
       "args" : [
         {
           "name" : "i",
@@ -4016,7 +4016,7 @@
     {
       "name" : "uses_deleted_view_alias",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1513,
+      "definedOnLine" : 1512,
       "args" : [
       ],
       "usesTables" : [  ],
@@ -4047,7 +4047,7 @@
     {
       "name" : "test_interface1_implementation_correct",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1562,
+      "definedOnLine" : 1561,
       "args" : [
         {
           "name" : "id_",
@@ -4096,7 +4096,7 @@
     {
       "name" : "generate_quoted_items",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1943,
+      "definedOnLine" : 1942,
       "args" : [
       ],
       "fromTables" : [ "abc def" ],
@@ -4911,7 +4911,7 @@
     {
       "name" : "proc_with_deps",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1164,
+      "definedOnLine" : 1163,
       "args" : [
         {
           "binding" : "out",
@@ -4936,7 +4936,7 @@
     {
       "name" : "using_kinds",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1355,
+      "definedOnLine" : 1354,
       "args" : [
         {
           "name" : "list",
@@ -4973,7 +4973,7 @@
     {
       "name" : "shared_frag_user",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1412,
+      "definedOnLine" : 1411,
       "args" : [
       ],
       "fromTables" : [ "Foo", "T1", "T2", "T6" ],
@@ -5004,7 +5004,7 @@
     {
       "name" : "shared_frag_user_nested_select",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1430,
+      "definedOnLine" : 1429,
       "args" : [
       ],
       "fromTables" : [ "Foo", "T1", "T2", "T6" ],
@@ -5031,7 +5031,7 @@
     {
       "name" : "string_literal_attr",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1469,
+      "definedOnLine" : 1468,
       "args" : [
       ],
       "usesTables" : [  ],
@@ -6009,7 +6009,7 @@
     {
       "name" : "interface1",
       "definedInFile" : "cg_test_json_schema.sql",
-      "definedOnLine" : 1559,
+      "definedOnLine" : 1558,
       "attributes" : [
         {
           "name" : "cql:java_package",

--- a/sources/test/cg_test_json_schema.sql
+++ b/sources/test/cg_test_json_schema.sql
@@ -1148,10 +1148,9 @@ begin
   begin
   end;
 
-  begin try
-  end try;
-  begin catch
-  end catch;
+  try
+  catch
+  end;
 end;
 
 declare proc proc_as_func(out x integer not null);

--- a/sources/test/cg_test_lua.sql
+++ b/sources/test/cg_test_lua.sql
@@ -492,13 +492,12 @@ end;
 -- + end
 create procedure throwing()
 begin
-  begin try
+  try
    delete from bar;
-  end try;
-  begin catch
+  catch
    call printf("error\n");
    throw;
-  end catch;
+  end;
 end;
 
 -- TEST: a simple case expression
@@ -1580,30 +1579,28 @@ end;
 -- - cql_cleanup
 create proc no_cleanup_label_needed_proc()
 begin
-  begin try
+  try
     declare C cursor for select 1 as N;
     fetch C;
-  end try;
-  begin catch
+  catch
     declare x integer;
-  end catch;
+  end;
 end;
 
 -- TEST: no code after the last label
--- begin try and begin catch imply dml proc
+-- try/catch imply dml proc
 -- + function no_code_after_catch(_db_)
 -- - cql_cleanup
 -- + return _rc_
 create proc no_code_after_catch()
 begin
-  begin try
+  try
     @attribute(foo) -- just messing with the tree
     declare x integer;
-  end try;
-  begin catch
+  catch
     @attribute(bar) -- just messing with the tree
     declare y integer;
-  end catch;
+  end;
 end;
 
 -- TEST: void cursor fetcher
@@ -2606,12 +2603,11 @@ declare proc out_union_no_dml(id integer) out union (id integer not null);
 -- + ::cql_cleanup::
 create proc use_return()
 begin
-  begin try
+  try
     select 1 x;
-  end try;
-  begin catch
+  catch
     return;
-  end catch;
+  end;
 end;
 
 -- TEST: emit goto cql_cleanup in case of return, force the label even if not
@@ -2664,10 +2660,9 @@ begin
   begin
   end;
 
-  begin try
-  end try;
-  begin catch
-  end catch;
+  try
+  catch
+  end;
 end;
 
 -- This proc illustrates empty catch blocks correctly emitting labels
@@ -2681,14 +2676,12 @@ end;
 -- +2 ::catch_end_%::
 create proc tail_catch()
 begin
-   begin try
-   end try;
-   begin catch
-     begin try
-     end try;
-     begin catch
-     end catch;
-   end catch;
+   try
+   catch
+     try
+     catch
+     end;
+  end;
 end;
 
 -- TEST: the SQL output will include an escaped quote ''
@@ -3502,29 +3495,26 @@ create proc rc_test()
 begin
   LET err := @rc;
   let e0 := @rc;
-  begin try
-  begin try
-    create table whatever_anything(id integer);
-  end try;
-  begin catch
-    set err := @rc;
-    let e1 := @rc;
-    begin try
-       let e2 := @rc;
-       create table whatever_anything(id integer);
-    end try;
-    begin catch
-       let e3 := @rc;
-       set err := @rc;
-       throw;
-    end catch;
-    let e4 := @rc;
-  end catch;
-  end try;
-  begin catch
+  try
+    try
+      create table whatever_anything(id integer);
+    catch
+      set err := @rc;
+      let e1 := @rc;
+      try
+        let e2 := @rc;
+        create table whatever_anything(id integer);
+      catch
+        let e3 := @rc;
+        set err := @rc;
+        throw;
+      end;
+      let e4 := @rc;
+    end;
+  catch
     let e5 := @rc;
     call printf("Error %d\n", err);
-  end catch;
+  end;
   let e6 := @rc;
 end;
 
@@ -3534,17 +3524,15 @@ end;
 -- + _rc_ = cql_best_error(_rc_thrown_2)
 create proc rc_test_lazy1()
 begin
-  begin try
+  try
     create table whatever_anything(id integer);
-  end try;
-  begin catch
-    begin try
-       create table whatever_anything(id integer);
-    end try;
-    begin catch
-       throw;
-    end catch;
-  end catch;
+  catch
+    try
+      create table whatever_anything(id integer);
+    catch
+      throw;
+    end;
+  end;
 end;
 
 -- TEST: lazy decl of rcthrown variables (via @rc)
@@ -3553,17 +3541,15 @@ end;
 -- + err = _rc_thrown_2
 create proc rc_test_lazy2()
 begin
-  begin try
+  try
     create table whatever_anything(id integer);
-  end try;
-  begin catch
-    begin try
+  catch
+    try
        create table whatever_anything(id integer);
-    end try;
-    begin catch
+    catch
        let err := @rc;
-    end catch;
-  end catch;
+    end;
+  end;
 end;
 
 -- TEST: make an integer enum
@@ -3915,11 +3901,10 @@ end;
 create proc try_catch_rc()
 begin
   declare C cursor for select 'foo' extra2 from bar;
-  begin try
+  try
     fetch C;
-  end try;
-  begin catch
-  end catch;
+  catch
+  end;
 end;
 
 -- TEST: basic code gen for the switch

--- a/sources/test/cg_test_query_plan.out.ref
+++ b/sources/test/cg_test_query_plan.out.ref
@@ -1183,293 +1183,252 @@ END;
 CREATE PROC query_plan()
 BEGIN
   CALL create_schema();
-  BEGIN TRY
+  TRY
     CALL populate_no_table_scan();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating no_table_scan table\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_1();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 1\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_2();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 2\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_3();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 3\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_4();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 4\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_5();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 5\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_6();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 6\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_7();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 7\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_8();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 8\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_9();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 9\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_10();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 10\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_11();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 11\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_12();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 12\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_13();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 13\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_14();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 14\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_15();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 15\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_16();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 16\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_17();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 17\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_18();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 18\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_19();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 19\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_20();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 20\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_21();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 21\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_22();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 22\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_23();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 23\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_24();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 24\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_25();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 25\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_26();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 26\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_27();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 27\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_28();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 28\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_29();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 29\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_30();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 30\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_31();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 31\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_32();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 32\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_33();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 33\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_34();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 34\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_35();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 35\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_36();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 36\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_37();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 37\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_38();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 38\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_39();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 39\n");
     THROW;
-  END CATCH;
-  BEGIN TRY
+  END;
+  TRY
     CALL populate_query_plan_40();
-  END TRY;
-  BEGIN CATCH
+  CATCH
     CALL printf("failed populating query 40\n");
     THROW;
-  END CATCH;
+  END;
   CALL printf("{\n");
   CALL print_query_violation();
   CALL printf("\"plans\" : [\n");

--- a/sources/test/cg_test_query_plan.sql
+++ b/sources/test/cg_test_query_plan.sql
@@ -329,13 +329,12 @@
 -- + CREATE PROC query_plan()
 -- + BEGIN
 -- +   CALL create_schema();
--- +   BEGIN TRY
+-- +   TRY
 -- +     CALL populate_no_table_scan();
--- +   END TRY;
--- +   BEGIN CATCH
+-- +   CATCH
 -- +     CALL printf("failed populating no_table_scan table\n");
 -- +     THROW;
--- +   END CATCH;
+-- +   END;
 -- +   CALL printf("{\n");
 -- +   CALL print_query_violation();
 -- +   CALL printf("\"plans\" : [\n");

--- a/sources/test/cg_test_schema_min_version_upgrade.out.ref
+++ b/sources/test/cg_test_schema_min_version_upgrade.out.ref
@@ -424,12 +424,11 @@ CREATE TEMP TABLE IF NOT EXISTS cql_schema_rebuilt_tables(
 -- helper proc for getting the schema version of a facet
 CREATE PROCEDURE test_cql_get_facet_version(_facet TEXT NOT NULL, out _version LONG INTEGER NOT NULL)
 BEGIN
-  BEGIN TRY
+  TRY
     SET _version := (SELECT version FROM test_cql_schema_facets WHERE facet = _facet LIMIT 1 IF NOTHING -1);
-  END TRY;
-  BEGIN CATCH
+  CATCH
     SET _version := -1;
-  END CATCH;
+  END;
 END;
 
 -- saved facets table declaration --
@@ -887,17 +886,16 @@ END;
 @attribute(cql:private)
 CREATE PROCEDURE test_setup_facets()
 BEGIN
-  BEGIN TRY
+  TRY
     SET test_facets := cql_facets_create();
     DECLARE C CURSOR FOR SELECT * from test_cql_schema_facets;
     LOOP FETCH C
     BEGIN
       LET added := cql_facet_add(test_facets, C.facet, C.version);
     END;
-  END TRY;
-  BEGIN CATCH
-   -- if table doesn't exist we just have empty facets, that's ok
-  END CATCH;
+  CATCH
+    -- if table doesn't exist we just have empty facets, that's ok
+  END;
 END;
 
 DECLARE FUNCTION _cql_contains_column_def(needle TEXT, haystack TEXT) BOOL NOT NULL;
@@ -1121,15 +1119,14 @@ BEGIN
   CALL test_cql_get_facet_version('cql_schema_crc', schema_crc);
 
   IF schema_crc <> -2270053074149662303 THEN
-    BEGIN TRY
+    TRY
       CALL test_setup_facets();
       CALL test_perform_needed_upgrades(include_virtual_tables);
-    END TRY;
-    BEGIN CATCH
+    CATCH
       SET test_facets := NULL;
       SET test_tables_dict_ := NULL;
       THROW;
-    END CATCH;
+    END;
     SET test_facets := NULL;
     SET test_tables_dict_ := NULL;
   ELSE

--- a/sources/test/cg_test_schema_partial_upgrade.out.ref
+++ b/sources/test/cg_test_schema_partial_upgrade.out.ref
@@ -179,12 +179,11 @@ CREATE TEMP TABLE IF NOT EXISTS cql_schema_rebuilt_tables(
 -- helper proc for getting the schema version of a facet
 CREATE PROCEDURE test_cql_get_facet_version(_facet TEXT NOT NULL, out _version LONG INTEGER NOT NULL)
 BEGIN
-  BEGIN TRY
+  TRY
     SET _version := (SELECT version FROM test_cql_schema_facets WHERE facet = _facet LIMIT 1 IF NOTHING -1);
-  END TRY;
-  BEGIN CATCH
+  CATCH
     SET _version := -1;
-  END CATCH;
+  END;
 END;
 
 -- saved facets table declaration --
@@ -371,17 +370,16 @@ END;
 @attribute(cql:private)
 CREATE PROCEDURE test_setup_facets()
 BEGIN
-  BEGIN TRY
+  TRY
     SET test_facets := cql_facets_create();
     DECLARE C CURSOR FOR SELECT * from test_cql_schema_facets;
     LOOP FETCH C
     BEGIN
       LET added := cql_facet_add(test_facets, C.facet, C.version);
     END;
-  END TRY;
-  BEGIN CATCH
-   -- if table doesn't exist we just have empty facets, that's ok
-  END CATCH;
+  CATCH
+    -- if table doesn't exist we just have empty facets, that's ok
+  END;
 END;
 
 DECLARE FUNCTION _cql_contains_column_def(needle TEXT, haystack TEXT) BOOL NOT NULL;
@@ -531,15 +529,14 @@ BEGIN
   CALL test_cql_get_facet_version('cql_schema_crc', schema_crc);
 
   IF schema_crc <> 5550480522444860907 THEN
-    BEGIN TRY
+    TRY
       CALL test_setup_facets();
       CALL test_perform_needed_upgrades(include_virtual_tables);
-    END TRY;
-    BEGIN CATCH
+    CATCH
       SET test_facets := NULL;
       SET test_tables_dict_ := NULL;
       THROW;
-    END CATCH;
+    END;
     SET test_facets := NULL;
     SET test_tables_dict_ := NULL;
   ELSE

--- a/sources/test/cg_test_schema_upgrade.out.ref
+++ b/sources/test/cg_test_schema_upgrade.out.ref
@@ -424,12 +424,11 @@ CREATE TEMP TABLE IF NOT EXISTS cql_schema_rebuilt_tables(
 -- helper proc for getting the schema version of a facet
 CREATE PROCEDURE test_cql_get_facet_version(_facet TEXT NOT NULL, out _version LONG INTEGER NOT NULL)
 BEGIN
-  BEGIN TRY
+  TRY
     SET _version := (SELECT version FROM test_cql_schema_facets WHERE facet = _facet LIMIT 1 IF NOTHING -1);
-  END TRY;
-  BEGIN CATCH
+  CATCH
     SET _version := -1;
-  END CATCH;
+  END;
 END;
 
 -- saved facets table declaration --
@@ -945,17 +944,16 @@ END;
 @attribute(cql:private)
 CREATE PROCEDURE test_setup_facets()
 BEGIN
-  BEGIN TRY
+  TRY
     SET test_facets := cql_facets_create();
     DECLARE C CURSOR FOR SELECT * from test_cql_schema_facets;
     LOOP FETCH C
     BEGIN
       LET added := cql_facet_add(test_facets, C.facet, C.version);
     END;
-  END TRY;
-  BEGIN CATCH
-   -- if table doesn't exist we just have empty facets, that's ok
-  END CATCH;
+  CATCH
+    -- if table doesn't exist we just have empty facets, that's ok
+  END;
 END;
 
 DECLARE FUNCTION _cql_contains_column_def(needle TEXT, haystack TEXT) BOOL NOT NULL;
@@ -1232,15 +1230,14 @@ BEGIN
   CALL test_cql_get_facet_version('cql_schema_crc', schema_crc);
 
   IF schema_crc <> -2270053074149662303 THEN
-    BEGIN TRY
+    TRY
       CALL test_setup_facets();
       CALL test_perform_needed_upgrades(include_virtual_tables);
-    END TRY;
-    BEGIN CATCH
+    CATCH
       SET test_facets := NULL;
       SET test_tables_dict_ := NULL;
       THROW;
-    END CATCH;
+    END;
     SET test_facets := NULL;
     SET test_tables_dict_ := NULL;
   ELSE

--- a/sources/test/cqltest.h
+++ b/sources/test/cqltest.h
@@ -24,18 +24,17 @@ declare proc exit no check;
 #define BEGIN_TEST(x) \
   create procedure test_##x() \
   begin \
-  begin try \
+  try \
   set tests := tests + 1; \
   declare starting_fails integer not null; \
   set starting_fails := fails;
 
 #define END_TEST(x) \
-  end try; \
-  begin catch \
+  catch \
     call printf("%s had an unexpected CQL exception (usually a db error)\n", #x); \
     set fails := fails + 1; \
     throw; \
-  end catch; \
+  end; \
   if starting_fails != fails then \
     call printf("%s failed.\n", #x); \
   else \

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -2783,13 +2783,12 @@ end;
 -- - error:
 create proc throw_before_out()
 begin
-  begin try
+  try
     declare C cursor for select 1 x;
     fetch C;
-  end try;
-  begin catch
+  catch
     throw;
-  end catch;
+  end;
   out C;
 end;
 
@@ -3322,24 +3321,22 @@ end;
 -- - error:
 -- + {trycatch_stmt}: ok
 -- + {throw_stmt}: ok
-begin try
+try
   select 1;
-end try;
-begin catch
+catch
   throw;
-end catch;
+end;
 
 -- TEST: error in try block should be propagated to top of tree
 -- * error: % string operand not allowed in 'NOT'
 -- + {trycatch_stmt}: err
 -- + {stmt_list}: err
 -- +1 error:
-begin try
+try
   select not 'x';
-end try;
-begin catch
+catch
   throw;
-end catch;
+end;
 
 -- TEST: error in catch block should be propagated to top of tree
 -- * error: % string operand not allowed in 'NOT'
@@ -3347,12 +3344,11 @@ end catch;
 -- + {stmt_list}: ok
 -- + {stmt_list}: err
 -- +1 error:
-begin try
+try
   throw;
-end try;
-begin catch
+catch
   select not 'x';
-end catch;
+end;
 
 -- TEST: this procedure will have a structured semantic type
 -- + {create_proc_stmt}: with_result_set: { id: integer notnull, name: text, rate: longint } dml_proc
@@ -18655,7 +18651,7 @@ begin
 
   set a := 1;
 
-  begin try
+  try
     -- use an if/else to make sure we're safe in the presence of effect merging
     if 0 then
       set a := null;
@@ -18668,11 +18664,10 @@ begin
       -- do nothing; neutral
     end if;
     let x0 := a; -- safely considered nonnull
-  end try;
-  begin catch
+  catch
     let x1 := a; -- nullable
     set a := 1; -- does not allow for improving x2 (at least for now)
-  end catch;
+  end;
 
   let x2 := a; -- nullable
 end;
@@ -19169,13 +19164,12 @@ begin
   set rc := 0;
   @attribute(cql:try_is_proc_body)
   @attribute(some_other_attribute)
-  begin try
+  try
     -- we're okay because it's initialized in the TRY...
     set a := "text";
-  end try;
-  begin catch
+  catch
     set rc := 1;
-  end catch;
+  end;
   -- ...even though it's not always initialized in the proc
 end;
 
@@ -19190,12 +19184,11 @@ begin
   set rc := 0;
   @attribute(some_other_attribute)
   @attribute(cql:try_is_proc_body)
-  begin try
+  try
     -- `a` is not initialized soon enough so we get an error...
-  end try;
-  begin catch
+  catch
     set rc := 1;
-  end catch;
+  end;
   -- ...even though it's always initialized in the proc
   set a := "text";
 end;
@@ -19209,15 +19202,13 @@ end;
 create proc try_is_proc_body_may_only_appear_once()
 begin
   @attribute(cql:try_is_proc_body)
-  begin try
-  end try;
-  begin catch
-  end catch;
+  try
+  catch
+  end;
   @attribute(cql:try_is_proc_body)
-  begin try
-  end try;
-  begin catch
-  end catch;
+  try
+  catch
+  end;
 end;
 
 -- TEST: try_is_proc_body accepts no values.
@@ -19229,10 +19220,9 @@ end;
 create proc try_is_proc_body_accepts_no_values()
 begin
   @attribute(cql:try_is_proc_body=(foo))
-  begin try
-  end try;
-  begin catch
-  end catch;
+  try
+  catch
+  end;
 end;
 
 -- TEST: Improvements can be set for names using the dot syntax even when the


### PR DESCRIPTION
All of these have been changed to the simpler equivalent notation. For coverage there is one case left in test.sql just to make sure the old way continues to parse.