### PR TITLE
Cursor diff becomes runtime helper

### DIFF
--- a/docs/user_guide/appendices/04_error_codes.md
+++ b/docs/user_guide/appendices/04_error_codes.md
@@ -2719,9 +2719,7 @@ This is almost certainly a cut/paste from a different location that needs to be 
 
 -----
 
-### CQL0341: argument must be a variable in function 'function_name'
-
-The argument for the CQL builtin function 'function_name' should always be a variable. It can not be an expression for example
+### CQL0341 available for re-use
 
 -----
 

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -3157,6 +3157,8 @@ cql_noexport CSTR cql_builtin_text() {
     "declare func cql_cursor_hash(C cursor) long!;"
     "[[builtin]]"
     "declare func cql_cursors_equal(l cursor, r cursor) bool!;"
+    "[[builtin]]"
+    "declare func cql_cursor_diff_col(l cursor, r cursor) create text!;"
 
     "[[builtin]]"
     "declare func cql_box_int(x int) create object<cql_box>!;"

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -3158,7 +3158,9 @@ cql_noexport CSTR cql_builtin_text() {
     "[[builtin]]"
     "declare func cql_cursors_equal(l cursor, r cursor) bool!;"
     "[[builtin]]"
-    "declare func cql_cursor_diff_col(l cursor, r cursor) create text!;"
+    "declare func cql_cursor_diff_col(l cursor, r cursor) create text;"
+    "[[builtin]]"
+    "declare func cql_cursor_diff_val(l cursor, r cursor) create text;"
 
     "[[builtin]]"
     "declare func cql_box_int(x int) create object<cql_box>!;"

--- a/sources/rewrite.h
+++ b/sources/rewrite.h
@@ -31,7 +31,6 @@ cql_noexport ast_node *_Nonnull rewrite_gen_full_column_list(sem_struct *_Nonnul
 cql_noexport void rewrite_expr_names_to_columns_values(ast_node *_Nonnull columns_values);
 cql_noexport void rewrite_select_stmt_to_columns_values(ast_node *_Nonnull columns_values);
 cql_noexport void rewrite_empty_column_list(ast_node *_Nonnull columns_values, sem_struct *_Nonnull sptr);
-cql_noexport void rewrite_cql_cursor_diff(ast_node *_Nonnull ast, bool_t report_column_name);
 cql_noexport void rewrite_iif(ast_node *_Nonnull ast);
 cql_noexport bool_t rewrite_ast_star_if_needed(ast_node *_Nullable arg_list, ast_node *_Nonnull proc_name_ast);
 cql_noexport bool_t rewrite_shape_forms_in_list_if_needed(ast_node *_Nullable arg_list);

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -9345,16 +9345,6 @@ static bool_t validate_cql_cursor_diff(ast_node *ast, uint32_t arg_count) {
   return true;
 }
 
-static void sem_func_cql_cursor_diff_col(ast_node *ast, uint32_t arg_count) {
-  if (!validate_cql_cursor_diff(ast, arg_count)) {
-    return;
-  }
-
-  // We have a cql_cursor_diff_col function call, we rewrite the node to
-  // a case_expr node.
-  rewrite_cql_cursor_diff(ast, true);
-}
-
 static void sem_func_cql_cursor_diff_val(ast_node *ast, uint32_t arg_count) {
   if (!validate_cql_cursor_diff(ast, arg_count)) {
     return;
@@ -10794,6 +10784,12 @@ additional_checks:
   if (!StrCaseCmp(name, "cql_cursor_to_blob")) {
      Contract(arg_count == 1); // already failed if wrong
      sem_infer_result_blob_type(ast, arg_list);
+  }
+  else if (!StrCaseCmp(name, "cql_cursor_diff_col")) {
+    if (!is_error(ast) && !validate_cql_cursor_diff(ast, arg_count)) {
+      record_error(ast);
+      return;
+    }
   }
   if (!call_aggr_or_user_def_func) {
     if (distinct) {
@@ -26170,7 +26166,6 @@ cql_noexport void sem_main(ast_node *ast) {
   FUNC_INIT(changes);
   FUNC_INIT(coalesce);
   FUNC_INIT(cql_compressed);
-  FUNC_INIT(cql_cursor_diff_col);
   FUNC_INIT(cql_cursor_diff_val);
   FUNC_INIT(cql_get_blob_size);
   FUNC_INIT(cume_dist);

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -9345,16 +9345,6 @@ static bool_t validate_cql_cursor_diff(ast_node *ast, uint32_t arg_count) {
   return true;
 }
 
-static void sem_func_cql_cursor_diff_val(ast_node *ast, uint32_t arg_count) {
-  if (!validate_cql_cursor_diff(ast, arg_count)) {
-    return;
-  }
-
-  // We have a cql_cursor_diff_val function call, we rewrite the node to
-  // a case_expr node.
-  rewrite_cql_cursor_diff(ast, false);
-}
-
 // This is a special function because we do not want to analyze the arguments
 // until after the rewrite to a CASE expression.
 static void sem_special_func_iif(ast_node *ast, uint32_t arg_count, bool_t *is_aggregate) {
@@ -10785,7 +10775,7 @@ additional_checks:
      Contract(arg_count == 1); // already failed if wrong
      sem_infer_result_blob_type(ast, arg_list);
   }
-  else if (!StrCaseCmp(name, "cql_cursor_diff_col")) {
+  else if (!StrCaseCmp(name, "cql_cursor_diff_col") || !StrCaseCmp(name, "cql_cursor_diff_val")) {
     if (!is_error(ast) && !validate_cql_cursor_diff(ast, arg_count)) {
       record_error(ast);
       return;
@@ -26166,7 +26156,6 @@ cql_noexport void sem_main(ast_node *ast) {
   FUNC_INIT(changes);
   FUNC_INIT(coalesce);
   FUNC_INIT(cql_compressed);
-  FUNC_INIT(cql_cursor_diff_val);
   FUNC_INIT(cql_get_blob_size);
   FUNC_INIT(cume_dist);
   FUNC_INIT(dense_rank);

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -33,7 +33,8 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
-extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_val(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -33,6 +33,7 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -316,6 +316,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -314,6 +314,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_globals.c.ref
+++ b/sources/test/cg_test_c_globals.c.ref
@@ -33,7 +33,8 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
-extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_val(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_globals.c.ref
+++ b/sources/test/cg_test_c_globals.c.ref
@@ -33,6 +33,7 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_globals.h.ref
+++ b/sources/test/cg_test_c_globals.h.ref
@@ -308,6 +308,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 #ifndef _foo_var_group_decl_
 #define _foo_var_group_decl_ 1
 

--- a/sources/test/cg_test_c_globals.h.ref
+++ b/sources/test/cg_test_c_globals.h.ref
@@ -310,6 +310,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 #ifndef _foo_var_group_decl_
 #define _foo_var_group_decl_ 1
 

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -33,7 +33,8 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
-extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_val(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -33,6 +33,7 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_with_header.h.ref
+++ b/sources/test/cg_test_c_with_header.h.ref
@@ -316,6 +316,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_header.h.ref
+++ b/sources/test/cg_test_c_with_header.h.ref
@@ -314,6 +314,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -33,7 +33,8 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
-extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_val(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -33,6 +33,7 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -316,6 +316,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -314,6 +314,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_type_getters.c.ref
+++ b/sources/test/cg_test_c_with_type_getters.c.ref
@@ -33,7 +33,8 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
-extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nullable cql_cursor_diff_val(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_with_type_getters.c.ref
+++ b/sources/test/cg_test_c_with_type_getters.c.ref
@@ -33,6 +33,7 @@ extern cql_blob_ref _Nullable cql_blob_dictionary_find(cql_object_ref _Nonnull d
 extern cql_string_ref _Nonnull cql_cursor_format(cql_dynamic_cursor *_Nonnull C);
 extern cql_int64 cql_cursor_hash(cql_dynamic_cursor *_Nonnull C);
 extern cql_bool cql_cursors_equal(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
+extern cql_string_ref _Nonnull cql_cursor_diff_col(cql_dynamic_cursor *_Nonnull l, cql_dynamic_cursor *_Nonnull r);
 extern cql_object_ref _Nonnull cql_box_int(cql_nullable_int32 x);
 extern cql_nullable_int32 cql_unbox_int(cql_object_ref _Nullable box);
 extern cql_object_ref _Nonnull cql_box_real(cql_nullable_double x);

--- a/sources/test/cg_test_c_with_type_getters.h.ref
+++ b/sources/test/cg_test_c_with_type_getters.h.ref
@@ -310,6 +310,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 #define CRC_selector -2086804524444672762L
 
 extern cql_string_ref _Nonnull selector_stored_procedure_name;

--- a/sources/test/cg_test_c_with_type_getters.h.ref
+++ b/sources/test/cg_test_c_with_type_getters.h.ref
@@ -308,6 +308,8 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
 #define CRC_selector -2086804524444672762L
 
 extern cql_string_ref _Nonnull selector_stored_procedure_name;

--- a/sources/test/cg_test_json_schema.out.ref
+++ b/sources/test/cg_test_json_schema.out.ref
@@ -6051,6 +6051,38 @@
     The statement ending at line XXXX
 
     [[builtin]]
+    DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!
+
+    {
+      "name" : "cql_cursor_diff_col",
+      "args" : [
+        {
+          "name" : "l",
+          "type" : "",
+          "isNotNull" : 0
+        },
+        {
+          "name" : "r",
+          "type" : "",
+          "isNotNull" : 0
+        }
+      ],
+      "attributes" : [
+        {
+          "name" : "cql:builtin",
+          "value" : 1
+        }
+      ],
+      "returnType" : {
+        "type" : "text",
+        "isNotNull" : 1
+      },
+      "createsObject" : 1
+    },
+
+    The statement ending at line XXXX
+
+    [[builtin]]
     DECLARE FUNC cql_box_int (x INT) CREATE OBJECT<cql_box>!
 
     {

--- a/sources/test/cg_test_json_schema.out.ref
+++ b/sources/test/cg_test_json_schema.out.ref
@@ -6051,7 +6051,7 @@
     The statement ending at line XXXX
 
     [[builtin]]
-    DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!
+    DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT
 
     {
       "name" : "cql_cursor_diff_col",
@@ -6075,7 +6075,39 @@
       ],
       "returnType" : {
         "type" : "text",
-        "isNotNull" : 1
+        "isNotNull" : 0
+      },
+      "createsObject" : 1
+    },
+
+    The statement ending at line XXXX
+
+    [[builtin]]
+    DECLARE FUNC cql_cursor_diff_val (l CURSOR, r CURSOR) CREATE TEXT
+
+    {
+      "name" : "cql_cursor_diff_val",
+      "args" : [
+        {
+          "name" : "l",
+          "type" : "",
+          "isNotNull" : 0
+        },
+        {
+          "name" : "r",
+          "type" : "",
+          "isNotNull" : 0
+        }
+      ],
+      "attributes" : [
+        {
+          "name" : "cql:builtin",
+          "value" : 1
+        }
+      ],
+      "returnType" : {
+        "type" : "text",
+        "isNotNull" : 0
       },
       "createsObject" : 1
     },

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -5563,6 +5563,86 @@ BEGIN
   EXPECT!(NOT cql_cursors_equal(G, H));
 END);
 
+TEST!(cursor_diff,
+BEGIN
+   let o1 := 1:box;
+   let o2 := 2:box;
+   cursor C like (a bool!, b int!, c long!, d real!, e text!, f blob!, g object!,
+                          i bool,  j int,  k long, l real, m text, n blob, o object);
+   cursor D like C;
+   cursor X like C;
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+
+   -- all different values
+   fetch X(g,o) from values(o2, o1) @dummy_seed(1) @dummy_nullables;
+
+   fetch D from C;
+   EXPECT!(cql_cursor_diff_col(C,D) is null);
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.a a;
+   EXPECT!(cql_cursor_diff_col(C,D) == "a");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.b b;
+   EXPECT!(cql_cursor_diff_col(C,D) == "b");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.c c;
+   EXPECT!(cql_cursor_diff_col(C,D) == "c");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.d d;
+   EXPECT!(cql_cursor_diff_col(C,D) == "d");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.e e;
+   EXPECT!(cql_cursor_diff_col(C,D) == "e");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.f f;
+   EXPECT!(cql_cursor_diff_col(C,D) == "f");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using X.g g;
+   EXPECT!(cql_cursor_diff_col(C,D) == "g");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null i;
+   EXPECT!(cql_cursor_diff_col(C,D) == "i");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null j;
+   EXPECT!(cql_cursor_diff_col(C,D) == "j");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null k;
+   EXPECT!(cql_cursor_diff_col(C,D) == "k");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null l;
+   EXPECT!(cql_cursor_diff_col(C,D) == "l");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null m;
+   EXPECT!(cql_cursor_diff_col(C,D) == "m");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null n;
+   EXPECT!(cql_cursor_diff_col(C,D) == "n");
+
+   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+   update cursor C using null o;
+   EXPECT!(cql_cursor_diff_col(C,D) == "o");
+
+   fetch C(g) from values(o1) @dummy_seed(0);
+   fetch D(g) from values(o1) @dummy_seed(0);
+   EXPECT!(C.i IS NULL);
+   EXPECT!(D.i IS NULL);
+   EXPECT!(cql_cursor_diff_col(C,D) is null);
+END);
+
 DECLARE PROC get_rows(result object!) OUT UNION (x INT!, y TEXT!, z BOOL);
 
 TEST!(child_results,

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -5563,84 +5563,168 @@ BEGIN
   EXPECT!(NOT cql_cursors_equal(G, H));
 END);
 
-TEST!(cursor_diff,
+TEST!(cursor_diff_col,
 BEGIN
-   let o1 := 1:box;
-   let o2 := 2:box;
-   cursor C like (a bool!, b int!, c long!, d real!, e text!, f blob!, g object!,
-                          i bool,  j int,  k long, l real, m text, n blob, o object);
-   cursor D like C;
-   cursor X like C;
+  let o1 := 1:box;
+  let o2 := 2:box;
+  cursor C like (
+    a bool!, b int!, c long!, d real!, e text!, f blob!, g object!,
+    i bool,  j int,  k long,  l real,  m text,  n blob,  o object);
+  cursor D like C;
+  cursor X like C;
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
 
-   -- all different values
-   fetch X(g,o) from values(o2, o1) @dummy_seed(1) @dummy_nullables;
+  -- all different values
+  fetch X(g,o) from values(o2, o1) @dummy_seed(1) @dummy_nullables;
 
-   fetch D from C;
-   EXPECT!(cql_cursor_diff_col(C,D) is null);
+  fetch D from C;
+  EXPECT!(cql_cursor_diff_col(C,D) is null);
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.a a;
-   EXPECT!(cql_cursor_diff_col(C,D) == "a");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.a a;
+  EXPECT!(cql_cursor_diff_col(C,D) == "a");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.b b;
-   EXPECT!(cql_cursor_diff_col(C,D) == "b");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.b b;
+  EXPECT!(cql_cursor_diff_col(C,D) == "b");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.c c;
-   EXPECT!(cql_cursor_diff_col(C,D) == "c");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.c c;
+  EXPECT!(cql_cursor_diff_col(C,D) == "c");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.d d;
-   EXPECT!(cql_cursor_diff_col(C,D) == "d");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.d d;
+  EXPECT!(cql_cursor_diff_col(C,D) == "d");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.e e;
-   EXPECT!(cql_cursor_diff_col(C,D) == "e");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.e e;
+  EXPECT!(cql_cursor_diff_col(C,D) == "e");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.f f;
-   EXPECT!(cql_cursor_diff_col(C,D) == "f");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.f f;
+  EXPECT!(cql_cursor_diff_col(C,D) == "f");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using X.g g;
-   EXPECT!(cql_cursor_diff_col(C,D) == "g");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.g g;
+  EXPECT!(cql_cursor_diff_col(C,D) == "g");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null i;
-   EXPECT!(cql_cursor_diff_col(C,D) == "i");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null i;
+  EXPECT!(cql_cursor_diff_col(C,D) == "i");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null j;
-   EXPECT!(cql_cursor_diff_col(C,D) == "j");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null j;
+  EXPECT!(cql_cursor_diff_col(C,D) == "j");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null k;
-   EXPECT!(cql_cursor_diff_col(C,D) == "k");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null k;
+  EXPECT!(cql_cursor_diff_col(C,D) == "k");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null l;
-   EXPECT!(cql_cursor_diff_col(C,D) == "l");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null l;
+  EXPECT!(cql_cursor_diff_col(C,D) == "l");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null m;
-   EXPECT!(cql_cursor_diff_col(C,D) == "m");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null m;
+  EXPECT!(cql_cursor_diff_col(C,D) == "m");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null n;
-   EXPECT!(cql_cursor_diff_col(C,D) == "n");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null n;
+  EXPECT!(cql_cursor_diff_col(C,D) == "n");
 
-   fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
-   update cursor C using null o;
-   EXPECT!(cql_cursor_diff_col(C,D) == "o");
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null o;
+  EXPECT!(cql_cursor_diff_col(C,D) == "o");
 
-   fetch C(g) from values(o1) @dummy_seed(0);
-   fetch D(g) from values(o1) @dummy_seed(0);
-   EXPECT!(C.i IS NULL);
-   EXPECT!(D.i IS NULL);
-   EXPECT!(cql_cursor_diff_col(C,D) is null);
+  fetch C(g) from values(o1) @dummy_seed(0);
+  fetch D(g) from values(o1) @dummy_seed(0);
+  EXPECT!(C.i IS NULL);
+  EXPECT!(D.i IS NULL);
+  EXPECT!(cql_cursor_diff_col(C,D) is null);
+END);
+
+TEST!(cursor_diff_val,
+BEGIN
+  let o1 := 1:box;
+  let o2 := 2:box;
+  cursor C like (
+    a bool!, b int!, c long!, d real!, e text!, f blob!, g object!,
+    i bool,  j int,  k long,  l real,  m text,  n blob,  o object);
+  cursor D like C;
+  cursor X like C;
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+
+  -- all different values
+  fetch X(g,o) from values(o2, o1) @dummy_seed(1) @dummy_nullables;
+
+  fetch D from C;
+  EXPECT!(cql_cursor_diff_val(C,D) is null);
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.a a;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:a c1:true c2:false");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.b b;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:b c1:1 c2:0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.c c;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:c c1:1 c2:0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.d d;
+  let diff := cql_cursor_diff_val(C,D);
+  EXPECT!(diff == "column:d c1:1 c2:0" or diff == "column:d c1:1.0 c2:0.0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.e e;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:e c1:e_1 c2:e_0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.f f;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:f c1:length 3 blob c2:length 3 blob");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using X.g g;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:g c1:generic object c2:generic object");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null i;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:i c1:null c2:false");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null j;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:j c1:null c2:0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null k;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:k c1:null c2:0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null l;
+  set diff := cql_cursor_diff_val(C,D);
+  EXPECT!(diff == "column:l c1:null c2:0" or diff == "column:l c1:null c2:0.0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null m;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:m c1:null c2:m_0");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null n;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:n c1:null c2:length 3 blob");
+
+  fetch C(g,o) from values(o1, o2) @dummy_seed(0) @dummy_nullables;
+  update cursor C using null o;
+  EXPECT!(cql_cursor_diff_val(C,D) == "column:o c1:null c2:generic object");
+
+  fetch C(g) from values(o1) @dummy_seed(0);
+  fetch D(g) from values(o1) @dummy_seed(0);
+  EXPECT!(C.i IS NULL);
+  EXPECT!(D.i IS NULL);
+  EXPECT!(cql_cursor_diff_val(C,D) is null);
 END);
 
 DECLARE PROC get_rows(result object!) OUT UNION (x INT!, y TEXT!, z BOOL);

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1092,9 +1092,8 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0252: @PROC literal can only appear
 test/sem_test.sql:XXXX:1: error: in str : CQL0252: @PROC literal can only appear inside of procedures
 test/sem_test.sql:XXXX:1: error: in str : CQL0252: @PROC literal can only appear inside of procedures
 test/sem_test.sql:XXXX:1: error: in str : CQL0252: @PROC literal can only appear inside of procedures
-test/sem_test.sql:XXXX:1: error: in num : CQL0341: argument must be a variable in function 'cql_cursor_diff_col'
+test/sem_test.sql:XXXX:1: error: in num : CQL0205: not a cursor '1'
 test/sem_test.sql:XXXX:1: error: in str : CQL0205: not a cursor 'an_int'
-test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'cql_cursor_diff_col'
 test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'cql_cursor_diff_val'
 test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fetch [cursor]' 'c1'
 test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fetch [cursor]' 'C'

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1094,7 +1094,6 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0252: @PROC literal can only appear
 test/sem_test.sql:XXXX:1: error: in str : CQL0252: @PROC literal can only appear inside of procedures
 test/sem_test.sql:XXXX:1: error: in num : CQL0205: not a cursor '1'
 test/sem_test.sql:XXXX:1: error: in str : CQL0205: not a cursor 'an_int'
-test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'cql_cursor_diff_val'
 test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fetch [cursor]' 'c1'
 test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fetch [cursor]' 'C'
 test/sem_test.sql:XXXX:1: error: in str : CQL0061: in cql_cursor_diff_col, all columns must be an exact type match (expected integer notnull; found text notnull) 'x'

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -51414,25 +51414,6 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0205: not a cursor 'an_int'
 
 The statement ending at line XXXX
 
-SET a_string := cql_cursor_diff_val(an_int, an_int2, 1);
-
-test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'cql_cursor_diff_val'
-
-  {assign}: err
-  | {name a_string}: a_string: text variable was_set
-  | {call}: err
-    | {name cql_cursor_diff_val}: err
-    | {call_arg_list}
-      | {call_filter_clause}
-      | {arg_list}: ok
-        | {name an_int}: an_int: integer variable was_set
-        | {arg_list}
-          | {name an_int2}: an_int2: integer variable was_set
-          | {arg_list}
-            | {int 1}: integer notnull
-
-The statement ending at line XXXX
-
 PROC cql_cursor_diff_col_without_cursor_arg ()
 BEGIN
   DECLARE x INT!;
@@ -51970,22 +51951,7 @@ BEGIN
     SELECT nullable(1) AS x, 'v' AS y;
   FETCH c1;
   FETCH c2;
-  CALL printf(CASE
-    WHEN c1.x IS NOT c2.x THEN printf('column:%s c1:%s c2:%s', 'x', CASE
-      WHEN c1.x IS NULL THEN 'null'
-      ELSE printf('%d', c1.x)
-    END, CASE
-      WHEN c2.x IS NULL THEN 'null'
-      ELSE printf('%d', c2.x)
-    END)
-    WHEN c1.y IS NOT c2.y THEN printf('column:%s c1:%s c2:%s', 'y', CASE
-      WHEN nullable(c1.y) IS NULL THEN 'null'
-      ELSE printf('%s', c1.y)
-    END, CASE
-      WHEN nullable(c2.y) IS NULL THEN 'null'
-      ELSE printf('%s', c2.y)
-    END)
-  END);
+  CALL printf(cql_cursor_diff_val(c1, c2));
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -51993,7 +51959,7 @@ END;
   | {proc_params_stmts}
     | {stmt_list}: ok
       | {declare_cursor}: c1: select: { x: integer, y: text notnull } variable dml_proc
-      | | {name c1}: c1: select: { x: integer, y: text notnull } variable dml_proc shape_storage
+      | | {name c1}: c1: select: { x: integer, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer, y: text notnull }
       |   | {select_core_list}: select: { x: integer, y: text notnull }
       |   | | {select_core}: select: { x: integer, y: text notnull }
@@ -52021,7 +51987,7 @@ END;
       |     | {select_limit}
       |       | {select_offset}
       | {declare_cursor}: c2: select: { x: integer, y: text notnull } variable dml_proc
-      | | {name c2}: c2: select: { x: integer, y: text notnull } variable dml_proc shape_storage
+      | | {name c2}: c2: select: { x: integer, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer, y: text notnull }
       |   | {select_core_list}: select: { x: integer, y: text notnull }
       |   | | {select_core}: select: { x: integer, y: text notnull }
@@ -52055,146 +52021,14 @@ END;
       | {call_stmt}: ok
         | {name printf}: ok
         | {arg_list}: ok
-          | {case_expr}: text
-            | {connector}: text
-              | {case_list}: text notnull
-                | {when}: text notnull
-                | | {is_not}: bool notnull
-                | | | {dot}: c1.x: integer variable
-                | | | | {name c1}
-                | | | | {name x}
-                | | | {dot}: c2.x: integer variable
-                | |   | {name c2}
-                | |   | {name x}
-                | | {call}: text notnull
-                |   | {name printf}: text notnull
-                |   | {call_arg_list}
-                |     | {call_filter_clause}
-                |     | {arg_list}: ok
-                |       | {strlit 'column:%s c1:%s c2:%s'}: text notnull
-                |       | {arg_list}
-                |         | {strlit 'x'}: text notnull
-                |         | {arg_list}
-                |           | {case_expr}: text notnull
-                |           | | {connector}: text notnull
-                |           |   | {case_list}: text notnull
-                |           |   | | {when}: text notnull
-                |           |   |   | {is}: bool notnull
-                |           |   |   | | {dot}: c1.x: integer variable
-                |           |   |   | | | {name c1}
-                |           |   |   | | | {name x}
-                |           |   |   | | {null}: null
-                |           |   |   | {strlit 'null'}: text notnull
-                |           |   | {call}: text notnull
-                |           |     | {name printf}: text notnull
-                |           |     | {call_arg_list}
-                |           |       | {call_filter_clause}
-                |           |       | {arg_list}: ok
-                |           |         | {strlit '%d'}: text notnull
-                |           |         | {arg_list}
-                |           |           | {call}: c1.x: integer notnull variable
-                |           |             | {name cql_inferred_notnull}: c1.x: integer notnull variable
-                |           |             | {call_arg_list}
-                |           |               | {call_filter_clause}
-                |           |               | {arg_list}: ok
-                |           |                 | {dot}: c1.x: integer inferred_notnull variable
-                |           |                   | {name c1}
-                |           |                   | {name x}
-                |           | {arg_list}
-                |             | {case_expr}: text notnull
-                |               | {connector}: text notnull
-                |                 | {case_list}: text notnull
-                |                 | | {when}: text notnull
-                |                 |   | {is}: bool notnull
-                |                 |   | | {dot}: c2.x: integer variable
-                |                 |   | | | {name c2}
-                |                 |   | | | {name x}
-                |                 |   | | {null}: null
-                |                 |   | {strlit 'null'}: text notnull
-                |                 | {call}: text notnull
-                |                   | {name printf}: text notnull
-                |                   | {call_arg_list}
-                |                     | {call_filter_clause}
-                |                     | {arg_list}: ok
-                |                       | {strlit '%d'}: text notnull
-                |                       | {arg_list}
-                |                         | {call}: c2.x: integer notnull variable
-                |                           | {name cql_inferred_notnull}: c2.x: integer notnull variable
-                |                           | {call_arg_list}
-                |                             | {call_filter_clause}
-                |                             | {arg_list}: ok
-                |                               | {dot}: c2.x: integer inferred_notnull variable
-                |                                 | {name c2}
-                |                                 | {name x}
-                | {case_list}: text notnull
-                  | {when}: text notnull
-                    | {is_not}: bool notnull
-                    | | {dot}: c1.y: text notnull variable
-                    | | | {name c1}
-                    | | | {name y}
-                    | | {dot}: c2.y: text notnull variable
-                    |   | {name c2}
-                    |   | {name y}
-                    | {call}: text notnull
-                      | {name printf}: text notnull
-                      | {call_arg_list}
-                        | {call_filter_clause}
-                        | {arg_list}: ok
-                          | {strlit 'column:%s c1:%s c2:%s'}: text notnull
-                          | {arg_list}
-                            | {strlit 'y'}: text notnull
-                            | {arg_list}
-                              | {case_expr}: text notnull
-                              | | {connector}: text notnull
-                              |   | {case_list}: text notnull
-                              |   | | {when}: text notnull
-                              |   |   | {is}: bool notnull
-                              |   |   | | {call}: c1.y: text variable
-                              |   |   | | | {name nullable}: c1.y: text variable
-                              |   |   | | | {call_arg_list}
-                              |   |   | |   | {call_filter_clause}
-                              |   |   | |   | {arg_list}: ok
-                              |   |   | |     | {dot}: c1.y: text notnull variable
-                              |   |   | |       | {name c1}
-                              |   |   | |       | {name y}
-                              |   |   | | {null}: null
-                              |   |   | {strlit 'null'}: text notnull
-                              |   | {call}: text notnull
-                              |     | {name printf}: text notnull
-                              |     | {call_arg_list}
-                              |       | {call_filter_clause}
-                              |       | {arg_list}: ok
-                              |         | {strlit '%s'}: text notnull
-                              |         | {arg_list}
-                              |           | {dot}: c1.y: text notnull variable
-                              |             | {name c1}
-                              |             | {name y}
-                              | {arg_list}
-                                | {case_expr}: text notnull
-                                  | {connector}: text notnull
-                                    | {case_list}: text notnull
-                                    | | {when}: text notnull
-                                    |   | {is}: bool notnull
-                                    |   | | {call}: c2.y: text variable
-                                    |   | | | {name nullable}: c2.y: text variable
-                                    |   | | | {call_arg_list}
-                                    |   | |   | {call_filter_clause}
-                                    |   | |   | {arg_list}: ok
-                                    |   | |     | {dot}: c2.y: text notnull variable
-                                    |   | |       | {name c2}
-                                    |   | |       | {name y}
-                                    |   | | {null}: null
-                                    |   | {strlit 'null'}: text notnull
-                                    | {call}: text notnull
-                                      | {name printf}: text notnull
-                                      | {call_arg_list}
-                                        | {call_filter_clause}
-                                        | {arg_list}: ok
-                                          | {strlit '%s'}: text notnull
-                                          | {arg_list}
-                                            | {dot}: c2.y: text notnull variable
-                                              | {name c2}
-                                              | {name y}
+          | {call}: text
+            | {name cql_cursor_diff_val}: text
+            | {call_arg_list}
+              | {call_filter_clause}
+              | {arg_list}: ok
+                | {name c1}: c1: select: { x: integer, y: text notnull } variable dml_proc shape_storage serialize
+                | {arg_list}
+                  | {name c2}: c2: select: { x: integer, y: text notnull } variable dml_proc shape_storage serialize
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -51613,7 +51613,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0061: in cql_cursor_diff_col, all c
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull } variable dml_proc shape_storage serialize
+              | {name c1}: c1: select: { x: integer notnull } variable dml_proc shape_storage
               | {arg_list}
                 | {name c2}: err
 
@@ -51688,9 +51688,9 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0342: cursor arguments must have i
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc shape_storage serialize
+              | {name c1}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc shape_storage
               | {arg_list}
-                | {name c2}: c2: select: { x: integer notnull } variable dml_proc shape_storage serialize
+                | {name c2}: c2: select: { x: integer notnull } variable dml_proc shape_storage
 
 The statement ending at line XXXX
 
@@ -51780,7 +51780,7 @@ only in 2nd: v text notnull
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
               | {arg_list}
                 | {name c2}: err
 
@@ -51858,9 +51858,9 @@ END;
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
               | {arg_list}
-                | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+                | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
 
 The statement ending at line XXXX
 
@@ -51937,9 +51937,9 @@ END;
             | {call_arg_list}
               | {call_filter_clause}
               | {arg_list}: ok
-                | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+                | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
                 | {arg_list}
-                  | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+                  | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
 
 The statement ending at line XXXX
 
@@ -52026,9 +52026,9 @@ END;
             | {call_arg_list}
               | {call_filter_clause}
               | {arg_list}: ok
-                | {name c1}: c1: select: { x: integer, y: text notnull } variable dml_proc shape_storage serialize
+                | {name c1}: c1: select: { x: integer, y: text notnull } variable dml_proc shape_storage
                 | {arg_list}
-                  | {name c2}: c2: select: { x: integer, y: text notnull } variable dml_proc shape_storage serialize
+                  | {name c2}: c2: select: { x: integer, y: text notnull } variable dml_proc shape_storage
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -51382,7 +51382,7 @@ The statement ending at line XXXX
 
 SET a_string := cql_cursor_diff_col(1, "bogus");
 
-test/sem_test.sql:XXXX:1: error: in num : CQL0341: argument must be a variable in function 'cql_cursor_diff_col'
+test/sem_test.sql:XXXX:1: error: in num : CQL0205: not a cursor '1'
 
   {assign}: err
   | {name a_string}: a_string: text variable was_set
@@ -51393,7 +51393,7 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0341: argument must be a variable i
       | {arg_list}: ok
         | {int 1}: err
         | {arg_list}
-          | {strlit 'bogus'}: text notnull
+          | {strlit 'bogus'}
 
 The statement ending at line XXXX
 
@@ -51410,26 +51410,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0205: not a cursor 'an_int'
       | {arg_list}: ok
         | {name an_int}: err
         | {arg_list}
-          | {name an_int2}: an_int2: integer variable was_set
-
-The statement ending at line XXXX
-
-SET a_string := cql_cursor_diff_col(an_int, an_int2, 1);
-
-test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'cql_cursor_diff_col'
-
-  {assign}: err
-  | {name a_string}: a_string: text variable was_set
-  | {call}: err
-    | {name cql_cursor_diff_col}: err
-    | {call_arg_list}
-      | {call_filter_clause}
-      | {arg_list}: ok
-        | {name an_int}: an_int: integer variable was_set
-        | {arg_list}
-          | {name an_int2}: an_int2: integer variable was_set
-          | {arg_list}
-            | {int 1}: integer notnull
+          | {name an_int2}
 
 The statement ending at line XXXX
 
@@ -51544,7 +51525,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0067: cursor was not used with 'fet
             | {arg_list}: ok
               | {name c1}: err
               | {arg_list}
-                | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+                | {name c2}
 
 The statement ending at line XXXX
 
@@ -51605,7 +51586,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0061: in cql_cursor_diff_col, all c
   | {proc_params_stmts}
     | {stmt_list}: err
       | {declare_cursor}: c1: select: { x: integer notnull } variable dml_proc
-      | | {name c1}: c1: select: { x: integer notnull } variable dml_proc shape_storage
+      | | {name c1}: c1: select: { x: integer notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull }
       |   | {select_core_list}: select: { x: integer notnull }
       |   | | {select_core}: select: { x: integer notnull }
@@ -51623,7 +51604,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0061: in cql_cursor_diff_col, all c
       |     | {select_limit}
       |       | {select_offset}
       | {declare_cursor}: c2: select: { x: text notnull } variable dml_proc
-      | | {name c2}: c2: select: { x: text notnull } variable dml_proc shape_storage
+      | | {name c2}: c2: select: { x: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: text notnull }
       |   | {select_core_list}: select: { x: text notnull }
       |   | | {select_core}: select: { x: text notnull }
@@ -51651,7 +51632,7 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0061: in cql_cursor_diff_col, all c
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull } variable dml_proc shape_storage
+              | {name c1}: c1: select: { x: integer notnull } variable dml_proc shape_storage serialize
               | {arg_list}
                 | {name c2}: err
 
@@ -51675,7 +51656,7 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0342: cursor arguments must have i
   | {proc_params_stmts}
     | {stmt_list}: err
       | {declare_cursor}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc
-      | | {name c1}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc shape_storage
+      | | {name c1}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull, z: text notnull }
       |   | {select_core_list}: select: { x: integer notnull, z: text notnull }
       |   | | {select_core}: select: { x: integer notnull, z: text notnull }
@@ -51698,7 +51679,7 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0342: cursor arguments must have i
       |     | {select_limit}
       |       | {select_offset}
       | {declare_cursor}: c2: select: { x: integer notnull } variable dml_proc
-      | | {name c2}: c2: select: { x: integer notnull } variable dml_proc shape_storage
+      | | {name c2}: c2: select: { x: integer notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull }
       |   | {select_core_list}: select: { x: integer notnull }
       |   | | {select_core}: select: { x: integer notnull }
@@ -51726,9 +51707,9 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0342: cursor arguments must have i
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc shape_storage
+              | {name c1}: c1: select: { x: integer notnull, z: text notnull } variable dml_proc shape_storage serialize
               | {arg_list}
-                | {name c2}: c2: select: { x: integer notnull } variable dml_proc shape_storage
+                | {name c2}: c2: select: { x: integer notnull } variable dml_proc shape_storage serialize
 
 The statement ending at line XXXX
 
@@ -51762,7 +51743,7 @@ only in 2nd: v text notnull
   | {proc_params_stmts}
     | {stmt_list}: err
       | {declare_cursor}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc
-      | | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+      | | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull, y: text notnull }
       |   | {select_core_list}: select: { x: integer notnull, y: text notnull }
       |   | | {select_core}: select: { x: integer notnull, y: text notnull }
@@ -51785,7 +51766,7 @@ only in 2nd: v text notnull
       |     | {select_limit}
       |       | {select_offset}
       | {declare_cursor}: c2: select: { z: integer notnull, v: text notnull } variable dml_proc
-      | | {name c2}: c2: select: { z: integer notnull, v: text notnull } variable dml_proc shape_storage
+      | | {name c2}: c2: select: { z: integer notnull, v: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { z: integer notnull, v: text notnull }
       |   | {select_core_list}: select: { z: integer notnull, v: text notnull }
       |   | | {select_core}: select: { z: integer notnull, v: text notnull }
@@ -51818,7 +51799,7 @@ only in 2nd: v text notnull
           | {call_arg_list}
             | {call_filter_clause}
             | {arg_list}: ok
-              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
               | {arg_list}
                 | {name c2}: err
 
@@ -51832,10 +51813,7 @@ BEGIN
     SELECT 1 AS x, 'y' AS y;
   FETCH c1;
   FETCH c2;
-  SET a_string := CASE
-    WHEN c1.x IS NOT c2.x THEN 'x'
-    WHEN c1.y IS NOT c2.y THEN 'y'
-  END;
+  SET a_string := cql_cursor_diff_col(c1, c2);
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -51843,7 +51821,7 @@ END;
   | {proc_params_stmts}
     | {stmt_list}: ok
       | {declare_cursor}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc
-      | | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+      | | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull, y: text notnull }
       |   | {select_core_list}: select: { x: integer notnull, y: text notnull }
       |   | | {select_core}: select: { x: integer notnull, y: text notnull }
@@ -51866,7 +51844,7 @@ END;
       |     | {select_limit}
       |       | {select_offset}
       | {declare_cursor}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc
-      | | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+      | | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull, y: text notnull }
       |   | {select_core_list}: select: { x: integer notnull, y: text notnull }
       |   | | {select_core}: select: { x: integer notnull, y: text notnull }
@@ -51894,28 +51872,14 @@ END;
       | | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
       | {assign}: a_string: text variable was_set
         | {name a_string}: a_string: text variable was_set
-        | {case_expr}: text
-          | {connector}: text
-            | {case_list}: text notnull
-              | {when}: text notnull
-              | | {is_not}: bool notnull
-              | | | {dot}: c1.x: integer notnull variable
-              | | | | {name c1}
-              | | | | {name x}
-              | | | {dot}: c2.x: integer notnull variable
-              | |   | {name c2}
-              | |   | {name x}
-              | | {strlit 'x'}: text notnull
-              | {case_list}: text notnull
-                | {when}: text notnull
-                  | {is_not}: bool notnull
-                  | | {dot}: c1.y: text notnull variable
-                  | | | {name c1}
-                  | | | {name y}
-                  | | {dot}: c2.y: text notnull variable
-                  |   | {name c2}
-                  |   | {name y}
-                  | {strlit 'y'}: text notnull
+        | {call}: text
+          | {name cql_cursor_diff_col}: text
+          | {call_arg_list}
+            | {call_filter_clause}
+            | {arg_list}: ok
+              | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+              | {arg_list}
+                | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
 
 The statement ending at line XXXX
 
@@ -51927,10 +51891,7 @@ BEGIN
     SELECT 1 AS x, 'v' AS y;
   FETCH c1;
   FETCH c2;
-  CALL printf(CASE
-    WHEN c1.x IS NOT c2.x THEN 'x'
-    WHEN c1.y IS NOT c2.y THEN 'y'
-  END);
+  CALL printf(cql_cursor_diff_col(c1, c2));
 END;
 
   {create_proc_stmt}: ok dml_proc
@@ -51938,7 +51899,7 @@ END;
   | {proc_params_stmts}
     | {stmt_list}: ok
       | {declare_cursor}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc
-      | | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+      | | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull, y: text notnull }
       |   | {select_core_list}: select: { x: integer notnull, y: text notnull }
       |   | | {select_core}: select: { x: integer notnull, y: text notnull }
@@ -51961,7 +51922,7 @@ END;
       |     | {select_limit}
       |       | {select_offset}
       | {declare_cursor}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc
-      | | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage
+      | | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
       | | {select_stmt}: select: { x: integer notnull, y: text notnull }
       |   | {select_core_list}: select: { x: integer notnull, y: text notnull }
       |   | | {select_core}: select: { x: integer notnull, y: text notnull }
@@ -51990,28 +51951,14 @@ END;
       | {call_stmt}: ok
         | {name printf}: ok
         | {arg_list}: ok
-          | {case_expr}: text
-            | {connector}: text
-              | {case_list}: text notnull
-                | {when}: text notnull
-                | | {is_not}: bool notnull
-                | | | {dot}: c1.x: integer notnull variable
-                | | | | {name c1}
-                | | | | {name x}
-                | | | {dot}: c2.x: integer notnull variable
-                | |   | {name c2}
-                | |   | {name x}
-                | | {strlit 'x'}: text notnull
-                | {case_list}: text notnull
-                  | {when}: text notnull
-                    | {is_not}: bool notnull
-                    | | {dot}: c1.y: text notnull variable
-                    | | | {name c1}
-                    | | | {name y}
-                    | | {dot}: c2.y: text notnull variable
-                    |   | {name c2}
-                    |   | {name y}
-                    | {strlit 'y'}: text notnull
+          | {call}: text
+            | {name cql_cursor_diff_col}: text
+            | {call_arg_list}
+              | {call_filter_clause}
+              | {arg_list}: ok
+                | {name c1}: c1: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
+                | {arg_list}
+                  | {name c2}: c2: select: { x: integer notnull, y: text notnull } variable dml_proc shape_storage serialize
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -13723,14 +13723,6 @@ set a_string := cql_cursor_diff_col(1, "bogus");
 -- +1 error:
 set a_string := cql_cursor_diff_col(an_int, an_int2);
 
--- TEST: call cql_cursor_diff_val with incorrect number of arguments
--- + {assign}: err
--- + {call}: err
--- + {name cql_cursor_diff_val}: err
--- * error: % function got incorrect number of arguments 'cql_cursor_diff_val'
--- +1 error:
-set a_string := cql_cursor_diff_val(an_int, an_int2, 1);
-
 -- TEST: call cql_cursor_diff_col with cursor with fetch value and same shape
 -- + {create_proc_stmt}: err
 -- + {assign}: err
@@ -13843,22 +13835,7 @@ begin
 end;
 
 -- TEST: call cql_cursor_diff_val from another func
--- + CALL printf(CASE
--- + WHEN c1.x IS NOT c2.x THEN printf('column:%s c1:%s c2:%s', 'x', CASE
--- + WHEN c1.x IS NULL THEN 'null'
--- + ELSE printf('%d', c1.x)
--- + END, CASE
--- + WHEN c2.x IS NULL THEN 'null'
--- + ELSE printf('%d', c2.x)
--- + END)
--- + WHEN c1.y IS NOT c2.y THEN printf('column:%s c1:%s c2:%s', 'y', CASE
--- + WHEN nullable(c1.y) IS NULL THEN 'null'
--- + ELSE printf('%s', c1.y)
--- + END, CASE
--- + WHEN nullable(c2.y) IS NULL THEN 'null'
--- + ELSE printf('%s', c2.y)
--- + END)
--- + END);
+-- + CALL printf(cql_cursor_diff_val(c1, c2));
 -- + {create_proc_stmt}: ok dml_proc
 -- + {call_stmt}: ok
 -- - error:

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -13712,7 +13712,7 @@ end;
 -- TEST: call cql_cursor_diff_col with non variable arguments
 -- + {assign}: err
 -- + {call}: err
--- * error: % argument must be a variable in function 'cql_cursor_diff_col'
+-- * error: % CQL0205: not a cursor '1'
 -- +1 error:
 set a_string := cql_cursor_diff_col(1, "bogus");
 
@@ -13722,14 +13722,6 @@ set a_string := cql_cursor_diff_col(1, "bogus");
 -- * error: % not a cursor 'an_int'
 -- +1 error:
 set a_string := cql_cursor_diff_col(an_int, an_int2);
-
--- TEST: call cql_cursor_diff_col with incorrect number of arguments
--- + {assign}: err
--- + {call}: err
--- + {name cql_cursor_diff_col}: err
--- * error: % function got incorrect number of arguments 'cql_cursor_diff_col'
--- +1 error:
-set a_string := cql_cursor_diff_col(an_int, an_int2, 1);
 
 -- TEST: call cql_cursor_diff_val with incorrect number of arguments
 -- + {assign}: err
@@ -13823,10 +13815,7 @@ begin
 end;
 
 -- TEST: call cql_cursor_diff_col with cursor with fetch value and same shape
--- + SET a_string := CASE
--- + WHEN c1.x IS NOT c2.x THEN 'x'
--- + WHEN c1.y IS NOT c2.y THEN 'y'
--- + END;
+-- + SET a_string := cql_cursor_diff_col(c1, c2);
 -- + {create_proc_stmt}: ok dml_proc
 -- + {assign}: a_string: text variable
 -- - error:
@@ -13840,10 +13829,7 @@ begin
 end;
 
 -- TEST: call cql_cursor_diff_col from another func
--- + CALL printf(CASE
--- + WHEN c1.x IS NOT c2.x THEN 'x'
--- + WHEN c1.y IS NOT c2.y THEN 'y'
--- + END);
+-- + CALL printf(cql_cursor_diff_col(c1, c2));
 -- + {create_proc_stmt}: ok dml_proc
 -- + {call_stmt}: ok
 -- - error:

--- a/sources/test/sem_test_dev.out.ref
+++ b/sources/test/sem_test_dev.out.ref
@@ -973,6 +973,34 @@ DECLARE FUNC cql_cursors_equal (l CURSOR, r CURSOR) BOOL!;
 The statement ending at line XXXX
 
 [[builtin]]
+DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: text notnull create_func
+    | {name cql_cursor_diff_col}: text notnull create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: l: cursor variable in
+      | | | {param_detail}: l: cursor variable in
+      | |   | {name l}: l: cursor variable in
+      | |   | {type_cursor}: cursor
+      | | {params}
+      |   | {param}: r: cursor variable in
+      |     | {param_detail}: r: cursor variable in
+      |       | {name r}: r: cursor variable in
+      |       | {type_cursor}: cursor
+      | {create_data_type}: text notnull create_func
+        | {notnull}: text notnull
+          | {type_text}: text
+
+The statement ending at line XXXX
+
+[[builtin]]
 DECLARE FUNC cql_box_int (x INT) CREATE OBJECT<cql_box>!;
 
   {stmt_and_attr}: ok

--- a/sources/test/sem_test_dev.out.ref
+++ b/sources/test/sem_test_dev.out.ref
@@ -973,7 +973,7 @@ DECLARE FUNC cql_cursors_equal (l CURSOR, r CURSOR) BOOL!;
 The statement ending at line XXXX
 
 [[builtin]]
-DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
+DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT;
 
   {stmt_and_attr}: ok
   | {misc_attrs}: ok
@@ -981,8 +981,8 @@ DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
   |   | {dot}
   |     | {name cql}
   |     | {name builtin}
-  | {declare_func_stmt}: text notnull create_func
-    | {name cql_cursor_diff_col}: text notnull create_func
+  | {declare_func_stmt}: text create_func
+    | {name cql_cursor_diff_col}: text create_func
     | {func_params_return}
       | {params}: ok
       | | {param}: l: cursor variable in
@@ -994,9 +994,35 @@ DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
       |     | {param_detail}: r: cursor variable in
       |       | {name r}: r: cursor variable in
       |       | {type_cursor}: cursor
-      | {create_data_type}: text notnull create_func
-        | {notnull}: text notnull
-          | {type_text}: text
+      | {create_data_type}: text create_func
+        | {type_text}: text
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE FUNC cql_cursor_diff_val (l CURSOR, r CURSOR) CREATE TEXT;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: text create_func
+    | {name cql_cursor_diff_val}: text create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: l: cursor variable in
+      | | | {param_detail}: l: cursor variable in
+      | |   | {name l}: l: cursor variable in
+      | |   | {type_cursor}: cursor
+      | | {params}
+      |   | {param}: r: cursor variable in
+      |     | {param_detail}: r: cursor variable in
+      |       | {name r}: r: cursor variable in
+      |       | {type_cursor}: cursor
+      | {create_data_type}: text create_func
+        | {type_text}: text
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test_migrate.out.ref
+++ b/sources/test/sem_test_migrate.out.ref
@@ -973,6 +973,34 @@ DECLARE FUNC cql_cursors_equal (l CURSOR, r CURSOR) BOOL!;
 The statement ending at line XXXX
 
 [[builtin]]
+DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: text notnull create_func
+    | {name cql_cursor_diff_col}: text notnull create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: l: cursor variable in
+      | | | {param_detail}: l: cursor variable in
+      | |   | {name l}: l: cursor variable in
+      | |   | {type_cursor}: cursor
+      | | {params}
+      |   | {param}: r: cursor variable in
+      |     | {param_detail}: r: cursor variable in
+      |       | {name r}: r: cursor variable in
+      |       | {type_cursor}: cursor
+      | {create_data_type}: text notnull create_func
+        | {notnull}: text notnull
+          | {type_text}: text
+
+The statement ending at line XXXX
+
+[[builtin]]
 DECLARE FUNC cql_box_int (x INT) CREATE OBJECT<cql_box>!;
 
   {stmt_and_attr}: ok

--- a/sources/test/sem_test_migrate.out.ref
+++ b/sources/test/sem_test_migrate.out.ref
@@ -973,7 +973,7 @@ DECLARE FUNC cql_cursors_equal (l CURSOR, r CURSOR) BOOL!;
 The statement ending at line XXXX
 
 [[builtin]]
-DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
+DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT;
 
   {stmt_and_attr}: ok
   | {misc_attrs}: ok
@@ -981,8 +981,8 @@ DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
   |   | {dot}
   |     | {name cql}
   |     | {name builtin}
-  | {declare_func_stmt}: text notnull create_func
-    | {name cql_cursor_diff_col}: text notnull create_func
+  | {declare_func_stmt}: text create_func
+    | {name cql_cursor_diff_col}: text create_func
     | {func_params_return}
       | {params}: ok
       | | {param}: l: cursor variable in
@@ -994,9 +994,35 @@ DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
       |     | {param_detail}: r: cursor variable in
       |       | {name r}: r: cursor variable in
       |       | {type_cursor}: cursor
-      | {create_data_type}: text notnull create_func
-        | {notnull}: text notnull
-          | {type_text}: text
+      | {create_data_type}: text create_func
+        | {type_text}: text
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE FUNC cql_cursor_diff_val (l CURSOR, r CURSOR) CREATE TEXT;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: text create_func
+    | {name cql_cursor_diff_val}: text create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: l: cursor variable in
+      | | | {param_detail}: l: cursor variable in
+      | |   | {name l}: l: cursor variable in
+      | |   | {type_cursor}: cursor
+      | | {params}
+      |   | {param}: r: cursor variable in
+      |     | {param_detail}: r: cursor variable in
+      |       | {name r}: r: cursor variable in
+      |       | {type_cursor}: cursor
+      | {create_data_type}: text create_func
+        | {type_text}: text
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test_prev.out.ref
+++ b/sources/test/sem_test_prev.out.ref
@@ -973,6 +973,34 @@ DECLARE FUNC cql_cursors_equal (l CURSOR, r CURSOR) BOOL!;
 The statement ending at line XXXX
 
 [[builtin]]
+DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: text notnull create_func
+    | {name cql_cursor_diff_col}: text notnull create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: l: cursor variable in
+      | | | {param_detail}: l: cursor variable in
+      | |   | {name l}: l: cursor variable in
+      | |   | {type_cursor}: cursor
+      | | {params}
+      |   | {param}: r: cursor variable in
+      |     | {param_detail}: r: cursor variable in
+      |       | {name r}: r: cursor variable in
+      |       | {type_cursor}: cursor
+      | {create_data_type}: text notnull create_func
+        | {notnull}: text notnull
+          | {type_text}: text
+
+The statement ending at line XXXX
+
+[[builtin]]
 DECLARE FUNC cql_box_int (x INT) CREATE OBJECT<cql_box>!;
 
   {stmt_and_attr}: ok

--- a/sources/test/sem_test_prev.out.ref
+++ b/sources/test/sem_test_prev.out.ref
@@ -973,7 +973,7 @@ DECLARE FUNC cql_cursors_equal (l CURSOR, r CURSOR) BOOL!;
 The statement ending at line XXXX
 
 [[builtin]]
-DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
+DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT;
 
   {stmt_and_attr}: ok
   | {misc_attrs}: ok
@@ -981,8 +981,8 @@ DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
   |   | {dot}
   |     | {name cql}
   |     | {name builtin}
-  | {declare_func_stmt}: text notnull create_func
-    | {name cql_cursor_diff_col}: text notnull create_func
+  | {declare_func_stmt}: text create_func
+    | {name cql_cursor_diff_col}: text create_func
     | {func_params_return}
       | {params}: ok
       | | {param}: l: cursor variable in
@@ -994,9 +994,35 @@ DECLARE FUNC cql_cursor_diff_col (l CURSOR, r CURSOR) CREATE TEXT!;
       |     | {param_detail}: r: cursor variable in
       |       | {name r}: r: cursor variable in
       |       | {type_cursor}: cursor
-      | {create_data_type}: text notnull create_func
-        | {notnull}: text notnull
-          | {type_text}: text
+      | {create_data_type}: text create_func
+        | {type_text}: text
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE FUNC cql_cursor_diff_val (l CURSOR, r CURSOR) CREATE TEXT;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: text create_func
+    | {name cql_cursor_diff_val}: text create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: l: cursor variable in
+      | | | {param_detail}: l: cursor variable in
+      | |   | {name l}: l: cursor variable in
+      | |   | {type_cursor}: cursor
+      | | {params}
+      |   | {param}: r: cursor variable in
+      |     | {param_detail}: r: cursor variable in
+      |       | {name r}: r: cursor variable in
+      |       | {type_cursor}: cursor
+      | {create_data_type}: text create_func
+        | {type_text}: text
 
 The statement ending at line XXXX
 

--- a/sources/test/test_ast.out.ref
+++ b/sources/test/test_ast.out.ref
@@ -911,8 +911,32 @@ The statement ending at line XXXX
       |       | {name r}
       |       | {type_cursor}
       | {create_data_type}
-        | {notnull}
-          | {type_text}
+        | {type_text}
+
+The statement ending at line XXXX
+
+[[builtin]]
+  {stmt_and_attr}
+  | {misc_attrs}
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}
+    | {name cql_cursor_diff_val}
+    | {func_params_return}
+      | {params}
+      | | {param}
+      | | | {param_detail}
+      | |   | {name l}
+      | |   | {type_cursor}
+      | | {params}
+      |   | {param}
+      |     | {param_detail}
+      |       | {name r}
+      |       | {type_cursor}
+      | {create_data_type}
+        | {type_text}
 
 The statement ending at line XXXX
 

--- a/sources/test/test_ast.out.ref
+++ b/sources/test/test_ast.out.ref
@@ -898,6 +898,32 @@ The statement ending at line XXXX
   |     | {name cql}
   |     | {name builtin}
   | {declare_func_stmt}
+    | {name cql_cursor_diff_col}
+    | {func_params_return}
+      | {params}
+      | | {param}
+      | | | {param_detail}
+      | |   | {name l}
+      | |   | {type_cursor}
+      | | {params}
+      |   | {param}
+      |     | {param_detail}
+      |       | {name r}
+      |       | {type_cursor}
+      | {create_data_type}
+        | {notnull}
+          | {type_text}
+
+The statement ending at line XXXX
+
+[[builtin]]
+  {stmt_and_attr}
+  | {misc_attrs}
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}
     | {name cql_box_int}
     | {func_params_return}
       | {params}


### PR DESCRIPTION
The cql_cursor_diff functions were implemented by rewriting them as huge case/when statements.  This is a lot of code in the compiler and lots of codegen.  With dyanmic cursors we can write a generic helper that can diff any two cursors so we did.  The generic helper is pretty big but smaller than one big cursor diff as currently written.

