### PR TITLE
Adding support for polymorphic (overloads) invocation using pipeline syntax

### DIFF
--- a/docs/user_guide/appendices/04_error_codes.md
+++ b/docs/user_guide/appendices/04_error_codes.md
@@ -4694,3 +4694,31 @@ will indicate which argument number or operand that is incorrect.
 
 Many json oriented functions cannot accept blob or object arguments.  The indicated argument
 is a blob.  The context indicates the function.
+
+----
+
+### CQL0506: left argument must have a type kind
+
+When using the pipeline syntax with no function name e.g.
+
+```sql
+foo:(1):(2):(3);
+```
+
+The left argument of the pipeline, `foo` in this example, must have a type "kind" because the
+pipeline uses the "kind" to generate the name of the function it will call.
+
+```sql
+var foo object<builder>;
+foo := new_builder();
+let u := foo:(1);
+
+-- becomes
+
+let u := object_builder_int(foo, 1);
+```
+
+Without the:(2):(3); `builder` the name isn't unique enough to be useful.
+
+Note that if object_builder_int returns the first argument (`foo`) then it can be chained as in
+the first example `foo:(1):(2):(3)`.

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -831,6 +831,7 @@ AST(region_spec);
 AST(reverse_apply)
 AST(reverse_apply_poly)
 AST(reverse_apply_typed)
+AST(reverse_apply_poly_args)
 AST(rs_eq)
 AST(rshift)
 AST(query_parts_macro_arg_ref)

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -1252,7 +1252,7 @@ call:
   | basic_expr ':' ':' simple_call { $call = new_ast_reverse_apply_typed($basic_expr, $simple_call); }
   | basic_expr ':' ':' ':' simple_call { $call = new_ast_reverse_apply_poly($basic_expr, $simple_call); }
   | basic_expr ':' data_type_any ':' { $call = new_ast_cast_expr($basic_expr, $data_type_any); }
-  | basic_expr ':' '(' arg_list ')' { $call = new_ast_reverse_apply($basic_expr, $arg_list); }
+  | basic_expr ':' '(' arg_list ')' { $call = new_ast_reverse_apply_poly_args($basic_expr, $arg_list); }
   ;
 
 basic_expr:

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -1252,6 +1252,7 @@ call:
   | basic_expr ':' ':' simple_call { $call = new_ast_reverse_apply_typed($basic_expr, $simple_call); }
   | basic_expr ':' ':' ':' simple_call { $call = new_ast_reverse_apply_poly($basic_expr, $simple_call); }
   | basic_expr ':' data_type_any ':' { $call = new_ast_cast_expr($basic_expr, $data_type_any); }
+  | basic_expr ':' '(' arg_list ')' { $call = new_ast_reverse_apply($basic_expr, $arg_list); }
   ;
 
 basic_expr:

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -75,6 +75,7 @@ static void gen_select_expr_macro_ref(ast_node *ast);
 static void gen_select_expr_macro_arg_ref(ast_node *ast);
 static void gen_expr_at_id(ast_node *ast, CSTR op, int32_t pri, int32_t pri_new);
 static void gen_select_expr(ast_node *ast);
+static void gen_arg_list(ast_node *ast);
 
 static int32_t gen_indent = 0;
 static int32_t pending_indent = 0;
@@ -874,7 +875,14 @@ static void gen_binary_no_spaces(ast_node *ast, CSTR op, int32_t pri, int32_t pr
   if (pri_new < pri) gen_printf("(");
   gen_expr(ast->left, pri_new);
   gen_printf("%s", op);
-  gen_expr(ast->right, pri_new + 1);
+  if (is_ast_arg_list(ast->right)) {
+    gen_printf("(");
+    gen_arg_list(ast->right);
+    gen_printf(")");
+  }
+  else {
+    gen_expr(ast->right, pri_new + 1);
+  }
   if (pri_new < pri) gen_printf(")");
 }
 

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -875,7 +875,7 @@ static void gen_binary_no_spaces(ast_node *ast, CSTR op, int32_t pri, int32_t pr
   if (pri_new < pri) gen_printf("(");
   gen_expr(ast->left, pri_new);
   gen_printf("%s", op);
-  if (is_ast_arg_list(ast->right)) {
+  if (is_ast_reverse_apply_poly_args(ast)) {
     gen_printf("(");
     gen_arg_list(ast->right);
     gen_printf(")");
@@ -5630,6 +5630,7 @@ cql_noexport void gen_init() {
   EXPR_INIT(reverse_apply, gen_binary_no_spaces, ":", EXPR_PRI_REVERSE_APPLY);
   EXPR_INIT(reverse_apply_typed, gen_binary_no_spaces, "::", EXPR_PRI_REVERSE_APPLY);
   EXPR_INIT(reverse_apply_poly, gen_binary_no_spaces, ":::", EXPR_PRI_REVERSE_APPLY);
+  EXPR_INIT(reverse_apply_poly_args, gen_binary_no_spaces, ":", EXPR_PRI_REVERSE_APPLY);
 }
 
 cql_export void gen_cleanup() {

--- a/sources/rewrite.c
+++ b/sources/rewrite.c
@@ -1061,7 +1061,7 @@ cql_noexport void rewrite_reverse_apply(ast_node *_Nonnull head, CSTR op) {
 // Create a new call node using these two and the argument passed in
 // prior to the ':' symbol.
 cql_noexport void rewrite_reverse_apply_polymorphic(ast_node *_Nonnull head) {
-  Contract(is_ast_reverse_apply(head));
+  Contract(is_ast_reverse_apply_poly_args(head));
   EXTRACT_ANY_NOTNULL(argument, head->left);
   EXTRACT(arg_list, head->right);
 
@@ -1072,12 +1072,10 @@ cql_noexport void rewrite_reverse_apply_polymorphic(ast_node *_Nonnull head) {
 
   CHARBUF_OPEN(new_name);
 
-  if (!argument->sem->kind || !argument->sem->kind[0]) {
-    bprintf(&new_name, "%s", rewrite_type_suffix(sem_type));
-  }
-  else {
-    bprintf(&new_name, "%s_%s", rewrite_type_suffix(sem_type), argument->sem->kind);
-  }
+  Contract(argument->sem);
+  Contract(argument->sem->kind);
+
+  bprintf(&new_name, "%s_%s", rewrite_type_suffix(sem_type), argument->sem->kind);
 
   ast_node *item = arg_list;
   while (item) {

--- a/sources/rewrite.c
+++ b/sources/rewrite.c
@@ -1057,6 +1057,58 @@ cql_noexport void rewrite_reverse_apply(ast_node *_Nonnull head, CSTR op) {
   head->type = new_call->type;
 }
 
+// Walk through the ast and grab the arg list as well as the function name.
+// Create a new call node using these two and the argument passed in
+// prior to the ':' symbol.
+cql_noexport void rewrite_reverse_apply_polymorphic(ast_node *_Nonnull head) {
+  Contract(is_ast_reverse_apply(head));
+  EXTRACT_ANY_NOTNULL(argument, head->left);
+  EXTRACT(arg_list, head->right);
+
+  AST_REWRITE_INFO_SET(head->lineno, head->filename);
+
+  // This is the ::: case where we use type and kind
+  sem_t sem_type = core_type_of(argument->sem->sem_type);
+
+  CHARBUF_OPEN(new_name);
+
+  if (!argument->sem->kind || !argument->sem->kind[0]) {
+    bprintf(&new_name, "%s", rewrite_type_suffix(sem_type));
+  }
+  else {
+    bprintf(&new_name, "%s_%s", rewrite_type_suffix(sem_type), argument->sem->kind);
+  }
+
+  ast_node *item = arg_list;
+  while (item) {
+    EXTRACT_ANY_NOTNULL(arg, item->left);
+
+    bprintf(&new_name, "_%s", rewrite_type_suffix(arg->sem->sem_type));
+    item = item->right;
+  }
+
+  // we need to remove any internal space
+  rewrite_replace_space_if_needed(new_name.ptr);
+
+  // further changes would be invalid, the string has escaped into the tree
+  ast_node *function_name = new_ast_str(Strdup(new_name.ptr));
+
+  CHARBUF_CLOSE(new_name);
+
+  ast_node *new_arg_list =
+    new_ast_call_arg_list(
+      new_ast_call_filter_clause(NULL, NULL),
+      new_ast_arg_list(argument, arg_list)
+    );
+  ast_node *new_call = new_ast_call(function_name, new_arg_list);
+
+  AST_REWRITE_INFO_RESET();
+
+  ast_set_right(head, new_call->right);
+  ast_set_left(head, new_call->left);
+  head->type = new_call->type;
+}
+
 // Walk the param list looking for any of the "like T" forms
 // if any is found, replace that parameter with the table/shape columns
 cql_noexport void rewrite_params(ast_node *head, bytebuf *args_info) {

--- a/sources/rewrite.h
+++ b/sources/rewrite.h
@@ -49,6 +49,7 @@ cql_noexport void rewrite_out_union_parent_child_stmt(ast_node *_Nonnull ast);
 cql_noexport void rewrite_shared_fragment_from_backed_table(ast_node *_Nonnull backed_table);
 cql_noexport void rewrite_select_for_backed_tables(ast_node *_Nonnull stmt, list_item *_Nonnull backed_tables_list);
 cql_noexport void rewrite_reverse_apply(ast_node *_Nonnull head, CSTR _Nonnull op);
+cql_noexport void rewrite_reverse_apply_polymorphic(ast_node *_Nonnull head);
 cql_noexport void rewrite_insert_statement_for_backed_table(ast_node *_Nonnull ast, list_item *_Nullable backed_tables_list);
 cql_noexport void rewrite_delete_statement_for_backed_table(ast_node *_Nonnull ast, list_item *_Nullable backed_tables_list);
 cql_noexport void rewrite_update_statement_for_backed_table(ast_node *_Nonnull ast, list_item *_Nullable backed_tables_list);

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -10826,12 +10826,13 @@ static bool_t sem_reverse_apply_if_needed(ast_node *ast, bool_t analyze) {
       hard_fail = is_error(ast->left);
     }
     if (!hard_fail) {
-      if (ast->right && is_ast_arg_list(ast->right)) {
+      if (is_ast_reverse_apply_poly_args(ast)) {
         EXTRACT_ANY_NOTNULL(arg, ast->left);
         EXTRACT_ANY(arg_list, ast->right);
 
         if (!arg->sem->kind || !arg->sem->kind[0]) {
-          report_error(arg, "left argument must have a type kind", NULL);
+          report_error(arg, "CQL0506: left argument must have a type kind", NULL);
+          record_error(ast);
           return true;
         }
 
@@ -10863,7 +10864,7 @@ static bool_t sem_reverse_apply_if_needed(ast_node *ast, bool_t analyze) {
 
 // Validates the right arg of ':', '::' and then rewrites the ast node
 static void sem_reverse_apply(ast_node *ast, CSTR op) {
-  Contract(is_ast_reverse_apply(ast) || is_ast_reverse_apply_typed(ast) || is_ast_reverse_apply_poly(ast));
+  Contract(is_ast_reverse_apply(ast) || is_ast_reverse_apply_typed(ast) || is_ast_reverse_apply_poly(ast) || is_ast_reverse_apply_poly_args(ast));
   bool_t failed = sem_reverse_apply_if_needed(ast, SEM_REVERSE_APPLY_ANALYZE_CALL);
   if (failed) {
     // error already reported if any
@@ -26155,6 +26156,7 @@ cql_noexport void sem_main(ast_node *ast) {
   EXPR_INIT(reverse_apply, sem_reverse_apply, ":");
   EXPR_INIT(reverse_apply_typed, sem_reverse_apply, "::");
   EXPR_INIT(reverse_apply_poly, sem_reverse_apply, ":::");
+  EXPR_INIT(reverse_apply_poly_args, sem_reverse_apply, ":");
   EXPR_INIT(expr_assign, sem_expr_invalid_op, ":=");
   EXPR_INIT(add_eq, sem_expr_invalid_op, "+=");
   EXPR_INIT(sub_eq, sem_expr_invalid_op, "-=");

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1762,4 +1762,6 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0081: aggregates only make sense i
 test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'json_group_object'
 test/sem_test.sql:XXXX:1: error: in call : CQL0081: aggregates only make sense if there is a FROM clause 'json_group_object'
 test/sem_test.sql:XXXX:1: error: in call : CQL0081: aggregates only make sense if there is a FROM clause 'jsonb_group_object'
+test/sem_test.sql:XXXX:1: error: in num : CQL0506: left argument must have a type kind
+test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
 semantic errors present; no code gen.

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -93404,3 +93404,170 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0081: aggregates only make sense i
     | {select_limit}
       | {select_offset}
 
+The statement ending at line XXXX
+
+DECLARE FUNC new_builder () CREATE OBJECT<list_builder>;
+
+  {declare_func_stmt}: object<list_builder> create_func
+  | {name new_builder}: object<list_builder> create_func
+  | {func_params_return}
+    | {create_data_type}: object<list_builder> create_func
+      | {type_object}: object<list_builder>
+        | {name list_builder}
+
+The statement ending at line XXXX
+
+DECLARE FUNC object_list_builder_int (arg1 OBJECT<list_builder>, arg2 INT!) OBJECT<list_builder>;
+
+  {declare_func_stmt}: object<list_builder>
+  | {name object_list_builder_int}: object<list_builder>
+  | {func_params_return}
+    | {params}: ok
+    | | {param}: arg1: object<list_builder> variable in
+    | | | {param_detail}: arg1: object<list_builder> variable in
+    | |   | {name arg1}: arg1: object<list_builder> variable in
+    | |   | {type_object}: object<list_builder>
+    | |     | {name list_builder}
+    | | {params}
+    |   | {param}: arg2: integer notnull variable in
+    |     | {param_detail}: arg2: integer notnull variable in
+    |       | {name arg2}: arg2: integer notnull variable in
+    |       | {notnull}: integer notnull
+    |         | {type_int}: integer
+    | {type_object}: object<list_builder>
+      | {name list_builder}
+
+The statement ending at line XXXX
+
+DECLARE FUNC object_list_builder_int_int (arg1 OBJECT<list_builder>, arg2 INT!, arg3 INT!) OBJECT<list_builder>;
+
+  {declare_func_stmt}: object<list_builder>
+  | {name object_list_builder_int_int}: object<list_builder>
+  | {func_params_return}
+    | {params}: ok
+    | | {param}: arg1: object<list_builder> variable in
+    | | | {param_detail}: arg1: object<list_builder> variable in
+    | |   | {name arg1}: arg1: object<list_builder> variable in
+    | |   | {type_object}: object<list_builder>
+    | |     | {name list_builder}
+    | | {params}
+    |   | {param}: arg2: integer notnull variable in
+    |   | | {param_detail}: arg2: integer notnull variable in
+    |   |   | {name arg2}: arg2: integer notnull variable in
+    |   |   | {notnull}: integer notnull
+    |   |     | {type_int}: integer
+    |   | {params}
+    |     | {param}: arg3: integer notnull variable in
+    |       | {param_detail}: arg3: integer notnull variable in
+    |         | {name arg3}: arg3: integer notnull variable in
+    |         | {notnull}: integer notnull
+    |           | {type_int}: integer
+    | {type_object}: object<list_builder>
+      | {name list_builder}
+
+The statement ending at line XXXX
+
+DECLARE FUNC object_list_builder_real (arg1 OBJECT<list_builder>, arg2 REAL!) OBJECT<list_builder>;
+
+  {declare_func_stmt}: object<list_builder>
+  | {name object_list_builder_real}: object<list_builder>
+  | {func_params_return}
+    | {params}: ok
+    | | {param}: arg1: object<list_builder> variable in
+    | | | {param_detail}: arg1: object<list_builder> variable in
+    | |   | {name arg1}: arg1: object<list_builder> variable in
+    | |   | {type_object}: object<list_builder>
+    | |     | {name list_builder}
+    | | {params}
+    |   | {param}: arg2: real notnull variable in
+    |     | {param_detail}: arg2: real notnull variable in
+    |       | {name arg2}: arg2: real notnull variable in
+    |       | {notnull}: real notnull
+    |         | {type_real}: real
+    | {type_object}: object<list_builder>
+      | {name list_builder}
+
+The statement ending at line XXXX
+
+DECLARE FUNC to_list_object_list_builder (arg1 OBJECT<list_builder>) CREATE OBJECT<list>;
+
+  {declare_func_stmt}: object<list> create_func
+  | {name to_list_object_list_builder}: object<list> create_func
+  | {func_params_return}
+    | {params}: ok
+    | | {param}: arg1: object<list_builder> variable in
+    |   | {param_detail}: arg1: object<list_builder> variable in
+    |     | {name arg1}: arg1: object<list_builder> variable in
+    |     | {type_object}: object<list_builder>
+    |       | {name list_builder}
+    | {create_data_type}: object<list> create_func
+      | {type_object}: object<list>
+        | {name list}
+
+The statement ending at line XXXX
+
+LET list_result := to_list_object_list_builder(object_list_builder_int_int(object_list_builder_real(object_list_builder_int(new_builder(), 5), 7.0), 1, 2));
+
+  {let_stmt}: list_result: object<list> variable
+  | {name list_result}: list_result: object<list> variable
+  | {call}: object<list> create_func
+    | {name to_list_object_list_builder}
+    | {call_arg_list}
+      | {call_filter_clause}
+      | {arg_list}: ok
+        | {call}: object<list_builder>
+          | {name object_list_builder_int_int}
+          | {call_arg_list}
+            | {call_filter_clause}
+            | {arg_list}: ok
+              | {call}: object<list_builder>
+              | | {name object_list_builder_real}
+              | | {call_arg_list}
+              |   | {call_filter_clause}
+              |   | {arg_list}: ok
+              |     | {call}: object<list_builder>
+              |     | | {name object_list_builder_int}
+              |     | | {call_arg_list}
+              |     |   | {call_filter_clause}
+              |     |   | {arg_list}: ok
+              |     |     | {call}: object<list_builder> create_func
+              |     |     | | {name new_builder}
+              |     |     | | {call_arg_list}
+              |     |     |   | {call_filter_clause}
+              |     |     | {arg_list}: ok
+              |     |       | {int 5}: integer notnull
+              |     | {arg_list}: ok
+              |       | {dbl 7.0}: real notnull
+              | {arg_list}: ok
+                | {int 1}: integer notnull
+                | {arg_list}
+                  | {int 2}: integer notnull
+
+The statement ending at line XXXX
+
+LET r := 1:();
+
+test/sem_test.sql:XXXX:1: error: in num : CQL0506: left argument must have a type kind
+
+  {let_stmt}: err
+  | {name r}
+  | {reverse_apply_poly_args}: err
+    | {int 1}: integer notnull
+
+The statement ending at line XXXX
+
+LET r := new_builder():(NOT 'x');
+
+test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in 'NOT'
+
+  {let_stmt}: err
+  | {name r}
+  | {reverse_apply_poly_args}: err
+    | {call}: object<list_builder> create_func
+    | | {name new_builder}
+    | | {call_arg_list}
+    |   | {call_filter_clause}
+    | {arg_list}: err
+      | {not}: err
+        | {strlit 'x'}: text notnull
+

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -24910,3 +24910,25 @@ select json_group_object();
 -- + {call}: err
 -- * error: % aggregates only make sense if there is a FROM clause 'jsonb_group_object'
 select jsonb_group_object();
+
+declare function new_builder() create object<list_builder>;
+declare function object_list_builder_int(arg1 object<list_builder>, arg2 int!) object<list_builder>;
+declare function object_list_builder_int_int(arg1 object<list_builder>, arg2 int!, arg3 int!) object<list_builder>;
+declare function object_list_builder_real(arg1 object<list_builder>, arg2 real!) object<list_builder>;
+declare function to_list_object_list_builder(arg1 object<list_builder>) create object<list>;
+
+-- TEST: multiple rewrites based on the builder pattern above
+-- verify rewrite only
+-- + LET list_result := to_list_object_list_builder(object_list_builder_int_int(object_list_builder_real(object_list_builder_int(new_builder(), 5), 7.0), 1, 2));
+let list_result := new_builder():(5):(7.0):(1,2):::to_list();
+
+-- TEST: no kind specified in the left arg
+-- + reverse_apply_poly_args}: err
+-- * error: % left argument must have a type kind
+let r := 1:();
+
+-- TEST: poly args with invalid arg list
+-- + reverse_apply_poly_args}: err
+-- + {arg_list}: err
+-- * error: % string operand not allowed in 'NOT'
+let r := new_builder():(not 'x');

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -2372,3 +2372,5 @@ SELECT *
 '{ "x" : 1}' -> '$.x';
 
 '{ "x" : 1}' ->> :INT: '$.x';
+
+LET list := new_builder():(5):(7.0):(1, 2):::to_list();

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1823,3 +1823,6 @@ with foo as (select 1 x, '2' y)
 -- JSON extraction operators
 '{ "x" : 1}' -> '$.x';
 '{ "x" : 1}' ->> :int: '$.x';
+
+-- polymorphic function call syntax
+let list := new_builder():(5):(7.0):(1,2):::to_list();

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -2390,3 +2390,5 @@ SELECT *
 '{ "x" : 1}' -> '$.x';
 
 '{ "x" : 1}' ->> :INT: '$.x';
+
+LET list := new_builder():(5):(7.0):(1, 2):::to_list();


### PR DESCRIPTION
The idea is that in this form the type of the arguments becomes part of the rewritten function call.  This can include more than one argument type.

Here is an example that could build a list for you:

```
declare function new_builder() create object<list_builder>;
declare function object_list_builder_int(arg1 object<list_builder>, arg2 int!) object<list_builder>;
declare function object_list_builder_int_int(arg1 object<list_builder>, arg2 int!, arg3 int!) object<list_builder>;
declare function object_list_builder_real(arg1 object<list_builder>, arg2 real!) object<list_builder>;
declare function to_list_object_list_builder(arg1 object<list_builder>) create object<list>;

let list := new_builder():(5):(7.0):(1,2):::to_list();
```

This expands to the much less readable:

```
LET list := 
  to_list_object_list_builder(
    object_list_builder_int_int(
      object_list_builder_real(
        object_list_builder_int(
          new_builder(), 5), 7.0), 1, 2));
```

You can use this to build helper functions that assemble text, arrays, JSON and many other uses.  Anywhere the fluent pattern is helpful this gives you a strong weapon.