### PR TITLE
Cleaner macros -- the tree-sitter way

### DIFF
--- a/scripts/grammar_utils/tree_sitter.py
+++ b/scripts/grammar_utils/tree_sitter.py
@@ -156,27 +156,6 @@ FIXED_RULES = """
        seq('--', /(\\\\(.|\\r?\\n)|[^\\\\\\n])*/),
        seq('/*', /[^*]*\*+([^/*][^*]*\*+)*/, '/'))),
 
-    non_expr_macro_ref: $ => choice(
-      $.stmt_list_macro_ref,
-      $.cte_tables_macro_ref,
-      $.select_core_macro_ref,
-      $.select_expr_macro_ref,
-      $.query_parts_macro_ref),
-
-    expr_macro_ref: $ => prec.left(1,choice(
-      seq($.name, '!'),
-      seq($.name, '!', '(', optional($.macro_args), ')'),
-      seq($.basic_expr, ':', $.name, '!', '(', optional($.macro_args), ')'),
-      seq($.basic_expr, ':', $.name, '!'))),
-
-    macro_ref: $ => choice(seq($.name, '!'), seq($.name, '!', '(', optional($.macro_args), ')')),
-
-    query_parts_macro_ref: $ => prec(1, $.macro_ref),
-    cte_tables_macro_ref: $ => prec(2, $.macro_ref),
-    select_core_macro_ref: $ => prec(3, $.macro_ref),
-    select_expr_macro_ref: $ => prec(4, $.macro_ref),
-    stmt_list_macro_ref: $ => prec(5, $.macro_ref),
-
     stmt_list: $ => repeat1(choice($.stmt, $.include_stmt, $.comment)),
 """
 
@@ -199,18 +178,11 @@ DELETED_PRODUCTIONS = {
     "ELSE_IF",
     "ID!",
     "`quoted_identifier`",
-    "cte_tables_macro_ref",
     "end_of_included_file",
-    "expr_macro_ref",
     "include_section",
     "include_stmts",
-    "non_expr_macro_ref",
     "program",
-    "query_parts_macro_ref",
-    "select_core_macro_ref",
-    "select_expr_macro_ref",
     "stmt_list",
-    "stmt_list_macro_ref",
     "top_level_stmts",
 }
 

--- a/sources/ast.c
+++ b/sources/ast.c
@@ -1384,7 +1384,7 @@ cql_noexport CSTR install_macro_args(ast_node *macro_formals) {
 // different sizes so we have to use the more general mechanism.
 // This means we might have to refetch parent->left or right
 // to get the new value of the node.
-static ast_node *replace_node(ast_node *old, ast_node *new) {
+static void replace_node(ast_node *old, ast_node *new) {
   if (old->parent->left == old) {
    ast_set_left(old->parent, new);
   }

--- a/sources/ast.c
+++ b/sources/ast.c
@@ -1820,6 +1820,22 @@ tail_recurse:
     // so we can attribute the AST better
     node->lineno = macro_state.line;
   }
+
+  if (is_ast_ifdef_stmt(node) || is_ast_ifndef_stmt(node)) {
+    EXTRACT_ANY_NOTNULL(evaluation, node->left);
+    EXTRACT_NOTNULL(pre, node->right);
+
+    if (is_ast_is_true(evaluation)) {
+       node = pre->left;
+    }
+    else {
+       node = pre->right;
+    }
+    if (node)
+      goto tail_recurse;
+    return;
+  }
+
   // do not recurse into macro definitions
   if (is_macro_def(node)) {
     return;

--- a/sources/ast.c
+++ b/sources/ast.c
@@ -1687,6 +1687,11 @@ static void expand_macro_refs(ast_node *ast) {
     minfo = get_macro_arg_info(name);
   }
 
+  if (!minfo) {
+    report_macro_error(ast, "macro reference is not a valid macro", name);
+    return;
+  }
+
   Invariant(minfo);
   ast_node *copy = ast_clone_tree(minfo->def);
   ast_node *body = NULL;

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -199,6 +199,7 @@ cql_noexport bool_t set_macro_arg_info(CSTR _Nonnull name, int32_t macro_type, a
 cql_noexport macro_info *_Nullable get_macro_arg_info(CSTR _Nonnull name);
 cql_noexport macro_info *_Nullable get_macro_info(CSTR _Nonnull name);
 cql_noexport void expand_macros(ast_node *_Nonnull root);
+cql_noexport int32_t resolve_macro_name(_Nonnull CSTR name);
 
 // from the lexer
 extern int yylineno;
@@ -264,8 +265,7 @@ cql_noexport bool_t is_ast_num(ast_node *_Nullable node);
 cql_noexport bool_t is_ast_blob(ast_node *_Nullable node);
 
 cql_noexport bool_t is_any_macro_def(ast_node *_Nonnull ast);
-cql_noexport bool_t is_any_macro_arg_ref(ast_node *_Nonnull ast);
-cql_noexport bool_t is_any_macro_ref(ast_node *_Nonnull ast);
+cql_noexport bool_t is_any_macro_ref(ast_node *_Nullable ast);
 
 cql_noexport bool_t is_select_stmt(ast_node *_Nullable ast);
 cql_noexport bool_t is_delete_stmt(ast_node *_Nullable ast);
@@ -698,7 +698,6 @@ AST(cte_binding_list)
 AST(cte_decl)
 AST(cte_table)
 AST(cte_tables)
-AST(cte_tables_macro_arg_ref)
 AST(cte_tables_macro_def)
 AST(cte_tables_macro_ref)
 AST(declare_const_stmt)
@@ -736,8 +735,6 @@ AST(eq)
 AST(explain_stmt)
 AST(expr_assign)
 AST(expr_list)
-AST1(expr_macro_arg)
-AST(expr_macro_arg_ref)
 AST(expr_macro_def)
 AST(expr_macro_ref)
 AST(expr_name)
@@ -823,10 +820,12 @@ AST(out_union_parent_child_stmt)
 AST(param)
 AST(param_detail)
 AST(params)
-AST(pre)
 AST(pk_def)
+AST(pre)
 AST(proc_name_type)
 AST(proc_params_stmts)
+AST(query_parts_macro_def)
+AST(query_parts_macro_ref)
 AST(raise);
 AST(range)
 AST(recreate_attr)
@@ -837,21 +836,16 @@ AST(reverse_apply)
 AST(reverse_apply_poly_args)
 AST(rs_eq)
 AST(rshift)
-AST(query_parts_macro_arg_ref)
-AST(query_parts_macro_def)
-AST(query_parts_macro_ref)
 AST(schema_ad_hoc_migration_stmt);
 AST(seed_stub)
 AST(select_core)
 AST(select_core_compound)
 AST(select_core_list)
-AST(select_core_macro_arg_ref)
 AST(select_core_macro_def)
 AST(select_core_macro_ref)
 AST(select_expr)
 AST(select_expr_list)
 AST(select_expr_list_con)
-AST(select_expr_macro_arg_ref)
 AST(select_expr_macro_def)
 AST(select_expr_macro_ref)
 AST(select_from_etc)
@@ -873,7 +867,6 @@ AST(shape_exprs)
 AST(shared_cte)
 AST(stmt_and_attr)
 AST(stmt_list)
-AST(stmt_list_macro_arg_ref);
 AST(stmt_list_macro_def)
 AST(stmt_list_macro_ref);
 AST(str_chain)
@@ -900,6 +893,7 @@ AST(trycatch_stmt)
 AST(type_check_expr)
 AST(typed_name)
 AST(typed_names)
+AST(unknown_macro_ref)
 AST(unq_def)
 AST(update_cursor_stmt)
 AST(update_entry)
@@ -978,6 +972,7 @@ AST1(column_spec);
 AST1(const)
 AST1(create_data_type);
 AST1(cte_tables_macro_arg);
+AST1(cte_tables_macro_arg_ref)
 AST1(declare_out_call_stmt)
 AST1(declare_proc_no_check_stmt)
 AST1(desc)
@@ -988,6 +983,8 @@ AST1(emit_group_stmt)
 AST1(enforce_normal_stmt);
 AST1(enforce_strict_stmt);
 AST1(exists_expr)
+AST1(expr_macro_arg)
+AST1(expr_macro_arg_ref)
 AST1(expr_stmt)
 AST1(groupby_item)
 AST1(is_false)
@@ -1011,16 +1008,20 @@ AST1(out_stmt)
 AST1(out_union_stmt)
 AST1(proc_savepoint_stmt);
 AST1(query_parts_macro_arg);
+AST1(query_parts_macro_arg_ref)
 AST1(release_savepoint_stmt);
 AST1(rollback_trans_stmt);
 AST1(savepoint_stmt);
 AST1(schema_unsub_stmt);
 AST1(schema_upgrade_version_stmt);
 AST1(select_core_macro_arg);
+AST1(select_core_macro_arg_ref)
 AST1(select_expr_macro_arg);
+AST1(select_expr_macro_arg_ref)
 AST1(select_if_nothing_throw_expr)
 AST1(select_opts)
 AST1(stmt_list_macro_arg);
+AST1(stmt_list_macro_arg_ref);
 AST1(table_star)
 AST1(tilde)
 AST1(type_blob)
@@ -1031,6 +1032,7 @@ AST1(type_object)
 AST1(type_real)
 AST1(type_text)
 AST1(uminus)
+AST1(unknown_macro_arg_ref)
 AST1(window_clause)
 AST1(with)
 AST1(with_recursive)

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -200,7 +200,7 @@ cql_noexport macro_info *_Nullable get_macro_arg_info(CSTR _Nonnull name);
 cql_noexport macro_info *_Nullable get_macro_info(CSTR _Nonnull name);
 cql_noexport void expand_macros(ast_node *_Nonnull root);
 cql_noexport int32_t resolve_macro_name(_Nonnull CSTR name);
-cql_noexport ast_node *new_macro_arg_node(ast_node *_Nonnull arg);
+cql_noexport ast_node *_Nonnull new_macro_arg_node(ast_node *_Nonnull arg);
 
 // from the lexer
 extern int yylineno;

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -200,6 +200,7 @@ cql_noexport macro_info *_Nullable get_macro_arg_info(CSTR _Nonnull name);
 cql_noexport macro_info *_Nullable get_macro_info(CSTR _Nonnull name);
 cql_noexport void expand_macros(ast_node *_Nonnull root);
 cql_noexport int32_t resolve_macro_name(_Nonnull CSTR name);
+cql_noexport ast_node *new_macro_arg_node(ast_node *_Nonnull arg);
 
 // from the lexer
 extern int yylineno;
@@ -264,8 +265,10 @@ cql_noexport bool_t is_ast_str(ast_node *_Nullable node);
 cql_noexport bool_t is_ast_num(ast_node *_Nullable node);
 cql_noexport bool_t is_ast_blob(ast_node *_Nullable node);
 
-cql_noexport bool_t is_any_macro_def(ast_node *_Nonnull ast);
 cql_noexport bool_t is_any_macro_ref(ast_node *_Nullable ast);
+cql_noexport bool_t is_macro_def(ast_node *_Nonnull ast);
+cql_noexport bool_t is_macro_ref(ast_node *_Nullable ast);
+cql_noexport bool_t is_macro_arg_ref(ast_node *_Nullable ast);
 
 cql_noexport bool_t is_select_stmt(ast_node *_Nullable ast);
 cql_noexport bool_t is_delete_stmt(ast_node *_Nullable ast);
@@ -893,7 +896,9 @@ AST(trycatch_stmt)
 AST(type_check_expr)
 AST(typed_name)
 AST(typed_names)
+AST(unknown_macro_arg)
 AST(unknown_macro_ref)
+AST(unknown_macro_def)
 AST(unq_def)
 AST(update_cursor_stmt)
 AST(update_entry)
@@ -1040,4 +1045,3 @@ AST1(with_recursive)
 #ifndef _MSC_VER
 #pragma clang diagnostic pop
 #endif
-

--- a/sources/cql.h
+++ b/sources/cql.h
@@ -603,8 +603,7 @@ cql_noexport CSTR cql_builtin_text();
 cql_noexport void cql_setup_for_builtins(void);
 
 cql_noexport int32_t macro_type_from_str(CSTR type);
-
-cql_noexport bool_t macro_arg_valid(int32_t type, struct ast_node *ast);
+cql_noexport int32_t macro_arg_type(struct ast_node *ast);
 
 cql_noexport void cql_cleanup_open_includes(void);
 cql_noexport void cql_reset_open_includes(void);

--- a/sources/cql.l
+++ b/sources/cql.l
@@ -32,7 +32,6 @@ void line_directive(const char *);
 char *Strdup(const char *);
 static CSTR last_doc_comment = NULL;
 
-
 static bool_t cql_already_processed_file(CSTR);
 static void cql_record_processed_file(CSTR);
 

--- a/sources/cql.l
+++ b/sources/cql.l
@@ -33,7 +33,6 @@ char *Strdup(const char *);
 static CSTR last_doc_comment = NULL;
 
 
-cql_noexport int32_t resolve_macro_name(const char *);
 static bool_t cql_already_processed_file(CSTR);
 static void cql_record_processed_file(CSTR);
 
@@ -535,15 +534,6 @@ X'({hex}{hex})*'                 { yylval.sval = Strdup(yytext); return BLOBLIT;
 \{                               { return yytext[0]; }
 \}                               { return yytext[0]; }
 {id}                             { yylval.sval = Strdup(yytext); return ID; }
-{id}!                            { int32_t result = resolve_macro_name(yytext);
-                                   if (result == EOF) {
-                                     REJECT;
-                                   }
-                                   else {
-                                     yylval.sval = Strdup(yytext);
-                                   }
-                                   return result;
-                                 }
 
 [ \t\r\n]                        ;
 \-\-.*                           ;

--- a/sources/cql.l
+++ b/sources/cql.l
@@ -1,10 +1,6 @@
-%option noyywrap nodefault yylineno case-insensitive never-interactive
+%option noyywrap yylineno case-insensitive never-interactive
 
 %x at_inc
-%x skipping
-%x skipping_c_comment
-%x ifdef
-%x ifndef
 
 %{
 

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -144,25 +144,17 @@ void yyrestart(FILE *);
 
 // if macro arg found that's an error, it should be a macro
 #define YY_ERROR_ON_MACRO_ARG(x) \
-  if (get_macro_arg_info(x)) yyerror("expected a defined macro not a macro formal.");
+  if (get_macro_arg_info(x) && !get_macro_info(x)) yyerror("expected a defined macro not a macro formal.");
 
 // if macro arg not found that's an error, it shouldn't be a macro, it should be an arg
 #define YY_ERROR_ON_MACRO(x) \
-  if (!get_macro_arg_info(x)) yyerror("expected a defined macro formal not a macro.");
+  if (!get_macro_arg_info(x) && get_macro_info(x)) yyerror("expected a defined macro formal not a macro.");
 
 #define YY_ERROR_ON_FAILED_ADD_MACRO(success, name) \
   if (!success) { yyerror(dup_printf("macro already exists '%s'.", name)); }
 
 #define YY_ERROR_ON_FAILED_MACRO_ARG(name) \
   if (name) { yyerror(dup_printf("macro argument already exists '%s'.", name)); }
-
-#define YY_ERROR_ON_CONDITIONAL_MACRO(name) \
- if (cql_ifdef_state) { \
-   yyerror( \
-     dup_printf( \
-       "macro '%s!' is inside an @if[n]def; Put the @if[n]def inside the macro instead.", \
-       name)); \
- }
 
 // We insert calls to `cql_inferred_notnull` as part of a rewrite so we expect
 // to see it during semantic analysis, but it cannot be allowed to appear in a
@@ -2616,22 +2608,22 @@ expr_macro_def:
     CSTR bad_name = install_macro_args($opt_macro_formals);
     YY_ERROR_ON_FAILED_MACRO_ARG(bad_name);
     $$ = new_ast_expr_macro_def(new_ast_macro_name_formals($name, $opt_macro_formals), NULL);
-    EXTRACT_STRING(name, $name);
-    YY_ERROR_ON_CONDITIONAL_MACRO(name);
-    bool_t success = set_macro_info(name, EXPR_MACRO, $expr_macro_def);
-    YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
-    }
+    if (is_processing()) {
+      EXTRACT_STRING(name, $name);
+      bool_t success = set_macro_info(name, EXPR_MACRO, $expr_macro_def);
+      YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
+    } }
 
 stmt_list_macro_def:
   AT_MACRO '(' STMT_LIST ')' name '!' '(' opt_macro_formals ')' {
     CSTR bad_name = install_macro_args($opt_macro_formals);
     YY_ERROR_ON_FAILED_MACRO_ARG(bad_name);
     $$ = new_ast_stmt_list_macro_def(new_ast_macro_name_formals($name, $opt_macro_formals), NULL);
-    EXTRACT_STRING(name, $name);
-    YY_ERROR_ON_CONDITIONAL_MACRO(name);
-    bool_t success = set_macro_info(name, STMT_LIST_MACRO, $stmt_list_macro_def);
-    YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
-    }
+    if (is_processing()) {
+      EXTRACT_STRING(name, $name);
+      bool_t success = set_macro_info(name, STMT_LIST_MACRO, $stmt_list_macro_def);
+      YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
+    } }
   ;
 
 query_parts_macro_def:
@@ -2639,11 +2631,11 @@ query_parts_macro_def:
     CSTR bad_name = install_macro_args($opt_macro_formals);
     YY_ERROR_ON_FAILED_MACRO_ARG(bad_name);
     $$ = new_ast_query_parts_macro_def(new_ast_macro_name_formals($name, $opt_macro_formals), NULL);
-    EXTRACT_STRING(name, $name);
-    YY_ERROR_ON_CONDITIONAL_MACRO(name);
-    bool_t success = set_macro_info(name, QUERY_PARTS_MACRO, $query_parts_macro_def);
-    YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
-    }
+    if (is_processing()) {
+      EXTRACT_STRING(name, $name);
+      bool_t success = set_macro_info(name, QUERY_PARTS_MACRO, $query_parts_macro_def);
+      YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
+    } }
   ;
 
 cte_tables_macro_def:
@@ -2651,11 +2643,11 @@ cte_tables_macro_def:
     CSTR bad_name = install_macro_args($opt_macro_formals);
     YY_ERROR_ON_FAILED_MACRO_ARG(bad_name);
     $$ = new_ast_cte_tables_macro_def(new_ast_macro_name_formals($name, $opt_macro_formals), NULL);
-    EXTRACT_STRING(name, $name);
-    YY_ERROR_ON_CONDITIONAL_MACRO(name);
-    bool_t success = set_macro_info(name, CTE_TABLES_MACRO, $cte_tables_macro_def);
-    YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
-    }
+    if (is_processing()) {
+      EXTRACT_STRING(name, $name);
+      bool_t success = set_macro_info(name, CTE_TABLES_MACRO, $cte_tables_macro_def);
+      YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
+    } }
   ;
 
 select_core_macro_def:
@@ -2663,11 +2655,11 @@ select_core_macro_def:
     CSTR bad_name = install_macro_args($opt_macro_formals);
     YY_ERROR_ON_FAILED_MACRO_ARG(bad_name);
     $$ = new_ast_select_core_macro_def(new_ast_macro_name_formals($name, $opt_macro_formals), NULL);
-    EXTRACT_STRING(name, $name);
-    YY_ERROR_ON_CONDITIONAL_MACRO(name);
-    bool_t success = set_macro_info(name, SELECT_CORE_MACRO, $select_core_macro_def);
-    YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
-    }
+    if (is_processing()) {
+      EXTRACT_STRING(name, $name);
+      bool_t success = set_macro_info(name, SELECT_CORE_MACRO, $select_core_macro_def);
+      YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
+    } }
   ;
 
 select_expr_macro_def:
@@ -2675,11 +2667,11 @@ select_expr_macro_def:
     CSTR bad_name = install_macro_args($opt_macro_formals);
     YY_ERROR_ON_FAILED_MACRO_ARG(bad_name);
     $$ = new_ast_select_expr_macro_def(new_ast_macro_name_formals($name, $opt_macro_formals), NULL);
-    EXTRACT_STRING(name, $name);
-    YY_ERROR_ON_CONDITIONAL_MACRO(name);
-    bool_t success = set_macro_info(name, SELECT_EXPR_MACRO, $select_expr_macro_def);
-    YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
-    }
+    if (is_processing()) {
+      EXTRACT_STRING(name, $name);
+      bool_t success = set_macro_info(name, SELECT_EXPR_MACRO, $select_expr_macro_def);
+      YY_ERROR_ON_FAILED_ADD_MACRO(success, name);
+    } }
   ;
 
 op_stmt: AT_OP data_type_any ':' loose_name[op] loose_name_or_type[func] AS loose_name[targ] {
@@ -3693,7 +3685,7 @@ static ast_node *macro_arg_ref_node(CSTR name) {
     case SELECT_CORE_MACRO:  return new_ast_select_core_macro_arg_ref(id);
     case SELECT_EXPR_MACRO:  return new_ast_select_expr_macro_arg_ref(id);
   }
-  return new_ast_unknown_macro_ref(id, NULL);
+  return new_ast_unknown_macro_arg_ref(id);
 }
 
 static ast_node *macro_ref_node(CSTR name, ast_node *args) {
@@ -3786,9 +3778,7 @@ static ast_node *do_ifndef(ast_node *ast) {
 }
 
 static void do_else() {
-  if (cql_ifdef_state && cql_ifdef_state->process_else) {
-   cql_ifdef_state->processing = true;
-  }
+  cql_ifdef_state->processing = cql_ifdef_state && cql_ifdef_state->process_else;
 }
 
 static void do_endif() {

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -82,6 +82,8 @@ static ast_node *do_ifndef(ast_node *ast);
 static void do_endif(void);
 static void do_else(void);
 static bool_t is_processing(void);
+static ast_node *macro_ref_node(CSTR name, ast_node *args);
+static ast_node *macro_arg_ref_node(CSTR name);
 
 // The stack needed is modest (32k) and this prevents leaks in error cases because
 // it's just a stack alloc.
@@ -238,7 +240,7 @@ static void cql_reset_globals(void);
 %left NOT
 %left BETWEEN NOT_BETWEEN NE NE_ '=' EQEQ LIKE NOT_LIKE GLOB NOT_GLOB MATCH NOT_MATCH REGEXP NOT_REGEXP IN NOT_IN IS_NOT IS IS_TRUE IS_FALSE IS_NOT_TRUE IS_NOT_FALSE
 %left ISNULL NOTNULL
-%left '<' '>' GE LE 
+%left '<' '>' GE LE
 %left LS RS '&' '|'
 %left '+' '-'
 %left '*' '/' '%'
@@ -352,10 +354,10 @@ static void cql_reset_globals(void);
 %type <aval> create_proc_stmt declare_func_stmt declare_select_func_stmt declare_proc_stmt declare_interface_stmt declare_proc_no_check_stmt declare_out_call_stmt
 %type <aval> arg_expr arg_list arg_exprs inout param params func_params func_param
 %type <aval> macro_def_stmt opt_macro_args macro_args macro_arg op_stmt
-%type <aval> opt_macro_formals macro_formals macro_formal macro_type non_expr_macro_ref
+%type <aval> opt_macro_formals macro_formals macro_formal macro_type
 %type <aval> top_level_stmts include_stmts include_section
 %type <aval> stmt_list_macro_def expr_macro_def query_parts_macro_def cte_tables_macro_def select_core_macro_def select_expr_macro_def
-%type <aval> stmt_list_macro_ref expr_macro_ref query_parts_macro_ref cte_tables_macro_ref select_core_macro_ref select_expr_macro_ref
+%type <aval> macro_ref
 
 
 /* statements */
@@ -482,74 +484,13 @@ opt_stmt_list:
   | stmt_list  { $opt_stmt_list = $stmt_list; }
   ;
 
-non_expr_macro_ref:
-  stmt_list_macro_ref  { $$ = $1; }
-  | cte_tables_macro_ref { $$ = $1; }
-  | select_core_macro_ref { $$ = $1; }
-  | select_expr_macro_ref { $$ = $1; }
-  | query_parts_macro_ref { $$ = $1; }
-  ;
-
-stmt_list_macro_ref:
-  STMT_LIST_MACRO {
-    YY_ERROR_ON_MACRO($STMT_LIST_MACRO);
-    $$ = new_ast_stmt_list_macro_arg_ref(new_ast_str($STMT_LIST_MACRO), NULL); }
-  | STMT_LIST_MACRO '(' opt_macro_args ')' {
-    YY_ERROR_ON_MACRO_ARG($STMT_LIST_MACRO);
-    $$ = new_ast_stmt_list_macro_ref(new_ast_str($STMT_LIST_MACRO), $opt_macro_args); }
-  ;
-
-expr_macro_ref:
-  EXPR_MACRO {
-    YY_ERROR_ON_MACRO($EXPR_MACRO);
-    $$ = new_ast_expr_macro_arg_ref(new_ast_str($EXPR_MACRO), NULL); }
-  | EXPR_MACRO '(' opt_macro_args ')' {
-    YY_ERROR_ON_MACRO_ARG($EXPR_MACRO);
-    $$ = new_ast_expr_macro_ref(new_ast_str($EXPR_MACRO), $opt_macro_args); }
-  | basic_expr ':' EXPR_MACRO '(' opt_macro_args ')' {
-      ast_node *macro_arg = new_ast_expr_macro_arg($basic_expr);
-      ast_node *macro_args = new_ast_macro_args(macro_arg, $opt_macro_args);
-      $$ = new_ast_expr_macro_ref(new_ast_str($EXPR_MACRO), macro_args); }
-  | basic_expr ':' EXPR_MACRO {
-      ast_node *macro_arg = new_ast_expr_macro_arg($basic_expr);
-      ast_node *macro_args = new_ast_macro_args(macro_arg, NULL);
-      $$ = new_ast_expr_macro_ref(new_ast_str($EXPR_MACRO), macro_args); }
-  ;
-
-query_parts_macro_ref:
-  QUERY_PARTS_MACRO {
-    YY_ERROR_ON_MACRO($QUERY_PARTS_MACRO);
-    $$ = new_ast_query_parts_macro_arg_ref(new_ast_str($QUERY_PARTS_MACRO), NULL); }
-  | QUERY_PARTS_MACRO '(' opt_macro_args ')' {
-    YY_ERROR_ON_MACRO_ARG($QUERY_PARTS_MACRO);
-    $$ = new_ast_query_parts_macro_ref(new_ast_str($QUERY_PARTS_MACRO), $opt_macro_args); }
-  ;
-
-cte_tables_macro_ref:
-  CTE_TABLES_MACRO {
-    YY_ERROR_ON_MACRO($CTE_TABLES_MACRO);
-    $$ = new_ast_cte_tables_macro_arg_ref(new_ast_str($CTE_TABLES_MACRO), NULL); }
-  | CTE_TABLES_MACRO '(' opt_macro_args ')' {
-    YY_ERROR_ON_MACRO_ARG($CTE_TABLES_MACRO);
-    $$ = new_ast_cte_tables_macro_ref(new_ast_str($CTE_TABLES_MACRO), $opt_macro_args); }
-  ;
-
-select_core_macro_ref:
-  SELECT_CORE_MACRO {
-    YY_ERROR_ON_MACRO($SELECT_CORE_MACRO);
-    $$ = new_ast_select_core_macro_arg_ref(new_ast_str($SELECT_CORE_MACRO), NULL); }
-  | SELECT_CORE_MACRO '(' opt_macro_args ')' {
-    YY_ERROR_ON_MACRO_ARG($SELECT_CORE_MACRO);
-    $$ = new_ast_select_core_macro_ref(new_ast_str($SELECT_CORE_MACRO), $opt_macro_args); }
-  ;
-
-select_expr_macro_ref:
-  SELECT_EXPR_MACRO {
-    YY_ERROR_ON_MACRO($SELECT_EXPR_MACRO);
-    $$ = new_ast_select_expr_macro_arg_ref(new_ast_str($SELECT_EXPR_MACRO), NULL); }
-  | SELECT_EXPR_MACRO '(' opt_macro_args ')' {
-    YY_ERROR_ON_MACRO_ARG($SELECT_EXPR_MACRO);
-    $$ = new_ast_select_expr_macro_ref(new_ast_str($SELECT_EXPR_MACRO), $opt_macro_args); }
+macro_ref:
+  ID '!' {
+     YY_ERROR_ON_MACRO($ID);
+     $$ = macro_arg_ref_node($ID); }
+  | ID '!' '(' opt_macro_args ')' {
+     YY_ERROR_ON_MACRO_ARG($ID);
+     $$ = macro_ref_node($ID, $opt_macro_args); }
   ;
 
 stmt_list[result]:
@@ -574,28 +515,7 @@ stmt_list[result]:
      // set up the tail pointer invariant to use later
      $result->parent = $result;
      }
-  | stmt_list_macro_ref[stmt] ';' {
-     // same cheese as above
-
-     $result = new_ast_stmt_list($stmt, NULL);
-     $result->lineno = $stmt->lineno;
-
-     // set up the tail pointer invariant to use later
-     $result->parent = $result;
-     }
   | stmt_list[slist] stmt {
-     ast_node *new_stmt = new_ast_stmt_list($stmt, NULL);
-     new_stmt->lineno = $stmt->lineno;
-
-     // use our tail pointer invariant so we can add at the tail without searching
-     ast_node *tail = $slist->parent;
-     ast_set_right(tail, new_stmt);
-
-     // re-establish the tail invariant per the above
-     $slist->parent = new_stmt;
-     $result = $slist;
-     }
-  | stmt_list[slist] stmt_list_macro_ref[stmt] ';' {
      ast_node *new_stmt = new_ast_stmt_list($stmt, NULL);
      new_stmt->lineno = $stmt->lineno;
 
@@ -1131,7 +1051,7 @@ loose_name_or_type[r]:
      EXTRACT_STRING(n2, $l2);
      $$ = new_ast_str(dup_printf("%s<%s>", n1, n2)); }
   ;
-  
+
 
 opt_sql_name:
   /* nil */  { $opt_sql_name = NULL; }
@@ -1290,7 +1210,7 @@ text_args:
    | text_arg ',' text_args[ta] { $$ = new_ast_text_args($text_arg, $ta); }
    ;
 
-text_arg : expr | non_expr_macro_ref ;
+text_arg : expr ;
 
 raise_expr:
   RAISE '(' IGNORE ')'  { $raise_expr = new_ast_raise(new_ast_option(RAISE_IGNORE), NULL); }
@@ -1332,7 +1252,7 @@ call:
 basic_expr:
   name  { $basic_expr = $name; }
   | QID { $basic_expr = new_ast_qstr_quoted($QID); }
-  | expr_macro_ref { $basic_expr = $expr_macro_ref; }
+  | macro_ref { $basic_expr = $macro_ref; }
   | '*' { $basic_expr = new_ast_star(); }
   | AT_RC { $basic_expr = new_ast_str("@RC"); }
   | basic_expr[lhs] '.' sql_name[rhs] { $$ = new_ast_dot($lhs, $rhs); }
@@ -1516,7 +1436,7 @@ cte_table:
       $cte_table = new_ast_cte_table($cte_decl, new_ast_like($select_stmt, NULL)); }
   | cte_decl LIKE sql_name  {
       $cte_table = new_ast_cte_table($cte_decl, new_ast_like($sql_name, NULL)); }
-  | cte_tables_macro_ref[ref] { $cte_table = $ref; }
+  | macro_ref[ref] { $cte_table = $ref; }
   ;
 
 with_prefix:
@@ -1551,10 +1471,6 @@ select_core_list[result]:
   | select_core compound_operator select_core_list[list] {
      ast_node *select_core_compound = new_ast_select_core_compound(new_ast_option($compound_operator), $list);
      $result = new_ast_select_core_list($select_core, select_core_compound); }
-  | select_core_macro_ref { $result = new_ast_select_core_list($select_core_macro_ref, NULL); }
-  | select_core_macro_ref compound_operator select_core_list[list] {
-     ast_node *select_core_compound = new_ast_select_core_compound(new_ast_option($compound_operator), $list);
-     $result = new_ast_select_core_list($select_core_macro_ref, select_core_compound); }
   ;
 
 values[result]:
@@ -1575,6 +1491,7 @@ select_core:
     struct ast_node *select_expr_list_con = new_ast_select_expr_list_con($select_expr_list, select_from_etc);
      $select_core = new_ast_select_core($select_opts, select_expr_list_con);
   }
+  | ROWS '(' macro_ref ')' { $$ = $macro_ref; }
   | VALUES values  {
     $select_core = new_ast_select_core(new_ast_select_values(), $values);
   }
@@ -1820,8 +1737,6 @@ select_opts:
 select_expr_list[result]:
   select_expr  { $result = new_ast_select_expr_list($select_expr, NULL); }
   | select_expr ',' select_expr_list[sel]  { $result = new_ast_select_expr_list($select_expr, $sel); }
-  | select_expr_macro_ref  { $result = new_ast_select_expr_list($select_expr_macro_ref, NULL); }
-  | select_expr_macro_ref ',' select_expr_list[sel]  { $result = new_ast_select_expr_list($select_expr_macro_ref, $sel); }
   ;
 
 select_expr:
@@ -1872,7 +1787,7 @@ table_or_subquery:
   | '(' shared_cte ')' opt_as_alias  { $table_or_subquery = new_ast_table_or_subquery($shared_cte, $opt_as_alias); }
   | table_function opt_as_alias  { $table_or_subquery = new_ast_table_or_subquery($table_function, $opt_as_alias); }
   | '(' query_parts ')'  { $table_or_subquery = new_ast_table_or_subquery($query_parts, NULL); }
-  |  query_parts_macro_ref[qp] opt_as_alias { $table_or_subquery = new_ast_table_or_subquery($qp, $opt_as_alias); }
+  |  macro_ref[qp] opt_as_alias { $table_or_subquery = new_ast_table_or_subquery($qp, $opt_as_alias); }
   ;
 
 join_type:
@@ -2820,15 +2735,10 @@ opt_macro_args:
 macro_arg:
  expr[arg] { $macro_arg = new_ast_expr_macro_arg($arg); }
  | BEGIN_ stmt_list[arg] END { $macro_arg = new_ast_stmt_list_macro_arg($arg); }
- |  stmt_list_macro_ref[arg]  { $macro_arg = new_ast_stmt_list_macro_arg(new_ast_stmt_list($arg, NULL)); }
  | FROM '(' query_parts[arg] ')' { $macro_arg = new_ast_query_parts_macro_arg($arg); }
- |  query_parts_macro_ref[arg] { $macro_arg = new_ast_query_parts_macro_arg($arg); }
  | WITH '(' cte_tables[arg] ')' { $macro_arg = new_ast_cte_tables_macro_arg($arg); }
- |  cte_tables_macro_ref[arg] { $macro_arg = new_ast_cte_tables_macro_arg(new_ast_cte_tables($arg, NULL)); }
- | ALL '(' select_core_list[arg] ')' { $macro_arg = new_ast_select_core_macro_arg($arg); }
- |  select_core_macro_ref[arg] { $macro_arg = new_ast_select_core_macro_arg(new_ast_select_core_list($arg, NULL)); }
+ | ROWS '(' select_core_list[arg] ')' { $macro_arg = new_ast_select_core_macro_arg($arg); }
  | SELECT '(' select_expr_list[arg] ')' { $macro_arg = new_ast_select_expr_macro_arg($arg); }
- |  select_expr_macro_ref[arg]  { $macro_arg = new_ast_select_expr_macro_arg(new_ast_select_expr_list($arg, NULL)); }
  ;
 
 macro_args[result]:
@@ -3755,17 +3665,42 @@ cql_noexport int32_t macro_type_from_str(CSTR type) {
   return macro_type;
 }
 
-cql_noexport bool_t macro_arg_valid(int32_t macro_type, ast_node *macro_arg) {
-  bool_t valid = false;
+static ast_node *macro_arg_ref_node(CSTR name) {
+  int32_t macro_type = resolve_macro_name(name);
+  ast_node *id = new_ast_str(name);
   switch (macro_type) {
-    case EXPR_MACRO:         valid = is_ast_expr_macro_arg(macro_arg); break;
-    case STMT_LIST_MACRO:    valid = is_ast_stmt_list_macro_arg(macro_arg); break;
-    case QUERY_PARTS_MACRO:  valid = is_ast_query_parts_macro_arg(macro_arg); break;
-    case CTE_TABLES_MACRO:   valid = is_ast_cte_tables_macro_arg(macro_arg); break;
-    case SELECT_CORE_MACRO:  valid = is_ast_select_core_macro_arg(macro_arg); break;
-    case SELECT_EXPR_MACRO:  valid = is_ast_select_expr_macro_arg(macro_arg); break;
+    case EXPR_MACRO:         return new_ast_expr_macro_arg_ref(id);
+    case STMT_LIST_MACRO:    return new_ast_stmt_list_macro_arg_ref(id);
+    case QUERY_PARTS_MACRO:  return new_ast_query_parts_macro_arg_ref(id);
+    case CTE_TABLES_MACRO:   return new_ast_cte_tables_macro_arg_ref(id);
+    case SELECT_CORE_MACRO:  return new_ast_select_core_macro_arg_ref(id);
+    case SELECT_EXPR_MACRO:  return new_ast_select_expr_macro_arg_ref(id);
   }
-  return valid;
+  return new_ast_unknown_macro_ref(id, NULL);
+}
+
+static ast_node *macro_ref_node(CSTR name, ast_node *args) {
+  int32_t macro_type = resolve_macro_name(name);
+  ast_node *id = new_ast_str(name);
+  switch (macro_type) {
+    case EXPR_MACRO:         return new_ast_expr_macro_ref(id, args);
+    case STMT_LIST_MACRO:    return new_ast_stmt_list_macro_ref(id, args);
+    case QUERY_PARTS_MACRO:  return new_ast_query_parts_macro_ref(id, args);
+    case CTE_TABLES_MACRO:   return new_ast_cte_tables_macro_ref(id, args);
+    case SELECT_CORE_MACRO:  return new_ast_select_core_macro_ref(id, args);
+    case SELECT_EXPR_MACRO:  return new_ast_select_expr_macro_ref(id, args);
+  }
+  return new_ast_unknown_macro_ref(id, args);
+}
+
+cql_noexport int32_t macro_arg_type(ast_node *macro_arg) {
+  if (is_ast_expr_macro_arg(macro_arg)) return EXPR_MACRO;
+  if (is_ast_stmt_list_macro_arg(macro_arg)) return STMT_LIST_MACRO;
+  if (is_ast_query_parts_macro_arg(macro_arg)) return QUERY_PARTS_MACRO;
+  if (is_ast_cte_tables_macro_arg(macro_arg)) return CTE_TABLES_MACRO;
+  if (is_ast_select_core_macro_arg(macro_arg)) return SELECT_CORE_MACRO;
+  if (is_ast_select_expr_macro_arg(macro_arg)) return SELECT_EXPR_MACRO;
+  return EOF;
 }
 
 static symtab *defines;
@@ -3814,7 +3749,7 @@ static ast_node *do_ifdef(ast_node *ast) {
   cql_ifdef_state_t *new_state = _ast_pool_new(cql_ifdef_state_t);
   new_state->prev = cql_ifdef_state;
   bool_t processing = is_processing();
-  new_state->processing = processing && cql_is_defined(name); 
+  new_state->processing = processing && cql_is_defined(name);
   new_state->process_else = processing && !new_state->processing;
   ast = new_state->processing ? new_ast_is_true(ast) : new_ast_is_false(ast);
   cql_ifdef_state = new_state;
@@ -3826,7 +3761,7 @@ static ast_node *do_ifndef(ast_node *ast) {
   cql_ifdef_state_t *new_state = _ast_pool_new(cql_ifdef_state_t);
   new_state->prev = cql_ifdef_state;
   bool_t processing = is_processing();
-  new_state->processing = processing && !cql_is_defined(name); 
+  new_state->processing = processing && !cql_is_defined(name);
   new_state->process_else = processing && !new_state->processing;
   ast = new_state->processing ? new_ast_is_true(ast) : new_ast_is_false(ast);
   cql_ifdef_state = new_state;

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -2733,7 +2733,7 @@ opt_macro_args:
    ;
 
 macro_arg:
- expr[arg] { $macro_arg = new_ast_expr_macro_arg($arg); }
+ expr[arg] { $macro_arg = new_macro_arg_node($arg); }
  | BEGIN_ stmt_list[arg] END { $macro_arg = new_ast_stmt_list_macro_arg($arg); }
  | FROM '(' query_parts[arg] ')' { $macro_arg = new_ast_query_parts_macro_arg($arg); }
  | WITH '(' cte_tables[arg] ')' { $macro_arg = new_ast_cte_tables_macro_arg($arg); }

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -2707,6 +2707,10 @@ macro_def_stmt:
      delete_macro_formals(); }
   | stmt_list_macro_def BEGIN_ stmt_list END {
      $macro_def_stmt = $stmt_list_macro_def;
+     ast_node *stmt_list = $stmt_list;
+     if (is_ast_stmt_list(stmt_list) && is_ast_expr_stmt(stmt_list->left)) {
+        ast_set_left(stmt_list, stmt_list->left->left);
+     }
      ast_set_right($macro_def_stmt, $stmt_list);
      delete_macro_formals(); }
   | query_parts_macro_def BEGIN_ query_parts END {

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -535,7 +535,14 @@ stmt:
   | ifndef_stmt { $stmt = make_statement_node(NULL, $ifndef_stmt); }
   ;
 
-expr_stmt: expr { $expr_stmt = new_ast_expr_stmt($expr);  }
+expr_stmt: expr { 
+     if (is_ast_stmt_list_macro_ref($expr) || is_ast_stmt_list_macro_arg_ref($expr)) {
+        $$ = $expr;
+     }
+     else {
+       $expr_stmt = new_ast_expr_stmt($expr);
+     }
+   }
   ;
 
 any_stmt:

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -2715,7 +2715,6 @@ macro_def_stmt:
      delete_macro_formals(); }
   | stmt_list_macro_def BEGIN_ stmt_list END {
      $macro_def_stmt = $stmt_list_macro_def;
-     ast_node *stmt_list = $stmt_list;
      ast_set_right($macro_def_stmt, $stmt_list);
      delete_macro_formals(); }
   | query_parts_macro_def BEGIN_ query_parts END {

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -1177,10 +1177,7 @@ static void gen_expr_macro_text(ast_node *ast, CSTR op, int32_t pri, int32_t pri
 }
 
 cql_noexport void gen_any_text_arg(ast_node *ast) {
-  if (is_ast_cte_table(ast)) {
-    gen_cte_table(ast);
-  }
-  else if (is_ast_cte_tables(ast)) {
+  if (is_ast_cte_tables(ast)) {
     gen_cte_tables(ast, "");
   }
   else if (is_ast_table_or_subquery_list(ast) || is_ast_join_clause(ast)) {
@@ -1188,9 +1185,6 @@ cql_noexport void gen_any_text_arg(ast_node *ast) {
   }
   else if (is_ast_stmt_list(ast)) {
     gen_stmt_list(ast);
-  }
-  else if (is_ast_select_core(ast)) {
-    gen_select_core(ast);
   }
   else if (is_ast_select_core_list(ast)) {
     gen_select_core_list(ast);

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -5404,6 +5404,11 @@ static void gen_stmt_list(ast_node *root) {
 }
 
 cql_noexport void gen_one_stmt(ast_node *stmt)  {
+  if (is_any_macro_ref(stmt)) {
+    gen_any_macro_ref(stmt);
+    return;
+  }
+
   symtab_entry *entry = symtab_find(gen_stmts, stmt->type);
 
   // These are all the statements there are, we have to find it in this table

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -1189,9 +1189,6 @@ cql_noexport void gen_any_text_arg(ast_node *ast) {
   else if (is_ast_select_core_list(ast)) {
     gen_select_core_list(ast);
   }
-  else if (is_ast_select_expr(ast)) {
-    gen_select_expr(ast);
-  }
   else if (is_ast_select_expr_list(ast)) {
     gen_select_expr_list(ast);
   }
@@ -1199,19 +1196,6 @@ cql_noexport void gen_any_text_arg(ast_node *ast) {
     gen_root_expr(ast);
   }
 }
-
-// note that the final expression might end up with parens or not
-// but in this form no parens are needed, the replacement will
-// naturally cause parens around a lower binding macro or macro arg
-// hence we ignore pri and pri new just like for say identifiers
-static void gen_expr_macro_ref(ast_node *ast, CSTR op, int32_t pri, int32_t pri_new) {
-  Contract(is_ast_expr_macro_ref(ast));
-  EXTRACT_STRING(name, ast->left);
-  gen_printf("%s(", name);
-  gen_macro_args(ast->right);
-  gen_printf(")");
-}
-
 
 // this is used to token paste an identifier
 static void gen_expr_at_id(ast_node *ast, CSTR op, int32_t pri, int32_t pri_new) {
@@ -2777,11 +2761,6 @@ static void gen_select_statement_type(ast_node *ast) {
   Contract(is_ast_select_core(ast));
   EXTRACT_ANY(select_opts, ast->left);
 
-  if (is_any_macro_ref(select_opts)) {
-    gen_any_macro_ref(select_opts);
-    return;
-  }
-
   if (select_opts && is_ast_select_values(select_opts)) {
     gen_printf("VALUES");
   } else {
@@ -2821,11 +2800,7 @@ cql_noexport void gen_select_core(ast_node *ast) {
 
     gen_select_statement_type(ast);
   
-    // select_core subtree can be a macro, SELECT or VALUES statement
-    if (is_any_macro_ref(select_core_left)) {
-      gen_any_macro_ref(select_core_left);
-    }
-    else if (is_ast_select_values(select_core_left)) {
+    if (is_ast_select_values(select_core_left)) {
       // VALUES [values]
       EXTRACT(values, ast->right);
       gen_values(values);

--- a/sources/test.sh
+++ b/sources/test.sh
@@ -211,7 +211,7 @@ basic_test() {
 		failed
 	fi
 
-	echo "  computing diffs CRFL parsing (empty if none)"
+	echo "  computing diffs CRLF parsing (empty if none)"
 	mv "$O/test.out2" "$O/test.out"
 	on_diff_exit test.out
 

--- a/sources/test/macro_basic_parse_test.sql
+++ b/sources/test/macro_basic_parse_test.sql
@@ -84,11 +84,10 @@ end;
 
 @macro(select_core) selcor2!(x! select_core)
 begin
-   x! union all x!
+   ROWS(x!) union all ROWS(x!)
 end;
 
-selcor2!(all(selcor!(5)));
-
+ROWS(selcor2!(selcor!(5)));
 
 @macro(select_expr) se!(x! select_expr)
 begin
@@ -154,7 +153,7 @@ set z := @LINE;
 let zz := macro3!(from( (select 1 x, 2 y) as T));
 set zz := macro3!(from( T1 join T2 on T1.id = T2.id));
 set zz := macro4!(WITH( x(*) as (select 1 x, 2 y) ));
-set zz := macro5!(ALL(select 1 x from foo));
+set zz := macro5!(ROWS(select 1 x from foo));
 set zz := macro6!(1+2);
 set zz := macro7!(select(1 x, 2 y));
 
@@ -174,7 +173,7 @@ begin
   mondo1!(a!, b!, c!, d!, e!, f!);
 end;
 
-mondo2!(1+2, from(x join y), all(select 1 from foo union select 2 from bar), select(20 xx), 
+mondo2!(1+2, from(x join y), rows(select 1 from foo union select 2 from bar), select(20 xx),
   with(f(*) as (select 99 from yy)), begin let qq := 201; end);
 
 -- make sure these are ok to use as identifiers

--- a/sources/test/macro_basic_parse_test.sql
+++ b/sources/test/macro_basic_parse_test.sql
@@ -198,3 +198,4 @@ begin
 end;
 
 let z := @TEXT(1+5);
+

--- a/sources/test/macro_exp_errors.sql
+++ b/sources/test/macro_exp_errors.sql
@@ -32,3 +32,11 @@ begin
 end;
 
 sel3!();
+
+unknown_macro!();
+
+unknown_arg!;
+
+exp!(not_valid_arg!);
+
+exp!(not_valid_macro!());

--- a/sources/test/macro_test.err.out.ref
+++ b/sources/test/macro_test.err.out.ref
@@ -12,3 +12,11 @@ test/macro_exp_errors.sql:XXXX:1: error: in select_expr_macro_arg : macro type m
  -> 'sel1!' in test/macro_exp_errors.sql:26
  -> 'sel2!' in test/macro_exp_errors.sql:31
  -> 'sel3!' in test/macro_exp_errors.sql:34
+test/macro_exp_errors.sql:XXXX:1: error: in unknown_macro_ref : macro reference is not a valid macro 'unknown_macro'
+test/macro_exp_errors.sql:XXXX:1: error: in unknown_macro_arg_ref : macro reference is not a valid macro 'unknown_arg'
+test/macro_exp_errors.sql:XXXX:1: error: in unknown_macro_arg_ref : macro reference is not a valid macro 'not_valid_arg'
+test/macro_exp_errors.sql:XXXX:1: error: in unknown_macro_arg : macro type mismatch in argument 'e'
+ -> 'exp!' in test/macro_exp_errors.sql:40
+test/macro_exp_errors.sql:XXXX:1: error: in unknown_macro_ref : macro reference is not a valid macro 'not_valid_macro'
+test/macro_exp_errors.sql:XXXX:1: error: in unknown_macro_arg : macro type mismatch in argument 'e'
+ -> 'exp!' in test/macro_exp_errors.sql:42

--- a/sources/test/macro_test.out.ref
+++ b/sources/test/macro_test.out.ref
@@ -80,7 +80,7 @@ END;
       | {cond_action}
       | | {not}
       | | | {expr_macro_arg_ref}
-      | |   | {name e!}
+      | |   | {name e}
       | | {stmt_list}
       |   | {call_stmt}
       |     | {name printf}
@@ -91,7 +91,7 @@ END;
       |         | {macro_text}
       |         | | {text_args}
       |         |   | {expr_macro_arg_ref}
-      |         |     | {name e!}
+      |         |     | {name e}
       |         | {arg_list}
       |           | {name @MACRO_FILE}
       |           | {arg_list}
@@ -131,9 +131,9 @@ END;
   |       | {name EXPR}
   | {add}
     | {expr_macro_arg_ref}
-    | | {name x!}
+    | | {name x}
     | {expr_macro_arg_ref}
-      | {name z!}
+      | {name z}
 
 The statement ending at line XXXX
 
@@ -159,10 +159,10 @@ END;
     | {if_stmt}
       | {cond_action}
       | | {expr_macro_arg_ref}
-      | | | {name x!}
+      | | | {name x}
       | | {stmt_list}
       |   | {stmt_list_macro_arg_ref}
-      |     | {name y!}
+      |     | {name y}
       | {if_alt}
 
 The statement ending at line XXXX
@@ -397,12 +397,12 @@ END;
       |     | {select_expr_list}
       |     | | {select_expr}
       |     |   | {expr_macro_arg_ref}
-      |     |     | {name e!}
+      |     |     | {name e}
       |     | {select_from_etc}
       |       | {table_or_subquery_list}
       |       | | {table_or_subquery}
       |       |   | {query_parts_macro_arg_ref}
-      |       |   | | {name q!}
+      |       |   | | {name q}
       |       |   | {opt_as_alias}
       |       |     | {name Q}
       |       | {select_where}
@@ -1046,7 +1046,7 @@ END;
       | {with}
       | | {cte_tables}
       |   | {cte_tables_macro_arg_ref}
-      |     | {name u!}
+      |     | {name u}
       | {select_stmt}
         | {select_core_list}
         | | {select_core}
@@ -1141,7 +1141,7 @@ END;
     |   | | {select_expr}
     |   |   | {add}
     |   |   | | {expr_macro_arg_ref}
-    |   |   | | | {name x!}
+    |   |   | | | {name x}
     |   |   | | {int 1}
     |   |   | {opt_as_alias}
     |   |     | {name x}
@@ -1158,7 +1158,7 @@ END;
             | | {select_expr}
             |   | {add}
             |   | | {expr_macro_arg_ref}
-            |   | | | {name x!}
+            |   | | | {name x}
             |   | | {int 2}
             |   | {opt_as_alias}
             |     | {name x}
@@ -1171,9 +1171,9 @@ The statement ending at line XXXX
 
 @MACRO(SELECT_CORE) selcor2!(x! SELECT_CORE, y! SELECT_CORE)
 BEGIN
-  x!
+  ROWS(x!)
   UNION ALL
-  y!
+  ROWS(y!)
 END;
 
   {select_core_macro_def}
@@ -1189,12 +1189,12 @@ END;
   |       | {name SELECT_CORE}
   | {select_core_list}
     | {select_core_macro_arg_ref}
-    | | {name x!}
+    | | {name x}
     | {select_core_compound}
       | {int 2}
       | {select_core_list}
         | {select_core_macro_arg_ref}
-          | {name y!}
+          | {name y}
 
 The statement ending at line XXXX
 
@@ -1289,10 +1289,10 @@ END;
   |     | {name SELECT_EXPR}
   | {select_expr_list}
     | {select_expr_macro_arg_ref}
-    | | {name x!}
+    | | {name x}
     | {select_expr_list}
       | {select_expr_macro_arg_ref}
-        | {name x!}
+        | {name x}
 
 The statement ending at line XXXX
 
@@ -1310,12 +1310,12 @@ END;
   |     | {name SELECT_EXPR}
   | {select_expr_list}
     | {select_expr_macro_ref}
-      | {name se!}
+      | {name se}
       | {macro_args}
         | {select_expr_macro_arg}
           | {select_expr_list}
             | {select_expr_macro_arg_ref}
-              | {name x!}
+              | {name x}
 
 The statement ending at line XXXX
 
@@ -1364,9 +1364,9 @@ END;
   | {add}
     | {add}
     | | {expr_macro_arg_ref}
-    | | | {name u!}
+    | | | {name u}
     | | {expr_macro_arg_ref}
-    |   | {name u!}
+    |   | {name u}
     | {int 1}
 
 The statement ending at line XXXX
@@ -1389,14 +1389,14 @@ END;
   |       | {name EXPR}
   | {mul}
     | {expr_macro_arg_ref}
-    | | {name u!}
+    | | {name u}
     | {expr_macro_ref}
-      | {name macro1!}
+      | {name macro1}
       | {macro_args}
         | {expr_macro_arg}
           | {add}
             | {expr_macro_arg_ref}
-            | | {name v!}
+            | | {name v}
             | {int 5}
 
 The statement ending at line XXXX
@@ -1416,7 +1416,7 @@ END;
   | {macro_text}
     | {text_args}
       | {query_parts_macro_arg_ref}
-        | {name q!}
+        | {name q}
 
 The statement ending at line XXXX
 
@@ -1435,7 +1435,7 @@ END;
   | {macro_text}
     | {text_args}
       | {cte_tables_macro_arg_ref}
-        | {name q!}
+        | {name q}
 
 The statement ending at line XXXX
 
@@ -1454,7 +1454,7 @@ END;
   | {macro_text}
     | {text_args}
       | {select_core_macro_arg_ref}
-        | {name q!}
+        | {name q}
 
 The statement ending at line XXXX
 
@@ -1473,7 +1473,7 @@ END;
   | {macro_text}
     | {text_args}
       | {expr_macro_arg_ref}
-        | {name q!}
+        | {name q}
 
 The statement ending at line XXXX
 
@@ -1492,7 +1492,7 @@ END;
   | {macro_text}
     | {text_args}
       | {select_expr_macro_arg_ref}
-        | {name q!}
+        | {name q}
 
 The statement ending at line XXXX
 
@@ -1637,43 +1637,38 @@ END;
       | {macro_text}
         | {text_args}
           | {expr_macro_arg_ref}
-          | | {name a!}
+          | | {name a}
           | {text_args}
             | {strlit '___'}
             | {text_args}
               | {query_parts_macro_arg_ref}
-              | | {name b!}
+              | | {name b}
               | {text_args}
                 | {strlit '___'}
                 | {text_args}
                   | {select_core_macro_arg_ref}
-                  | | {name c!}
+                  | | {name c}
                   | {text_args}
                     | {strlit '___'}
                     | {text_args}
                       | {select_expr_macro_arg_ref}
-                      | | {name d!}
+                      | | {name d}
                       | {text_args}
                         | {strlit '___'}
                         | {text_args}
                           | {cte_tables_macro_arg_ref}
-                          | | {name e!}
+                          | | {name e}
                           | {text_args}
                             | {strlit '___'}
                             | {text_args}
                               | {stmt_list_macro_arg_ref}
-                                | {name f!}
+                                | {name f}
 
 The statement ending at line XXXX
 
 @MACRO(STMT_LIST) mondo2!(a! EXPR, b! QUERY_PARTS, c! SELECT_CORE, d! SELECT_EXPR, e! CTE_TABLES, f! STMT_LIST)
 BEGIN
-  mondo1!(a!, FROM(b!), ALL(c!), SELECT(d!), WITH(
-    e!
-  ), 
-  BEGIN
-    f!;
-  END);
+  mondo1!(a!, b!, c!, d!, e!, f!);
 END;
 
   {stmt_list_macro_def}
@@ -1705,35 +1700,31 @@ END;
   |               | {name STMT_LIST}
   | {stmt_list}
     | {stmt_list_macro_ref}
-      | {name mondo1!}
+      | {name mondo1}
       | {macro_args}
         | {expr_macro_arg}
         | | {expr_macro_arg_ref}
-        |   | {name a!}
+        |   | {name a}
         | {macro_args}
           | {query_parts_macro_arg}
           | | {query_parts_macro_arg_ref}
-          |   | {name b!}
+          |   | {name b}
           | {macro_args}
             | {select_core_macro_arg}
-            | | {select_core_list}
-            |   | {select_core_macro_arg_ref}
-            |     | {name c!}
+            | | {select_core_macro_arg_ref}
+            |   | {name c}
             | {macro_args}
               | {select_expr_macro_arg}
-              | | {select_expr_list}
-              |   | {select_expr_macro_arg_ref}
-              |     | {name d!}
+              | | {select_expr_macro_arg_ref}
+              |   | {name d}
               | {macro_args}
                 | {cte_tables_macro_arg}
-                | | {cte_tables}
-                |   | {cte_tables_macro_arg_ref}
-                |     | {name e!}
+                | | {cte_tables_macro_arg_ref}
+                |   | {name e}
                 | {macro_args}
                   | {stmt_list_macro_arg}
-                    | {stmt_list}
-                      | {stmt_list_macro_arg_ref}
-                        | {name f!}
+                    | {stmt_list_macro_arg_ref}
+                      | {name f}
 
 The statement ending at line XXXX
 

--- a/sources/test/macro_test.sql
+++ b/sources/test/macro_test.sql
@@ -286,7 +286,7 @@ end;
 -- + END;
 @macro(select_core) selcor2!(x! select_core, y! select_core)
 begin
-   x! union all y!
+   ROWS(x!) union all ROWS(y!)
 end;
 
 -- TEST: use macro that consumes select core list
@@ -297,7 +297,7 @@ end;
 -- + SELECT 50 + 1 AS x
 -- + UNION ALL
 -- + SELECT 50 + 2 AS x;
-selcor2!(all(selcor!(5)), selcor!(50));
+ROWS(selcor2!(selcor!(5), selcor!(50)));
 
 
 -- TEST: a select expression with args
@@ -415,7 +415,7 @@ set zz := macro4!(WITH( x(*) as (select 1 x, 2 y) ));
 
 -- TEST: select core list as text
 -- + SET zz := "SELECT 1 AS x\n  FROM foo";
-set zz := macro5!(ALL(select 1 x from foo));
+set zz := macro5!(ROWS(select 1 x from foo));
 
 -- TEST: expression as text
 -- + SET zz := "1 + 2";
@@ -446,12 +446,7 @@ end;
 -- TEST: macro with all the arg types and forwarded with the simple syntax
 -- + @MACRO(STMT_LIST) mondo2!(a! EXPR, b! QUERY_PARTS, c! SELECT_CORE, d! SELECT_EXPR, e! CTE_TABLES, f! STMT_LIST)
 -- + BEGIN
--- +  mondo1!(a!, FROM(b!), ALL(c!), SELECT(d!), WITH(
--- +    e!
--- +  ),
--- +  BEGIN
--- +    f!;
--- +  END);
+-- +   mondo1!(a!, b!, c!, d!, e!, f!);
 -- + END;
 @macro(stmt_list) mondo2!(a! expr, b! query_parts, c! select_core, d! select_expr, e! cte_tables, f! stmt_list)
 begin
@@ -463,7 +458,7 @@ end;
 mondo2!(
   1+2,
   from(x join y),
-  all(select 1 from foo union select 2 from bar), 
+  rows(select 1 from foo union select 2 from bar), 
   select(20 first_table), 
   with(f(*) as (select 99 from second_table)), 
   begin let qq := 201; end

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -59,16 +59,22 @@ begin
   end if;
 end;
 
+@ifdef __rt__lua
   -- This test case is suppressed in Lua, this is done
   -- because the Lua runtime is missing some blob features
-@macro(stmt_list) TEST_C!(name! expr, body! stmt_list)
-begin
-  @ifdef __rt__lua
+  @macro(stmt_list) TEST_C!(name! expr, body! stmt_list)
+  begin
     call printf("Skipping test %s in Lua\n", @TEXT(name!));
-  @else
+  end;
+
+@else
+
+  @macro(stmt_list) TEST_C!(name! expr, body! stmt_list)
+  begin
     TEST!(name!, body!);
-  @endif
-end;
+  end;
+
+@endif
 
 @MACRO(stmt_list) BEGIN_SUITE!()
 begin

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -117,12 +117,12 @@ END;
 
 @MACRO(SELECT_CORE) selcor2!(x! SELECT_CORE)
 BEGIN
-  x!
+  ROWS(x!)
   UNION ALL
-  x!
+  ROWS(x!)
 END;
 
-selcor2!(ALL(selcor!(5)));
+ROWS(selcor2!(selcor!(5)));
 
 @MACRO(SELECT_EXPR) se!(x! SELECT_EXPR)
 BEGIN
@@ -184,7 +184,7 @@ LET y := 2;
 
 LET z := macro2!(x, y);
 
-SET z := 151;
+SET z := 150;
 
 LET zz := macro3!(FROM((SELECT 1 AS x, 2 AS y) AS T));
 
@@ -197,7 +197,7 @@ SET zz := macro4!(WITH(
   )
 ));
 
-SET zz := macro5!(ALL(SELECT 1 AS x
+SET zz := macro5!(ROWS(SELECT 1 AS x
   FROM foo));
 
 SET zz := macro6!(1 + 2);
@@ -221,16 +221,11 @@ END;
 
 @MACRO(STMT_LIST) mondo2!(a! EXPR, b! QUERY_PARTS, c! SELECT_CORE, d! SELECT_EXPR, e! CTE_TABLES, f! STMT_LIST)
 BEGIN
-  mondo1!(a!, FROM(b!), ALL(c!), SELECT(d!), WITH(
-    e!
-  ), 
-  BEGIN
-    f!;
-  END);
+  mondo1!(a!, b!, c!, d!, e!, f!);
 END;
 
 mondo2!(1 + 2, FROM(x
-INNER JOIN y), ALL(SELECT 1
+INNER JOIN y), ROWS(SELECT 1
   FROM foo
 UNION
 SELECT 2

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -2413,3 +2413,18 @@ x:left('x', 'y');
 right('a', 'b');
 
 CALL @ID("foo")(1, 2);
+
+@IFDEF goo
+  @MACRO(STMT_LIST) c!()
+  BEGIN
+    foo!();
+    boo!;
+  END;
+@ELSE
+  @MACRO(STMT_LIST) c!()
+  BEGIN
+    foo!();
+    boo!;
+  END;
+@ENDIF
+

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1857,3 +1857,19 @@ x:left('x', 'y');
 right('a', 'b');
 
 call @ID("foo")(1,2);
+
+-- this forces macros on both paths as well as unknown macros
+-- it should still parse
+@ifdef goo
+  @macro(stmt_list) c!()
+  begin
+    foo!();
+    boo!;
+  end;
+@else
+  @macro(stmt_list) c!()
+  begin
+    foo!();
+    boo!;
+  end;
+@endif

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -146,9 +146,9 @@ END;
 
 @MACRO(SELECT_CORE) selcor2!(x! SELECT_CORE)
 BEGIN
-  x!
+  ROWS(x!)
   UNION ALL
-  x!
+  ROWS(x!)
 END;
 
 SELECT 5 + 1 AS x
@@ -219,7 +219,7 @@ LET y := 2;
 
 LET z := x * (y + 5 + (y + 5) + 1);
 
-SET z := 151;
+SET z := 150;
 
 LET zz := "(SELECT 1 AS x, 2 AS y) AS T";
 
@@ -233,7 +233,7 @@ SET zz := "1 + 2";
 
 SET zz := "1 AS x, 2 AS y";
 
-LET zzz := "begin\nIF NOT 7 THEN\n  CALL printf(\"assert '%s' failed at line %s:%d\\n\", \"7\", 'test/macro_basic_parse_test.sql', 161);\nEND;\n\nfoo";
+LET zzz := "begin\nIF NOT 7 THEN\n  CALL printf(\"assert '%s' failed at line %s:%d\\n\", \"7\", 'test/macro_basic_parse_test.sql', 160);\nEND;\n\nfoo";
 
 SET x := 5;
 
@@ -250,12 +250,7 @@ END;
 
 @MACRO(STMT_LIST) mondo2!(a! EXPR, b! QUERY_PARTS, c! SELECT_CORE, d! SELECT_EXPR, e! CTE_TABLES, f! STMT_LIST)
 BEGIN
-  mondo1!(a!, FROM(b!), ALL(c!), SELECT(d!), WITH(
-    e!
-  ), 
-  BEGIN
-    f!;
-  END);
+  mondo1!(a!, b!, c!, d!, e!, f!);
 END;
 
 SET zz := "1 + 2x\nINNER JOIN ySELECT 1\n  FROM foo\nUNION\nSELECT 2\n  FROM bar20 AS xxf (*) AS (\n  SELECT 99\n    FROM yy\n)\nLET qq := 201;\n";

--- a/sources/test/test_exp.out.ref
+++ b/sources/test/test_exp.out.ref
@@ -2431,3 +2431,18 @@ x:left('x', 'y');
 right('a', 'b');
 
 CALL foo(1, 2);
+
+@IFDEF goo
+  @MACRO(STMT_LIST) c!()
+  BEGIN
+    foo!();
+    boo!;
+  END;
+@ELSE
+  @MACRO(STMT_LIST) c!()
+  BEGIN
+    foo!();
+    boo!;
+  END;
+@ENDIF
+

--- a/sources/unit_tests.c
+++ b/sources/unit_tests.c
@@ -193,6 +193,15 @@ static bool test_sha256_example6() {
   return result;
 }
 
+static bool test_unknown_macro() {
+ ast_node *t = new_ast_unknown_macro_arg(NULL, NULL);
+ if (t->type != k_ast_unknown_macro_arg) return false;
+
+ t = new_ast_unknown_macro_def(NULL, NULL);
+ if (t->type != k_ast_unknown_macro_def) return false;
+ return true;
+}
+
 cql_noexport void run_unit_tests() {
   TEST_ASSERT(test_Strdup__empty_string());
   TEST_ASSERT(test_Strdup__one_character_string());
@@ -225,6 +234,7 @@ cql_noexport void run_unit_tests() {
   TEST_ASSERT(test_sha256_example4());
   TEST_ASSERT(test_sha256_example5());
   TEST_ASSERT(test_sha256_example6());
+  TEST_ASSERT(test_unknown_macro());
 }
 
 #endif


### PR DESCRIPTION
The manual grammar I was using for macro parsing in tree-sitter was actually a lot more flexible and cleaner than the one the real code used.  I changed the real code to be on the tree-sitter plan. This let me delete a lot of custom junkola and it for sure simplified the tree-sitter generation because now there is no special case code to generate working tree-sitter grammar from the .y file -- it just works;

This version is a lot more flexible in terms of how @ifdef and @macro can compose.  In particular it's quite good at parsing inert macros and dealing with macros that are unknown.  The tree-sitter grammar was too.

This is a no-op change except for one thing:  select core macro references have to be wrapped in ROWS(foo!).  These are hardly very popular but technically this is a breaking change.  This was the one sacrifice I had to make to get the grammar to be LALR1 for bison.