### PR TITLE
Introduce sqlite3_cql_extension codegen

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -144,3 +144,29 @@ jobs:
           ../playground/play.sh build-everything
           ../playground/play.sh run-data-access-demo
           ../playground/play.sh run c ../playground/examples/*.sql
+      - name: Cache SQLite Build Folder
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.cache/sqlite
+          key: ${{ runner.os }}-sqlite-build
+          restore-keys: ${{ runner.os }}-sqlite-build
+      - name: Build local SQLite
+        run: |
+          if [ ! -f ${{ github.workspace }}/.cache/sqlite/sqlite3 ]; then
+            echo "Cache miss: Building SQLite"
+
+            git clone --branch version-3.47.1 https://github.com/sqlite/sqlite.git ${{ github.workspace }}/.cache/sqlite
+            (cd ${{ github.workspace }}/.cache/sqlite \
+              && ./configure CFLAGS="-g -O0 -DSQLITE_ENABLE_LOAD_EXTENSION -rdynamic" LDFLAGS="-rdynamic" \
+              && make sqlite3)
+          else
+            echo "Cache hit: Using cached SQLite binary"
+          fi
+      - name: Verify SQLite Build
+        run: ${{ github.workspace }}/.cache/sqlite/sqlite3 --version
+      - name: Build SQLite CQL Extension using Clang
+        run: SQLITE_PATH=${{ github.workspace }}/.cache/sqlite ./sqlite3_cql_extension/make.sh --use_clang
+      - name: Build SQLite CQL Extension using GCC
+        run: SQLITE_PATH=${{ github.workspace }}/.cache/sqlite ./sqlite3_cql_extension/make.sh --use_gcc
+      - name: Test SQLite CQL Extension
+        run: SQLITE_PATH=${{ github.workspace }}/.cache/sqlite ./sqlite3_cql_extension/test.sh --non_interactive

--- a/sources/common/test_helpers.sh
+++ b/sources/common/test_helpers.sh
@@ -46,7 +46,7 @@ __on_diff_exit() {
 		# --non-interactive forces interactive mode off. If the environment is
 		# not actually interactive (connected to a terminal for both output and
 		# input), interactive mode is also disabled.
-		if [ "$NON_INTERACTIVE" == 1 ] || [ ! -t 0 ] || [ ! -t 1 ]; then
+		if [ "${NON_INTERACTIVE:-0}" == 1 ] || [ ! -t 0 ] || [ ! -t 1 ]; then
 			echo "When running: diff $*"
 			echo "The above differences were detected. If these are expected copy the test output to the reference."
 			echo "You can also re-run the tests without specifying --non_interactive to affirm the updates."
@@ -69,5 +69,5 @@ Don't just accept to make the error go away; you have to really understand the d
 }
 
 on_diff_exit() {
-	__on_diff_exit "$T/$1.ref" "$O/$1"
+	__on_diff_exit "${T:-}/$1.ref" "${O:-}/$1"
 }

--- a/sources/sqlite3_cql_extension/.gitignore
+++ b/sources/sqlite3_cql_extension/.gitignore
@@ -1,0 +1,2 @@
+out/*
+test.out

--- a/sources/sqlite3_cql_extension/README.md
+++ b/sources/sqlite3_cql_extension/README.md
@@ -1,0 +1,35 @@
+# SQLite3 CQL Extension
+
+## Requirements
+
+### Local SQLite3
+
+- Code source must be available to compile the extension (sqlite3ext.h).
+- The compiled SQLite3 binary must allow loading extensions
+- The version of the binary must match the version of the code source
+
+```bash
+git clone https://github.com/sqlite/sqlite.git && cd sqlite
+./configure && make sqlite3-all.c
+gcc -g -O0 -DSQLITE_ENABLE_LOAD_EXTENSION -o sqlite3 sqlite3-all.c shell.c
+```
+## How to use it
+
+```bash
+# Export the path of the sqlite sqlite3 source code
+export SQLITE_PATH=../../../sqlite
+
+# Build the extension
+./make.sh
+
+# Run the tests
+./test.sh
+
+# Use the extension
+## Linux
+$SQLITE_PATH/sqlite3 ":memory:" -cmd ".load out/cqlextension.so" "SELECT hello_world();"
+## MacOS
+$SQLITE_PATH/sqlite3 ":memory:" -cmd ".load out/cqlextension.dylib" "SELECT hello_world();"
+## Windows
+$SQLITE_PATH/sqlite3 ":memory:" -cmd ".load out/cqlextension.dll" "SELECT hello_world();"
+```

--- a/sources/sqlite3_cql_extension/README.md
+++ b/sources/sqlite3_cql_extension/README.md
@@ -1,5 +1,6 @@
 # SQLite3 CQL Extension
 
+<!-- build_requirements_start -->
 ## Requirements
 
 ### Local SQLite3
@@ -13,6 +14,8 @@ git clone https://github.com/sqlite/sqlite.git && cd sqlite
 ./configure && make sqlite3-all.c
 gcc -g -O0 -DSQLITE_ENABLE_LOAD_EXTENSION -o sqlite3 sqlite3-all.c shell.c
 ```
+<!-- build_requirements_end -->
+
 ## How to use it
 
 ```bash

--- a/sources/sqlite3_cql_extension/Sample.sql
+++ b/sources/sqlite3_cql_extension/Sample.sql
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare proc printf no check;
+
+proc hello_world()
+begin
+  select "Hello World !" as result;
+end;
+
+proc comprehensive_test(
+  in in__bool__not_null bool not null,
+  in in__bool__nullable bool,
+  in in__real__not_null real not null,
+  in in__real__nullable real,
+  in in__integer__not_null integer not null,
+  in in__integer__nullable integer,
+  in in__long__not_null long not null,
+  in in__long__nullable long,
+  in in__text__not_null text not null,
+  in in__text__nullable text,
+  -- in in__object__not_null object not null,
+  -- in in__object__nullable object,
+  in in__blob__not_null blob not null,
+  in in__blob__nullable blob,
+  inout inout__bool__not_null bool not null,
+  inout inout__bool__nullable bool,
+  inout inout__real__not_null real not null,
+  inout inout__real__nullable real,
+  inout inout__integer__not_null integer not null,
+  inout inout__integer__nullable integer,
+  inout inout__long__not_null long not null,
+  inout inout__long__nullable long,
+  inout inout__text__not_null text not null,
+  inout inout__text__nullable text,
+  -- inout inout__object__not_null object not null,
+  -- inout inout__object__nullable object,
+  inout inout__blob__not_null blob not null,
+  inout inout__blob__nullable blob,
+  out out__real__not_null real not null,
+  out out__real__nullable real,
+  out out__bool__not_null bool not null,
+  out out__bool__nullable bool,
+  out out__integer__not_null integer not null,
+  out out__integer__nullable integer,
+  out out__long__not_null long not null,
+  out out__long__nullable long,
+  out out__text__not_null text not null,
+  out out__text__nullable text,
+  -- out out__object__not_null object not null,
+  -- out out__object__nullable object,
+  out out__blob__not_null blob not null,
+  out out__blob__nullable blob
+)
+begin
+
+  out__bool__not_null := TRUE;
+  out__bool__nullable := TRUE;
+
+  out__real__not_null := 3.5;
+  out__real__nullable := 3.5;
+
+  out__integer__not_null := 3;
+  out__integer__nullable := 3;
+
+  out__long__not_null := 3L;
+  out__long__nullable := 3L;
+
+  out__text__not_null := 'three';
+  out__text__nullable := 'three';
+
+  -- out__object__not_null := null ~object~;
+  -- out__object__nullable := null ~object~;
+
+  out__blob__not_null := (select CAST("blob" as blob));
+  out__blob__nullable := (select CAST("blob" as blob));
+
+  select "hello" as `result`;
+end;
+
+proc result_from_result_set__no_args()
+begin
+  select "result_set" as `result`;
+end;
+
+proc result_from_result_set__with_in_out_inout(
+  in in__text__not_null text not null,
+  inout inout__text__not_null text not null,
+  out out__text__not_null text not null,
+)
+begin
+  inout__text__not_null := "inout_argument";
+  out__text__not_null := "out_argument";
+
+  select "result_set" as `result`;
+end;
+
+proc result_from_first_inout_or_out_argument__inout(
+  in in__text__not_null text not null,
+  inout inout__text__not_null text not null,
+  out out__text__not_null text not null,
+  inout inout__text__not_null_bis text not null,
+  out out__text__not_null_bis text not null,
+)
+begin
+  inout__text__not_null := "inout_argument";
+  out__text__not_null := "out_argument";
+  inout__text__not_null_bis := "inout_argument";
+  out__text__not_null_bis := "out_argument";
+end;
+
+proc result_from_first_inout_or_out_argument__out(
+  in in__text__not_null text not null,
+  out out__text__not_null text not null,
+  inout inout__text__not_null text not null,
+  out out__text__not_null_bis text not null,
+  inout inout__text__not_null_bis text not null,
+)
+begin
+  out__text__not_null := "out_argument";
+  inout__text__not_null := "inout_argument";
+  out__text__not_null_bis := "out_argument";
+  inout__text__not_null_bis := "inout_argument";
+end;
+
+proc result_from_inout(inout inout__text__not_null text not null) begin inout__text__not_null := "inout_argument"; end;
+proc result_from_out(out out__text__not_null text not null) begin out__text__not_null := "out_argument"; end;
+proc result_from_void__null__with_in(in in__text__not_null text not null) begin /* noop */ end;
+proc result_from_void__null__no_args() begin /* noop */ end;
+
+proc in__bool__not_null(in in__x bool not null)          begin SELECT in__x; end;
+proc in__bool__nullable(in in__x bool /*null*/)          begin SELECT in__x; end;
+proc in__real__not_null(in in__x real not null)          begin SELECT in__x; end;
+proc in__real__nullable(in in__x real /*null*/)          begin SELECT in__x; end;
+proc in__integer__not_null(in in__x integer not null)    begin SELECT in__x; end;
+proc in__integer__nullable(in in__x integer /*null*/)    begin SELECT in__x; end;
+proc in__long__not_null(in in__x long not null)          begin SELECT in__x; end;
+proc in__long__nullable(in in__x long /*null*/)          begin SELECT in__x; end;
+proc in__text__not_null(in in__x text not null)          begin SELECT in__x; end;
+proc in__text__nullable(in in__x text /*null*/)          begin SELECT in__x; end;
+proc in__blob__not_null(in in__x blob not null)          begin SELECT in__x; end;
+proc in__blob__nullable(in in__x blob /*null*/)          begin SELECT in__x; end;
+-- proc in__object__not_null(inout in__x integer not null)  begin SELECT x; end;
+-- proc in__object__nullable(inout in__x integer /*null*/)  begin SELECT x; end;
+
+proc inout__bool__not_null(inout inout__x bool not null)       begin /* noop */ end;
+proc inout__bool__nullable(inout inout__x bool /*null*/)       begin /* noop */ end;
+proc inout__real__not_null(inout inout__x real not null)       begin /* noop */ end;
+proc inout__real__nullable(inout inout__x real /*null*/)       begin /* noop */ end;
+proc inout__integer__not_null(inout inout__x integer not null) begin /* noop */ end;
+proc inout__integer__nullable(inout inout__x integer /*null*/) begin /* noop */ end;
+proc inout__long__not_null(inout inout__x long not null)       begin /* noop */ end;
+proc inout__long__nullable(inout inout__x long /*null*/)       begin /* noop */ end;
+proc inout__text__not_null(inout inout__x text not null)       begin /* noop */ end;
+proc inout__text__nullable(inout inout__x text /*null*/)       begin /* noop */ end;
+proc inout__blob__not_null(inout inout__x blob not null)       begin /* noop */ end;
+proc inout__blob__nullable(inout inout__x blob /*null*/)       begin /* noop */ end;
+-- proc inout__object__not_null(inout inout__x integer not null)  begin /* noop */ end;
+-- proc inout__object__nullable(inout inout__x integer /*null*/)  begin /* noop */ end;
+
+proc out__bool__not_null(out out__x bool not null)       begin out__x := TRUE; end;
+proc out__bool__nullable(out out__x bool /*null*/)       begin out__x := NULL; end;
+proc out__real__not_null(out out__x real not null)       begin out__x := 3.14; end;
+proc out__real__nullable(out out__x real /*null*/)       begin out__x := NULL; end;
+proc out__integer__not_null(out out__x integer not null) begin out__x := 1234; end;
+proc out__integer__nullable(out out__x integer /*null*/) begin out__x := NULL; end;
+proc out__long__not_null(out out__x long not null)       begin out__x := 1234567890123456789; end;
+proc out__long__nullable(out out__x long /*null*/)       begin out__x := NULL; end;
+proc out__text__not_null(out out__x text not null)       begin out__x := "HW"; end;
+proc out__text__nullable(out out__x text /*null*/)       begin out__x := NULL; end;
+proc out__blob__not_null(out out__x blob not null)       begin set out__x := (select CAST("blob" as blob)); end;
+proc out__blob__nullable(out out__x blob /*null*/)       begin out__x := NULL; end;
+-- proc out__object__not_null(out out__x integer not null)  begin out__x := 1 end;
+-- proc out__object__nullable(out out__x integer /*null*/)  begin out__x := NULL end;

--- a/sources/sqlite3_cql_extension/Sample.sql
+++ b/sources/sqlite3_cql_extension/Sample.sql
@@ -13,47 +13,47 @@ begin
 end;
 
 proc comprehensive_test(
-  in in__bool__not_null bool not null,
+  in in__bool__not_null bool!,
   in in__bool__nullable bool,
-  in in__real__not_null real not null,
+  in in__real__not_null real!,
   in in__real__nullable real,
-  in in__integer__not_null integer not null,
+  in in__integer__not_null integer!,
   in in__integer__nullable integer,
-  in in__long__not_null long not null,
+  in in__long__not_null long!,
   in in__long__nullable long,
-  in in__text__not_null text not null,
+  in in__text__not_null text!,
   in in__text__nullable text,
-  -- in in__object__not_null object not null,
+  -- in in__object__not_null object!,
   -- in in__object__nullable object,
-  in in__blob__not_null blob not null,
+  in in__blob__not_null blob!,
   in in__blob__nullable blob,
-  inout inout__bool__not_null bool not null,
+  inout inout__bool__not_null bool!,
   inout inout__bool__nullable bool,
-  inout inout__real__not_null real not null,
+  inout inout__real__not_null real!,
   inout inout__real__nullable real,
-  inout inout__integer__not_null integer not null,
+  inout inout__integer__not_null integer!,
   inout inout__integer__nullable integer,
-  inout inout__long__not_null long not null,
+  inout inout__long__not_null long!,
   inout inout__long__nullable long,
-  inout inout__text__not_null text not null,
+  inout inout__text__not_null text!,
   inout inout__text__nullable text,
-  -- inout inout__object__not_null object not null,
+  -- inout inout__object__not_null object!,
   -- inout inout__object__nullable object,
-  inout inout__blob__not_null blob not null,
+  inout inout__blob__not_null blob!,
   inout inout__blob__nullable blob,
-  out out__real__not_null real not null,
+  out out__real__not_null real!,
   out out__real__nullable real,
-  out out__bool__not_null bool not null,
+  out out__bool__not_null bool!,
   out out__bool__nullable bool,
-  out out__integer__not_null integer not null,
+  out out__integer__not_null integer!,
   out out__integer__nullable integer,
-  out out__long__not_null long not null,
+  out out__long__not_null long!,
   out out__long__nullable long,
-  out out__text__not_null text not null,
+  out out__text__not_null text!,
   out out__text__nullable text,
-  -- out out__object__not_null object not null,
+  -- out out__object__not_null object!,
   -- out out__object__nullable object,
-  out out__blob__not_null blob not null,
+  out out__blob__not_null blob!,
   out out__blob__nullable blob
 )
 begin
@@ -88,9 +88,9 @@ begin
 end;
 
 proc result_from_result_set__with_in_out_inout(
-  in in__text__not_null text not null,
-  inout inout__text__not_null text not null,
-  out out__text__not_null text not null,
+  in in__text__not_null text!,
+  inout inout__text__not_null text!,
+  out out__text__not_null text!,
 )
 begin
   inout__text__not_null := "inout_argument";
@@ -100,11 +100,11 @@ begin
 end;
 
 proc result_from_first_inout_or_out_argument__inout(
-  in in__text__not_null text not null,
-  inout inout__text__not_null text not null,
-  out out__text__not_null text not null,
-  inout inout__text__not_null_bis text not null,
-  out out__text__not_null_bis text not null,
+  in in__text__not_null text!,
+  inout inout__text__not_null text!,
+  out out__text__not_null text!,
+  inout inout__text__not_null_bis text!,
+  out out__text__not_null_bis text!,
 )
 begin
   inout__text__not_null := "inout_argument";
@@ -114,11 +114,11 @@ begin
 end;
 
 proc result_from_first_inout_or_out_argument__out(
-  in in__text__not_null text not null,
-  out out__text__not_null text not null,
-  inout inout__text__not_null text not null,
-  out out__text__not_null_bis text not null,
-  inout inout__text__not_null_bis text not null,
+  in in__text__not_null text!,
+  out out__text__not_null text!,
+  inout inout__text__not_null text!,
+  out out__text__not_null_bis text!,
+  inout inout__text__not_null_bis text!,
 )
 begin
   out__text__not_null := "out_argument";
@@ -127,52 +127,63 @@ begin
   inout__text__not_null_bis := "inout_argument";
 end;
 
-proc result_from_inout(inout inout__text__not_null text not null) begin inout__text__not_null := "inout_argument"; end;
-proc result_from_out(out out__text__not_null text not null) begin out__text__not_null := "out_argument"; end;
-proc result_from_void__null__with_in(in in__text__not_null text not null) begin /* noop */ end;
-proc result_from_void__null__no_args() begin /* noop */ end;
+proc result_from_inout(inout inout__x text!) begin
+  inout__x := "inout_argument";
+end;
 
-proc in__bool__not_null(in in__x bool not null)          begin SELECT in__x; end;
-proc in__bool__nullable(in in__x bool /*null*/)          begin SELECT in__x; end;
-proc in__real__not_null(in in__x real not null)          begin SELECT in__x; end;
-proc in__real__nullable(in in__x real /*null*/)          begin SELECT in__x; end;
-proc in__integer__not_null(in in__x integer not null)    begin SELECT in__x; end;
-proc in__integer__nullable(in in__x integer /*null*/)    begin SELECT in__x; end;
-proc in__long__not_null(in in__x long not null)          begin SELECT in__x; end;
-proc in__long__nullable(in in__x long /*null*/)          begin SELECT in__x; end;
-proc in__text__not_null(in in__x text not null)          begin SELECT in__x; end;
-proc in__text__nullable(in in__x text /*null*/)          begin SELECT in__x; end;
-proc in__blob__not_null(in in__x blob not null)          begin SELECT in__x; end;
-proc in__blob__nullable(in in__x blob /*null*/)          begin SELECT in__x; end;
--- proc in__object__not_null(inout in__x integer not null)  begin SELECT x; end;
--- proc in__object__nullable(inout in__x integer /*null*/)  begin SELECT x; end;
+proc result_from_out(out out__x text!) begin
+  out__x := "out_argument";
+end;
 
-proc inout__bool__not_null(inout inout__x bool not null)       begin /* noop */ end;
-proc inout__bool__nullable(inout inout__x bool /*null*/)       begin /* noop */ end;
-proc inout__real__not_null(inout inout__x real not null)       begin /* noop */ end;
-proc inout__real__nullable(inout inout__x real /*null*/)       begin /* noop */ end;
-proc inout__integer__not_null(inout inout__x integer not null) begin /* noop */ end;
-proc inout__integer__nullable(inout inout__x integer /*null*/) begin /* noop */ end;
-proc inout__long__not_null(inout inout__x long not null)       begin /* noop */ end;
-proc inout__long__nullable(inout inout__x long /*null*/)       begin /* noop */ end;
-proc inout__text__not_null(inout inout__x text not null)       begin /* noop */ end;
-proc inout__text__nullable(inout inout__x text /*null*/)       begin /* noop */ end;
-proc inout__blob__not_null(inout inout__x blob not null)       begin /* noop */ end;
-proc inout__blob__nullable(inout inout__x blob /*null*/)       begin /* noop */ end;
--- proc inout__object__not_null(inout inout__x integer not null)  begin /* noop */ end;
--- proc inout__object__nullable(inout inout__x integer /*null*/)  begin /* noop */ end;
+proc result_from_void__null__with_in(in in__x text!) begin
+  /* noop */
+end;
 
-proc out__bool__not_null(out out__x bool not null)       begin out__x := TRUE; end;
-proc out__bool__nullable(out out__x bool /*null*/)       begin out__x := NULL; end;
-proc out__real__not_null(out out__x real not null)       begin out__x := 3.14; end;
-proc out__real__nullable(out out__x real /*null*/)       begin out__x := NULL; end;
-proc out__integer__not_null(out out__x integer not null) begin out__x := 1234; end;
-proc out__integer__nullable(out out__x integer /*null*/) begin out__x := NULL; end;
-proc out__long__not_null(out out__x long not null)       begin out__x := 1234567890123456789; end;
-proc out__long__nullable(out out__x long /*null*/)       begin out__x := NULL; end;
-proc out__text__not_null(out out__x text not null)       begin out__x := "HW"; end;
-proc out__text__nullable(out out__x text /*null*/)       begin out__x := NULL; end;
-proc out__blob__not_null(out out__x blob not null)       begin set out__x := (select CAST("blob" as blob)); end;
-proc out__blob__nullable(out out__x blob /*null*/)       begin out__x := NULL; end;
--- proc out__object__not_null(out out__x integer not null)  begin out__x := 1 end;
--- proc out__object__nullable(out out__x integer /*null*/)  begin out__x := NULL end;
+proc result_from_void__null__no_args() begin
+  /* noop */
+end;
+
+proc in__bool__not_null(in in__x bool!) begin SELECT in__x; end;
+proc in__bool__nullable(in in__x bool) begin SELECT in__x; end;
+proc in__real__not_null(in in__x real!) begin SELECT in__x; end;
+proc in__real__nullable(in in__x real) begin SELECT in__x; end;
+proc in__integer__not_null(in in__x integer!) begin SELECT in__x; end;
+proc in__integer__nullable(in in__x integer) begin SELECT in__x; end;
+proc in__long__not_null(in in__x long!) begin SELECT in__x; end;
+proc in__long__nullable(in in__x long) begin SELECT in__x; end;
+proc in__text__not_null(in in__x text!) begin SELECT in__x; end;
+proc in__text__nullable(in in__x text) begin SELECT in__x; end;
+proc in__blob__not_null(in in__x blob!) begin SELECT in__x; end;
+proc in__blob__nullable(in in__x blob) begin SELECT in__x; end;
+-- proc in__object__not_null(inout in__x integer!) begin SELECT in__x; end;
+-- proc in__object__nullable(inout in__x integer) begin SELECT in__x; end;
+
+proc inout__bool__not_null(inout inout__x bool!) begin /* noop */ end;
+proc inout__bool__nullable(inout inout__x bool) begin /* noop */ end;
+proc inout__real__not_null(inout inout__x real!) begin /* noop */ end;
+proc inout__real__nullable(inout inout__x real) begin /* noop */ end;
+proc inout__integer__not_null(inout inout__x integer!) begin /* noop */ end;
+proc inout__integer__nullable(inout inout__x integer) begin /* noop */ end;
+proc inout__long__not_null(inout inout__x long!) begin /* noop */ end;
+proc inout__long__nullable(inout inout__x long) begin /* noop */ end;
+proc inout__text__not_null(inout inout__x text!) begin /* noop */ end;
+proc inout__text__nullable(inout inout__x text) begin /* noop */ end;
+proc inout__blob__not_null(inout inout__x blob!) begin /* noop */ end;
+proc inout__blob__nullable(inout inout__x blob) begin /* noop */ end;
+-- proc inout__object__not_null(inout inout__x integer!) begin /* noop */ end;
+-- proc inout__object__nullable(inout inout__x integer) begin /* noop */ end;
+
+proc out__bool__not_null(out out__x bool!) begin out__x := TRUE; end;
+proc out__bool__nullable(out out__x bool) begin out__x := NULL; end;
+proc out__real__not_null(out out__x real!) begin out__x := 3.14; end;
+proc out__real__nullable(out out__x real) begin out__x := NULL; end;
+proc out__integer__not_null(out out__x integer!) begin out__x := 1234; end;
+proc out__integer__nullable(out out__x integer) begin out__x := NULL; end;
+proc out__long__not_null(out out__x long!) begin out__x := 1234567890123456789; end;
+proc out__long__nullable(out out__x long) begin out__x := NULL; end;
+proc out__text__not_null(out out__x text!) begin out__x := "HW"; end;
+proc out__text__nullable(out out__x text) begin out__x := NULL; end;
+proc out__blob__not_null(out out__x blob!) begin out__x := (select CAST("blob" as blob)); end;
+proc out__blob__nullable(out out__x blob) begin out__x := NULL; end;
+-- proc out__object__not_null(out out__x integer!) begin out__x := 9876; end;
+-- proc out__object__nullable(out out__x integer) begin out__x := NULL; end;

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.c
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.c
@@ -7,8 +7,8 @@ extern const sqlite3_api_routines *sqlite3_api;
 cql_bool is_sqlite3_type_compatible_with_cql_core_type(
   int sqlite_type,
   int8_t cql_core_type,
-  cql_bool is_nullable
-) {
+  cql_bool is_nullable)
+{
   if (sqlite_type == SQLITE_NULL && is_nullable) return true;
   if (sqlite_type == SQLITE_NULL && !is_nullable) return false;
 
@@ -36,8 +36,7 @@ cql_bool is_sqlite3_type_compatible_with_cql_core_type(
   return false;
 }
 
-void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_result_set_ref _Nonnull result_set)
-{
+void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_result_set_ref _Nonnull result_set) {
   const cql_int32 row = 0;
   const cql_int32 column = 0;
 
@@ -49,10 +48,18 @@ void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_r
   if (cql_result_set_get_is_null_col(result_set, row, column)) goto silent_error;
 
   switch (CQL_CORE_DATA_TYPE_OF(meta->dataTypes[column])) {
-    case CQL_DATA_TYPE_INT32: sqlite3_result_int(context, cql_result_set_get_int32_col(result_set, row, column)); return;
-    case CQL_DATA_TYPE_INT64: sqlite3_result_int64(context, cql_result_set_get_int64_col(result_set, row, column)); return;
-    case CQL_DATA_TYPE_DOUBLE: sqlite3_result_double(context, cql_result_set_get_double_col(result_set, row, column)); return;
-    case CQL_DATA_TYPE_BOOL: sqlite3_result_int(context, cql_result_set_get_bool_col(result_set, row, column)); return;
+    case CQL_DATA_TYPE_INT32:
+      sqlite3_result_int(context, cql_result_set_get_int32_col(result_set, row, column));
+      return;
+    case CQL_DATA_TYPE_INT64:
+      sqlite3_result_int64(context, cql_result_set_get_int64_col(result_set, row, column));
+      return;
+    case CQL_DATA_TYPE_DOUBLE:
+      sqlite3_result_double(context, cql_result_set_get_double_col(result_set, row, column));
+      return;
+    case CQL_DATA_TYPE_BOOL:
+      sqlite3_result_int(context, cql_result_set_get_bool_col(result_set, row, column));
+      return;
     case CQL_DATA_TYPE_STRING: {
       cql_string_ref str_ref = cql_result_set_get_string_col(result_set, row, column);
       cql_alloc_cstr(c_str, str_ref);
@@ -68,6 +75,7 @@ void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_r
       return;
     }
     case CQL_DATA_TYPE_OBJECT: {
+      // Not supported yet — See https://www.sqlite.org/bindptr.html
       cql_object_ref obj_ref = cql_result_set_get_object_col(result_set, row, column);
       cql_retain((cql_type_ref)obj_ref);
       sqlite3_result_int64(context, (int64_t)obj_ref);
@@ -79,6 +87,21 @@ void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_r
     sqlite3_result_null(context);
 }
 
+cql_bool resolve_not_null_bool_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  return (cql_bool)sqlite3_value_int(value);
+}
+
+cql_double resolve_not_null_real_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  return (cql_double)sqlite3_value_double(value);
+}
+
+cql_int32 resolve_not_null_integer_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  return (cql_int32)sqlite3_value_int(value);
+}
+
+cql_int64 resolve_not_null_long_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  return (cql_int64)sqlite3_value_int64(value);
+}
 
 cql_nullable_double resolve_nullable_real_from_sqlite3_value(sqlite3_value *_Nonnull value) {
   if (sqlite3_value_type(value) == SQLITE_NULL) return (cql_nullable_double){ .is_null = true, .value = 0 };
@@ -121,7 +144,71 @@ cql_blob_ref _Nullable resolve_blob_from_sqlite3_value(sqlite3_value *_Nonnull v
 }
 
 cql_object_ref _Nullable resolve_object_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  // Not supported yet — See https://www.sqlite.org/bindptr.html
   if (sqlite3_value_type(value) == SQLITE_NULL) return NULL;
 
   return (cql_object_ref)sqlite3_value_pointer(value, "pointer_type");
+}
+
+void sqlite3_result_cql_nullable_bool(sqlite3_context *_Nonnull context, cql_nullable_bool value) {
+  if (value.is_null) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  sqlite3_result_int(context, value.value);
+}
+
+void sqlite3_result_cql_nullable_int(sqlite3_context *_Nonnull context, cql_nullable_int32 value) {
+  if (value.is_null) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  sqlite3_result_int(context, value.value);
+}
+
+void sqlite3_result_cql_nullable_int64(sqlite3_context *_Nonnull context, cql_nullable_int64 value) {
+  if (value.is_null) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  sqlite3_result_int64(context, value.value);
+}
+
+void sqlite3_result_cql_nullable_double(sqlite3_context *_Nonnull context, cql_nullable_double value) {
+  if (value.is_null) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  sqlite3_result_double(context, value.value);
+}
+
+void sqlite3_result_cql_pointer(sqlite3_context *_Nonnull context, void *value) {
+  // Not supported yet — See https://www.sqlite.org/bindptr.html
+  sqlite3_result_null(context);
+}
+
+void sqlite3_result_cql_blob(sqlite3_context *_Nonnull context, cql_blob_ref value) {
+  if (!value) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  const void *bytes = cql_get_blob_bytes(value);
+  cql_uint32 size = cql_get_blob_size(value);
+  sqlite3_result_blob(context, bytes, size, SQLITE_TRANSIENT);
+}
+
+void sqlite3_result_cql_text(sqlite3_context *_Nonnull context, cql_string_ref value) {
+  if (!value) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  cql_alloc_cstr(c_str, value);
+  sqlite3_result_text(context, c_str, -1, SQLITE_TRANSIENT);
+  cql_free_cstr(c_str, value);
 }

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.c
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.c
@@ -1,5 +1,7 @@
-#include "cql_sqlite_extension.h"
 #include <sqlite3ext.h>
+extern const sqlite3_api_routines *sqlite3_api;
+
+#include "cql_sqlite_extension.h"
 #include "cqlrt.h"
 
 cql_bool is_sqlite3_type_compatible_with_cql_core_type(

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.c
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.c
@@ -1,0 +1,125 @@
+#include "cql_sqlite_extension.h"
+#include <sqlite3ext.h>
+#include "cqlrt.h"
+
+cql_bool is_sqlite3_type_compatible_with_cql_core_type(
+  int sqlite_type,
+  int8_t cql_core_type,
+  cql_bool is_nullable
+) {
+  if (sqlite_type == SQLITE_NULL && is_nullable) return true;
+  if (sqlite_type == SQLITE_NULL && !is_nullable) return false;
+
+  switch (cql_core_type) {
+    case CQL_DATA_TYPE_INT32:
+    case CQL_DATA_TYPE_INT64:
+    case CQL_DATA_TYPE_BOOL:
+    case CQL_DATA_TYPE_OBJECT:
+      if (sqlite_type == SQLITE_INTEGER) return true;
+      break;
+
+    case CQL_DATA_TYPE_DOUBLE:
+      if (sqlite_type == SQLITE_FLOAT || sqlite_type == SQLITE_INTEGER) return true;
+      break;
+
+    case CQL_DATA_TYPE_STRING:
+      if (sqlite_type == SQLITE_TEXT) return true;
+      break;
+
+    case CQL_DATA_TYPE_BLOB:
+      if (sqlite_type == SQLITE_BLOB) return true;
+      break;
+  }
+
+  return false;
+}
+
+void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_result_set_ref _Nonnull result_set)
+{
+  const cql_int32 row = 0;
+  const cql_int32 column = 0;
+
+  if (row >= cql_result_set_get_count(result_set)) goto silent_error;
+
+  cql_result_set_meta *meta = cql_result_set_get_meta(result_set);
+
+  if (meta->columnOffsets == NULL || column >= meta->columnCount) goto silent_error;
+  if (cql_result_set_get_is_null_col(result_set, row, column)) goto silent_error;
+
+  switch (CQL_CORE_DATA_TYPE_OF(meta->dataTypes[column])) {
+    case CQL_DATA_TYPE_INT32: sqlite3_result_int(context, cql_result_set_get_int32_col(result_set, row, column)); return;
+    case CQL_DATA_TYPE_INT64: sqlite3_result_int64(context, cql_result_set_get_int64_col(result_set, row, column)); return;
+    case CQL_DATA_TYPE_DOUBLE: sqlite3_result_double(context, cql_result_set_get_double_col(result_set, row, column)); return;
+    case CQL_DATA_TYPE_BOOL: sqlite3_result_int(context, cql_result_set_get_bool_col(result_set, row, column)); return;
+    case CQL_DATA_TYPE_STRING: {
+      cql_string_ref str_ref = cql_result_set_get_string_col(result_set, row, column);
+      cql_alloc_cstr(c_str, str_ref);
+      sqlite3_result_text(context, c_str, -1, SQLITE_TRANSIENT);
+      cql_free_cstr(c_str, str_ref);
+      return;
+    }
+    case CQL_DATA_TYPE_BLOB: {
+      cql_blob_ref blob_ref = cql_result_set_get_blob_col(result_set, row, column);
+      const void *bytes = cql_get_blob_bytes(blob_ref);
+      cql_uint32 size = cql_get_blob_size(blob_ref);
+      sqlite3_result_blob(context, bytes, size, SQLITE_TRANSIENT);
+      return;
+    }
+    case CQL_DATA_TYPE_OBJECT: {
+      cql_object_ref obj_ref = cql_result_set_get_object_col(result_set, row, column);
+      cql_retain((cql_type_ref)obj_ref);
+      sqlite3_result_int64(context, (int64_t)obj_ref);
+      return;
+    }
+  }
+
+  silent_error:
+    sqlite3_result_null(context);
+}
+
+
+cql_nullable_double resolve_nullable_real_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return (cql_nullable_double){ .is_null = true, .value = 0 };
+  return (cql_nullable_double){ .is_null = false, .value = (cql_double)sqlite3_value_double(value) };
+}
+
+cql_nullable_int32 resolve_nullable_integer_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return (cql_nullable_int32){ .is_null = true, .value = 0 };
+  return (cql_nullable_int32){ .is_null = false, .value = (cql_int32)sqlite3_value_int(value) };
+}
+
+cql_nullable_int64 resolve_nullable_long_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return (cql_nullable_int64){ .is_null = true, .value = 0 };
+  return (cql_nullable_int64){ .is_null = false, .value = (cql_int64)sqlite3_value_int64(value) };
+}
+
+cql_nullable_bool resolve_nullable_bool_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return (cql_nullable_bool){ .is_null = true, .value = false };
+  return (cql_nullable_bool){ .is_null = false, .value = (cql_bool)sqlite3_value_int(value) };
+}
+
+cql_string_ref _Nullable resolve_text_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return NULL;
+
+  const char *text = (const char *)sqlite3_value_text(value);
+
+  if (!text) return NULL;
+
+  return cql_string_ref_new(text);
+}
+
+cql_blob_ref _Nullable resolve_blob_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return NULL;
+
+  const void *blob = sqlite3_value_blob(value);
+
+  if (!blob) return NULL;
+
+  return cql_blob_ref_new(blob, sqlite3_value_bytes(value));
+}
+
+cql_object_ref _Nullable resolve_object_from_sqlite3_value(sqlite3_value *_Nonnull value) {
+  if (sqlite3_value_type(value) == SQLITE_NULL) return NULL;
+
+  return (cql_object_ref)sqlite3_value_pointer(value, "pointer_type");
+}

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.h
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.h
@@ -5,6 +5,10 @@ cql_bool is_sqlite3_type_compatible_with_cql_core_type(int sqlite_type, int8_t c
 
 void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_result_set_ref _Nonnull result_set);
 
+cql_bool resolve_not_null_bool_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_double resolve_not_null_real_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_int32 resolve_not_null_integer_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_int64 resolve_not_null_long_from_sqlite3_value(sqlite3_value *_Nonnull value);
 cql_nullable_double resolve_nullable_real_from_sqlite3_value(sqlite3_value *_Nonnull value);
 cql_nullable_int32 resolve_nullable_integer_from_sqlite3_value(sqlite3_value *_Nonnull value);
 cql_nullable_int64 resolve_nullable_long_from_sqlite3_value(sqlite3_value *_Nonnull value);
@@ -13,32 +17,10 @@ cql_string_ref _Nullable resolve_text_from_sqlite3_value(sqlite3_value *_Nonnull
 cql_blob_ref _Nullable resolve_blob_from_sqlite3_value(sqlite3_value *_Nonnull value);
 cql_object_ref _Nullable resolve_object_from_sqlite3_value(sqlite3_value *_Nonnull value);
 
-#define RESOLVE_NOTNULL_BOOL_FROM_SQLITE3_VALUE(arg)    (cql_bool)sqlite3_value_int(arg);
-#define RESOLVE_NOTNULL_REAL_FROM_SQLITE3_VALUE(arg)    (cql_double)sqlite3_value_double(arg);
-#define RESOLVE_NOTNULL_INTEGER_FROM_SQLITE3_VALUE(arg) (cql_int32)sqlite3_value_int(arg);
-#define RESOLVE_NOTNULL_LONG_FROM_SQLITE3_VALUE(arg)    (cql_int64)sqlite3_value_int64(arg);
-
-#define SQLITE3_RESULT_CQL_NULLABLE_INT(context, nullable_output)    do { if ((nullable_output).is_null) { sqlite3_result_null(context); } else { sqlite3_result_int(context, (nullable_output).value); } } while (0)
-#define SQLITE3_RESULT_CQL_NULLABLE_INT64(context, nullable_output)  do { if ((nullable_output).is_null) { sqlite3_result_null(context); } else { sqlite3_result_int64(context, (nullable_output).value); } } while (0)
-#define SQLITE3_RESULT_CQL_NULLABLE_DOUBLE(context, nullable_output) do { if ((nullable_output).is_null) { sqlite3_result_null(context); } else { sqlite3_result_double(context, (nullable_output).value); } } while (0)
-#define SQLITE3_RESULT_CQL_POINTER(context, nullable_output)         do { /* Not implemented yet */ } while (0)
-#define SQLITE3_RESULT_CQL_BLOB(context, output)   \
-  do { \
-    if (!(output)) { \
-      sqlite3_result_null(context); \
-      break; \
-    } \
-    const void *bytes_##output = cql_get_blob_bytes(output); \
-    cql_uint32 size_##output = cql_get_blob_size(output); \
-    sqlite3_result_blob(context, bytes_##output, size_##output, SQLITE_TRANSIENT); \
-  } while (0)
-#define SQLITE3_RESULT_CQL_TEXT(context, output)   \
-  do { \
-    if (!(output)) { \
-      sqlite3_result_null(context); \
-      break; \
-    } \
-    cql_alloc_cstr(c_str_##output, output); \
-    sqlite3_result_text(context, c_str_##output, -1, SQLITE_TRANSIENT); \
-    cql_free_cstr(c_str_##output, output); \
-  } while (0)
+void sqlite3_result_cql_nullable_bool(sqlite3_context *_Nonnull context, cql_nullable_bool value);
+void sqlite3_result_cql_nullable_int(sqlite3_context *_Nonnull context, cql_nullable_int32 value);
+void sqlite3_result_cql_nullable_int64(sqlite3_context *_Nonnull context, cql_nullable_int64 value);
+void sqlite3_result_cql_nullable_double(sqlite3_context *_Nonnull context, cql_nullable_double value);
+void sqlite3_result_cql_pointer(sqlite3_context *_Nonnull context, void *_Nonnull value);
+void sqlite3_result_cql_blob(sqlite3_context *_Nonnull context, _Nullable cql_blob_ref value);
+void sqlite3_result_cql_text(sqlite3_context *_Nonnull context, _Nullable cql_string_ref value);

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.h
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.h
@@ -1,0 +1,44 @@
+#include <sqlite3ext.h>
+#include "cqlrt.h"
+
+cql_bool is_sqlite3_type_compatible_with_cql_core_type(int sqlite_type, int8_t cql_core_type, cql_bool is_nullable);
+
+void set_sqlite3_result_from_result_set(sqlite3_context *_Nonnull context, cql_result_set_ref _Nonnull result_set);
+
+cql_nullable_double resolve_nullable_real_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_nullable_int32 resolve_nullable_integer_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_nullable_int64 resolve_nullable_long_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_nullable_bool resolve_nullable_bool_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_string_ref _Nullable resolve_text_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_blob_ref _Nullable resolve_blob_from_sqlite3_value(sqlite3_value *_Nonnull value);
+cql_object_ref _Nullable resolve_object_from_sqlite3_value(sqlite3_value *_Nonnull value);
+
+#define RESOLVE_NOTNULL_BOOL_FROM_SQLITE3_VALUE(arg)    (cql_bool)sqlite3_value_int(arg);
+#define RESOLVE_NOTNULL_REAL_FROM_SQLITE3_VALUE(arg)    (cql_double)sqlite3_value_double(arg);
+#define RESOLVE_NOTNULL_INTEGER_FROM_SQLITE3_VALUE(arg) (cql_int32)sqlite3_value_int(arg);
+#define RESOLVE_NOTNULL_LONG_FROM_SQLITE3_VALUE(arg)    (cql_int64)sqlite3_value_int64(arg);
+
+#define SQLITE3_RESULT_CQL_NULLABLE_INT(context, nullable_output)    do { if ((nullable_output).is_null) { sqlite3_result_null(context); } else { sqlite3_result_int(context, (nullable_output).value); } } while (0)
+#define SQLITE3_RESULT_CQL_NULLABLE_INT64(context, nullable_output)  do { if ((nullable_output).is_null) { sqlite3_result_null(context); } else { sqlite3_result_int64(context, (nullable_output).value); } } while (0)
+#define SQLITE3_RESULT_CQL_NULLABLE_DOUBLE(context, nullable_output) do { if ((nullable_output).is_null) { sqlite3_result_null(context); } else { sqlite3_result_double(context, (nullable_output).value); } } while (0)
+#define SQLITE3_RESULT_CQL_POINTER(context, nullable_output)         do { /* Not implemented yet */ } while (0)
+#define SQLITE3_RESULT_CQL_BLOB(context, output)   \
+  do { \
+    if (!(output)) { \
+      sqlite3_result_null(context); \
+      break; \
+    } \
+    const void *bytes_##output = cql_get_blob_bytes(output); \
+    cql_uint32 size_##output = cql_get_blob_size(output); \
+    sqlite3_result_blob(context, bytes_##output, size_##output, SQLITE_TRANSIENT); \
+  } while (0)
+#define SQLITE3_RESULT_CQL_TEXT(context, output)   \
+  do { \
+    if (!(output)) { \
+      sqlite3_result_null(context); \
+      break; \
+    } \
+    cql_alloc_cstr(c_str_##output, output); \
+    sqlite3_result_text(context, c_str_##output, -1, SQLITE_TRANSIENT); \
+    cql_free_cstr(c_str_##output, output); \
+  } while (0)

--- a/sources/sqlite3_cql_extension/cqlsqlite3extension.py
+++ b/sources/sqlite3_cql_extension/cqlsqlite3extension.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# cqlcs.py -> converts CQL JSON format into a C Sqlite extension
+#
+# The CQL JSON format is documented here: https://cgsql.dev/cql-guide/ch13
+# and here: https://cgsql.dev/json-diagram
+#
+# NB: This code should be considered SAMPLE code, not production code.
+# Feel free to fork it and modify it to suit your needs.
+import json
+import sys
+
+def usage():
+    print(
+        """
+Usage: input.json [options] >result.c
+
+--cql_header header_file
+    specifies the CQL generated header file to include in the generated C code
+"""
+    )
+    sys.exit(0)
+
+# Reference type check
+is_ref_type = {}
+is_ref_type["bool"] = False
+is_ref_type["integer"] = False
+is_ref_type["long"] = False
+is_ref_type["real"] = False
+is_ref_type["object"] = True
+is_ref_type["blob"] = True
+is_ref_type["text"] = True
+
+# Sqlite3 null value getter for the given types
+sqlite3_value_getter_nullable = {}
+sqlite3_value_getter_nullable["bool"] = "resolve_nullable_bool_from_sqlite3_value"
+sqlite3_value_getter_nullable["integer"] = "resolve_nullable_integer_from_sqlite3_value"
+sqlite3_value_getter_nullable["long"] = "resolve_nullable_long_from_sqlite3_value"
+sqlite3_value_getter_nullable["real"] = "resolve_nullable_real_from_sqlite3_value"
+sqlite3_value_getter_nullable["object"] = "resolve_object_from_sqlite3_value"
+sqlite3_value_getter_nullable["blob"] = "resolve_blob_from_sqlite3_value"
+sqlite3_value_getter_nullable["text"] = "resolve_text_from_sqlite3_value"
+
+# Sqlite3 null value getter for the given types
+sqlite3_value_getter_notnull = {}
+sqlite3_value_getter_notnull["bool"] = "RESOLVE_NOTNULL_BOOL_FROM_SQLITE3_VALUE"
+sqlite3_value_getter_notnull["integer"] = "RESOLVE_NOTNULL_INTEGER_FROM_SQLITE3_VALUE"
+sqlite3_value_getter_notnull["long"] = "RESOLVE_NOTNULL_LONG_FROM_SQLITE3_VALUE"
+sqlite3_value_getter_notnull["real"] = "RESOLVE_NOTNULL_REAL_FROM_SQLITE3_VALUE"
+sqlite3_value_getter_notnull["object"] = "resolve_object_from_sqlite3_value"
+sqlite3_value_getter_notnull["blob"] = "resolve_blob_from_sqlite3_value"
+sqlite3_value_getter_notnull["text"] = "resolve_text_from_sqlite3_value"
+
+# Sqlite3 result setter for the given types
+sqlite3_result_setter_notnull = {}
+sqlite3_result_setter_notnull["bool"] = "sqlite3_result_int"
+sqlite3_result_setter_notnull["integer"] = "sqlite3_result_int"
+sqlite3_result_setter_notnull["long"] = "sqlite3_result_int64"
+sqlite3_result_setter_notnull["real"] = "sqlite3_result_double"
+sqlite3_result_setter_notnull["object"] = "sqlite3_result_pointer"
+sqlite3_result_setter_notnull["blob"] = "sqlite3_result_blob"
+sqlite3_result_setter_notnull["text"] = "sqlite3_result_text"
+
+# Sqlite3 result setter for nullable CQL types implemented with macros
+sqlite3_result_setter_nullable = {}
+sqlite3_result_setter_nullable["bool"] = "SQLITE3_RESULT_CQL_NULLABLE_INT"
+sqlite3_result_setter_nullable["integer"] = "SQLITE3_RESULT_CQL_NULLABLE_INT"
+sqlite3_result_setter_nullable["long"] = "SQLITE3_RESULT_CQL_NULLABLE_INT64"
+sqlite3_result_setter_nullable["real"] = "SQLITE3_RESULT_CQL_NULLABLE_DOUBLE"
+sqlite3_result_setter_nullable["object"] = "SQLITE3_RESULT_CQL_POINTER"
+sqlite3_result_setter_nullable["blob"] = "SQLITE3_RESULT_CQL_BLOB"
+sqlite3_result_setter_nullable["text"] = "SQLITE3_RESULT_CQL_TEXT"
+
+# CQL row type codes for the given kinds of fields
+row_types = {}
+row_types["bool"] = "CQL_DATA_TYPE_BOOL"
+row_types["integer"] = "CQL_DATA_TYPE_INT32"
+row_types["long"] = "CQL_DATA_TYPE_INT64"
+row_types["real"] = "CQL_DATA_TYPE_DOUBLE"
+row_types["object"] = "CQL_DATA_TYPE_OBJECT"
+row_types["blob"] = "CQL_DATA_TYPE_BLOB"
+row_types["text"] = "CQL_DATA_TYPE_STRING"
+
+# Notnull CQL C types for the given type of fields
+cql_notnull_types = {}
+cql_notnull_types["bool"] = "cql_bool"
+cql_notnull_types["integer"] = "cql_int32"
+cql_notnull_types["long"] = "cql_int64"
+cql_notnull_types["real"] = "cql_double"
+cql_notnull_types["object"] = "cql_object_ref"
+cql_notnull_types["blob"] = "cql_blob_ref"
+cql_notnull_types["text"] = "cql_string_ref"
+
+# Nullable CQL C types for the given type of fields
+cql_nullable_types = {}
+cql_nullable_types["bool"] = "cql_nullable_bool"
+cql_nullable_types["integer"] = "cql_nullable_int32"
+cql_nullable_types["long"] = "cql_nullable_int64"
+cql_nullable_types["real"] = "cql_nullable_double"
+cql_nullable_types["object"] = "cql_object_ref"
+cql_nullable_types["blob"] = "cql_blob_ref"
+cql_nullable_types["text"] = "cql_string_ref"
+
+# Storage for the various command line arguments
+cmd_args = {}
+cmd_args["cql_header"] = "something.h"
+cmd_args["namespace"] = ""
+
+
+def emit_licence():
+    # Include original license — Not actually written by Meta
+    print("""
+/*
+* Copyright (c) Meta Platforms, Inc. and affiliates.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+""")
+
+def emit_headers():
+    print("#include <sqlite3ext.h>")
+    print("SQLITE_EXTENSION_INIT1")
+    print("#include \"cqlrt.h\"")
+    print("#include \"cql_sqlite_extension.h\"")
+    print(f"#include \"{cmd_args['cql_header']}\"")
+    print("")
+
+
+def emit_extension_initializer(data):
+
+    print("""
+int sqlite3_cqlextension_init(sqlite3 *_Nonnull db, char *_Nonnull *_Nonnull pzErrMsg, const sqlite3_api_routines *_Nonnull pApi) {
+  SQLITE_EXTENSION_INIT2(pApi);
+
+  int rc = SQLITE_OK;
+""")
+    for proc in data['queries'] + data['deletes'] + data['inserts'] + data['generalInserts'] + data['updates'] + data['general']:
+        print(f"""
+  rc = sqlite3_create_function(db, "{cmd_args['namespace']}{proc['name']}", {len([arg for arg in proc['args'] if arg.get('binding', 'in') in ['in', 'inout']])}, SQLITE_UTF8, NULL, call_{cmd_args['namespace']}{proc['name']}, NULL, NULL);
+  if (rc != SQLITE_OK) return rc;
+""")
+
+    print("""
+  return rc;
+}
+
+""")
+
+def emit_all_procs(data):
+    for proc in (
+        data["queries"] +
+        data["deletes"] +
+        data["inserts"] +
+        data["generalInserts"] +
+        data["updates"] +
+        data["general"]
+    ):
+        proc['usesDatabase'] = proc["usesDatabase"] if "usesDatabase" in proc else True
+        proc['projection'] = "projection" in proc
+        proc['canonicalName'] = f"call_{cmd_args['namespace']}{proc['name']}"
+
+        attributes = {}
+        for attr in proc.get("attributes", []):
+            attributes[attr['name']] = attr['value']
+
+        # no codegen for private methods
+        if "cql:private" in attributes: return
+
+        emit_proc_c_func_body(proc, attributes)
+
+# This emits the main body of the C Interop function, this includes
+# * the Interop entry point for the procedure
+# * the call to the procedure
+# * the marshalling of the results
+# * the return of the results
+# * the cleanup of the results
+def emit_proc_c_func_body(proc, attributes):
+    in_arguments = [arg for arg in proc['args'] if arg.get('binding', 'in') == ('in')]
+    inout_arguments = [arg for arg in proc['args'] if arg.get('binding', 'in') == ('inout')]
+    out_arguments = [arg for arg in proc['args'] if arg.get('binding', 'in') == ('out')]
+
+    innie_arguments = in_arguments + inout_arguments
+    outtie_arguments = inout_arguments + out_arguments
+
+
+    print(f"void {proc['canonicalName']}(sqlite3_context *_Nonnull context, int32_t argc, sqlite3_value *_Nonnull *_Nonnull argv)", end="")
+    print("{")
+
+    print(f"  // 1. Ensure Sqlite function argument count matches count of the procedure in and inout arguments")
+    print(f"  if (argc != {len(innie_arguments)}) goto invalid_arguments;")
+    print(f"")
+
+
+    print("  // 2. Ensure sqlite3 value type is compatible with cql type")
+    for index, arg in enumerate(innie_arguments):
+        print(
+            f"  if (!is_sqlite3_type_compatible_with_cql_core_type("
+                f"sqlite3_value_type(argv[{index}]), "
+                f"{row_types[arg['type']]}, "
+                f"{'cql_false' if arg['isNotNull'] else 'cql_true'}"
+            f")) goto invalid_arguments; // {arg['name']}"
+        )
+    print("")
+
+
+    print("  // 3. Marshalled argument initialization")
+    for index, arg in enumerate(innie_arguments):
+        if arg['type'] in ("text", "blob", "object"):
+            print(f"  {cql_nullable_types[arg['type']].ljust(20)} {arg['name'].ljust(25)} = {sqlite3_value_getter_nullable[arg['type']]}(argv[{index}]);")
+        elif arg['isNotNull']:
+            print(f"  {cql_notnull_types[arg['type']].ljust(20)} {arg['name'].ljust(25)} = {sqlite3_value_getter_notnull[arg['type']]}(argv[{index}]);")
+        else:
+            print(f"  {cql_nullable_types[arg['type']].ljust(20)} {arg['name'].ljust(25)} = {sqlite3_value_getter_nullable[arg['type']]}(argv[{index}]);")
+    for arg in out_arguments:
+        if arg['type'] in ("text", "blob", "object"):
+            print(f"  {cql_nullable_types[arg['type']].ljust(20)} {arg['name'].ljust(25)} = NULL;")
+        elif arg['isNotNull']:
+            print(f"  {cql_notnull_types[arg['type']].ljust(20)} {arg['name'].ljust(25)} = 0;")
+        else:
+            print(f"  {cql_nullable_types[arg['type']].ljust(20)} {(arg['name'] + ';').ljust(25)}   cql_set_null({arg['name']});")
+    print("")
+
+
+    print("  // 4. Initialize procedure dependencies")
+    if proc['projection']:   print(f"  {proc['name']}_result_set_ref _data_result_set_ = NULL;")
+    if proc['usesDatabase']: print(f"  sqlite3* db = sqlite3_context_db_handle(context);")
+    if proc['usesDatabase']: print(f"  cql_code rc = SQLITE_OK;")
+    print("") if proc['usesDatabase'] or proc['projection'] else None
+
+
+    print("  // 5. Call the procedure")
+    print(f"  {'rc = ' if proc['usesDatabase'] else ''}{proc['name']}{'_fetch_results' if proc['projection'] else ''}(", end="")
+    for index, computed_arg in enumerate(
+        (["db"] if proc['usesDatabase'] else []) +
+        (["&_data_result_set_"] if proc['projection'] else []) +
+        [
+            f"&{arg['name']}" if arg.get('binding', 'in') != "in"
+                else arg['name'] if arg['type'] != "object"
+                else "/* unsupported arg type object*/"
+            for arg in proc['args']
+        ]
+    ):
+        print(f"{',' if index > 0 else ''}\n    {computed_arg}", end="")
+    print("")
+    print("  );")
+    print("")
+
+
+    print("  // 6. Cleanup In arguments since they are no longer needed")
+    for arg in [arg for arg in in_arguments if is_ref_type[arg['type']]]:
+        if   arg['type'] == "text":   print(f"  cql_string_release({arg['name']});")
+        elif arg['type'] == "blob":   print(f"  cql_blob_release({  arg['name']});")
+        elif arg['type'] == "object": print(f"  cql_object_release({arg['name']});")
+    print("")
+
+
+    print("  // 7. Ensure the procedure executed successfully")
+    if proc['usesDatabase']:
+        print("  if (rc != SQLITE_OK) {")
+        print("    sqlite3_result_null(context);")
+        print("    goto cleanup;")
+        print("  }")
+    print("")
+
+
+    print("  // 8. Resolve the result base on:")
+    print("  //   (A) The first column of first row of the result_set, if any")
+    print("  //   (B) The first outtie argument (in or inout) value, if any")
+    print("  //   (C) Fallback to: null")
+    print("  //")
+    if proc['projection']:
+        print("  // Current strategy: (A) Using the result set")
+
+        print("  set_sqlite3_result_from_result_set(context, (cql_result_set_ref)_data_result_set_);")
+        print("  goto cleanup;")
+        print("")
+    else:
+        print("  // Current strategy: (B) Using Outtie arguments")
+        print("  // Set Sqlite result")
+        print("  // NB: If the procedure generates a cql result set, the first column of the first row would be used as the result")
+        for arg in [arg for arg in proc['args'] if arg.get('binding', 'in') in ("inout", "out")]:
+            skip = False
+
+            if arg['type'] == "text":
+                print(f"  SQLITE3_RESULT_CQL_TEXT(context, {arg['name']}); goto cleanup;")
+            elif arg['type'] == "blob":
+                print(f"  SQLITE3_RESULT_CQL_BLOB(context, {arg['name']}); goto cleanup;")
+            elif is_ref_type[arg['type']]:
+                # Object
+                print(f"  /* {arg['type']} not implemented yet */")
+                skip = True
+            elif arg['isNotNull']:
+                print(f"  {sqlite3_result_setter_notnull[arg['type']]}(context, {arg['name']}); goto cleanup;")
+            elif not arg['isNotNull']:
+                print(f"  {sqlite3_result_setter_nullable[arg['type']]}(context, {arg['name']}); goto cleanup;")
+            else:
+                print(f"  /* Unsupported type {arg['type']} */")
+                skip = True
+
+            if not skip:
+                break
+        print("")
+        print("  goto cleanup;")
+
+
+    print("invalid_arguments:")
+    print("  sqlite3_result_error(context, \"CQL extension: Invalid procedure arguments\", -1);")
+    print("  return;")
+
+
+    print("")
+    print("cleanup:")
+    print("  // 10. Cleanup Outtie arguments")
+    for arg in [arg for arg in outtie_arguments if is_ref_type[arg['type']]]:
+        if   arg['type'] == "text":   print(f"  if({arg['name']}) cql_string_release({arg['name']});")
+        elif arg['type'] == "blob":   print(f"  if({arg['name']}) cql_blob_release({  arg['name']});")
+        elif arg['type'] == "object": print(f"  if({arg['name']}) cql_object_release({arg['name']});")
+    print("  /* Avoid empty block warning */ ;")
+
+    print("}")
+    print("")
+
+def main():
+    jfile = sys.argv[1]
+    with open(jfile) as json_file:
+        data = json.load(json_file)
+        i = 2
+
+        while i + 2 <= len(sys.argv):
+            if sys.argv[i] == "--cql_header":
+                cmd_args["cql_header"] = sys.argv[i + 1]
+            elif sys.argv[i] == "--namespace":
+                cmd_args["namespace"] = sys.argv[i + 1] + '_'
+            else:
+                usage()
+            i += 2
+
+        emit_licence()
+        emit_headers()
+        emit_all_procs(data)
+        emit_extension_initializer(data)
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        usage()
+    else:
+        main()

--- a/sources/sqlite3_cql_extension/make.sh
+++ b/sources/sqlite3_cql_extension/make.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -o errexit -o nounset -o pipefail
+
+S=$(cd $(dirname "$0"); pwd)
+O=$S/out
+R=$S/..
+
+if [ -z "$SQLITE_PATH" ]; then
+  echo "Error: SQLITE_PATH environment variable is not set"
+  echo "$ git clone https://github.com/sqlite/sqlite.git && cd sqlite"
+  echo "$ ./configure && make sqlite3-all.c"
+  echo "$ gcc -g -O0 -DSQLITE_ENABLE_LOAD_EXTENSION -o sqlite3 sqlite3-all.c shell.c"
+  exit 1
+fi
+
+rm -rf $O
+mkdir -p $O
+
+echo "building cql"
+(cd $O/../.. ; make)
+CQL=$R/out/cql
+
+pushd $O >/dev/null
+echo "Generate stored procs C and JSON"
+${CQL} --nolines --in ../Sample.sql --cg Sample.h Sample.c
+${CQL} --nolines --in ../Sample.sql --rt json_schema --cg Sample.json
+echo "Generate SQLite3 extension"
+../cqlsqlite3extension.py ./Sample.json --cql_header Sample.h > SampleInterop.c
+popd >/dev/null
+
+
+pushd $S >/dev/null
+
+CC="cc -g -O0"
+
+OS=$(uname)
+if [ "$OS" = "Darwin" ]; then
+  CC="${CC} -fPIC -undefined dynamic_lookup"
+  LIB_EXT="dylib"
+elif [ "$OS" = "Linux" ]; then
+  LIB_EXT="so"
+    CC="${CC} -fPIC"
+elif [ "$OS" = "MINGW64_NT" ] || [ "$OS" = "MSYS_NT" ]; then
+  LIB_EXT="dll"
+  CC="${CC} -Wl,--enable-auto-import"
+else
+  echo "Unsupported platform: $OS"
+  exit 1
+fi
+
+echo "Build extension for SQLite ($SQLITE_PATH) on $OS"
+${CC} -shared \
+  -I ./. \
+  -I ./out \
+  -I ./.. \
+  -I $SQLITE_PATH/sqlite3ext.h \
+  -o ./out/cqlextension.${LIB_EXT} \
+  ./out/SampleInterop.c \
+  ./cql_sqlite_extension.c \
+  ./out/Sample.c \
+  ./../cqlrt.c
+
+popd >/dev/null

--- a/sources/sqlite3_cql_extension/test.out.ref
+++ b/sources/sqlite3_cql_extension/test.out.ref
@@ -1,0 +1,293 @@
+
+.nullvalue 'NULL'
+.read test.sql
+CREATE TABLE t(cql TEXT, dummy, sqlite TEXT GENERATED ALWAYS AS (typeof(dummy)) VIRTUAL);
+INSERT INTO t(cql, dummy) VALUES
+  ("bool", 1),
+  ("real", 3.14),
+  ("integer", 1234),
+  ("long", 1234567890123456789),
+  ("text", 'HW'),
+  ("blob", (select CAST("blob" as blob))),
+  ("object", 123),
+  ("null", NULL)
+;
+
+-- Example from ./README.md
+SELECT hello_world(); -- Expect Result got RESULT:  [{"hello_world()":"Hello World !"}]
+
+-- Nullables as null
+SELECT comprehensive_test(
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null")
+) as out; -- Expect RESULT got RESULT:  [{"out":"hello"}]
+
+-- Nullables as non null
+SELECT comprehensive_test(
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob")
+) as out; -- Expect RESULT got RESULT:  [{"out":"hello"}]
+
+-- Nullables as null
+SELECT
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":null,"real__not_null":3.140000000000000124,"real__nullable":null,"integer__not_null":1234,"integer__nullable":null,"long__not_null":1234567890123456789,"long__nullable":null,"text__not_null":"HW","text__nullable":null,"blob__not_null":"blob","blob__nullable":null}]
+
+-- Nullables as non null
+SELECT
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":1,"real__not_null":3.140000000000000124,"real__nullable":3.140000000000000124,"integer__not_null":1234,"integer__nullable":1234,"long__not_null":1234567890123456789,"long__nullable":1234567890123456789,"text__not_null":"HW","text__nullable":"HW","blob__not_null":"blob","blob__nullable":"blob"}]
+
+-- Nullables as null
+SELECT
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":null,"real__not_null":3.140000000000000124,"real__nullable":null,"integer__not_null":1234,"integer__nullable":null,"long__not_null":1234567890123456789,"long__nullable":null,"text__not_null":"HW","text__nullable":null,"blob__not_null":"blob","blob__nullable":null}]
+
+-- Nullables as null
+SELECT
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":1,"real__not_null":3.140000000000000124,"real__nullable":3.140000000000000124,"integer__not_null":1234,"integer__nullable":1234,"long__not_null":1234567890123456789,"long__nullable":1234567890123456789,"text__not_null":"HW","text__nullable":"HW","blob__not_null":"blob","blob__nullable":"blob"}]
+
+SELECT
+  out__bool__not_null() bool__not_null,
+  out__bool__nullable() bool__nullable,
+  out__real__not_null() real__not_null,
+  out__real__nullable() real__nullable,
+  out__integer__not_null() integer__not_null,
+  out__integer__nullable() integer__nullable,
+  out__long__not_null() long__not_null,
+  out__long__nullable() long__nullable,
+  out__text__not_null() text__not_null,
+  out__text__nullable() text__nullable,
+  out__blob__not_null() blob__not_null,
+  out__blob__nullable() blob__nullable
+; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":null,"real__not_null":3.140000000000000124,"real__nullable":null,"integer__not_null":1234,"integer__nullable":null,"long__not_null":1234567890123456789,"long__nullable":null,"text__not_null":"HW","text__nullable":null,"blob__not_null":"blob","blob__nullable":null}]
+
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 151: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 152: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 153: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 154: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT got RESULT:  [{"output":"inout_argument","cql":"text","dummy":"HW","sqlite":"text"}]
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 156: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 157: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 158: CQL extension: Invalid procedure arguments
+
+
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":210,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":21,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 164: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 165: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 166: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 168: CQL extension: Invalid procedure arguments
+
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":210,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":21,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 173: CQL extension: Invalid procedure arguments
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 174: CQL extension: Invalid procedure arguments
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 175: CQL extension: Invalid procedure arguments
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1.0,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234.0,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456768.0,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT got RESULT:  [{"output":3.140000000000000124,"cql":"real","dummy":3.140000000000000124,"sqlite":"real"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 184: CQL extension: Invalid procedure arguments
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 185: CQL extension: Invalid procedure arguments
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123.0,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 187: CQL extension: Invalid procedure arguments
+
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1.0,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234.0,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456768.0,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT got RESULT:  [{"output":3.140000000000000124,"cql":"real","dummy":3.140000000000000124,"sqlite":"real"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 193: CQL extension: Invalid procedure arguments
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 194: CQL extension: Invalid procedure arguments
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123.0,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":2112454933,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 202: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 203: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 204: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 206: CQL extension: Invalid procedure arguments
+
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":2112454933,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 211: CQL extension: Invalid procedure arguments
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 212: CQL extension: Invalid procedure arguments
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 213: CQL extension: Invalid procedure arguments
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456789,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 221: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 222: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 223: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 225: CQL extension: Invalid procedure arguments
+
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456789,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 230: CQL extension: Invalid procedure arguments
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 231: CQL extension: Invalid procedure arguments
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 232: CQL extension: Invalid procedure arguments
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 237: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 238: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 239: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 240: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT got RESULT:  [{"output":"HW","cql":"text","dummy":"HW","sqlite":"text"}]
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 242: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 243: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 244: CQL extension: Invalid procedure arguments
+
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 246: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 247: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 248: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 249: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT got RESULT:  [{"output":"HW","cql":"text","dummy":"HW","sqlite":"text"}]
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 251: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 252: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 256: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 257: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 258: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 259: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 260: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT got RESULT:  [{"output":"blob","cql":"blob","dummy":"blob","sqlite":"blob"}]
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 262: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 263: CQL extension: Invalid procedure arguments
+
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 265: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 266: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 267: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 268: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 269: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT got RESULT:  [{"output":"blob","cql":"blob","dummy":"blob","sqlite":"blob"}]
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 271: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+--
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR

--- a/sources/sqlite3_cql_extension/test.out.ref
+++ b/sources/sqlite3_cql_extension/test.out.ref
@@ -3,14 +3,14 @@
 .read test.sql
 CREATE TABLE t(cql TEXT, dummy, sqlite TEXT GENERATED ALWAYS AS (typeof(dummy)) VIRTUAL);
 INSERT INTO t(cql, dummy) VALUES
-  ("bool", 1),
-  ("real", 3.14),
-  ("integer", 1234),
-  ("long", 1234567890123456789),
-  ("text", 'HW'),
-  ("blob", (select CAST("blob" as blob))),
-  ("object", 123),
-  ("null", NULL)
+  ('bool', 1),
+  ('real', 3.14),
+  ('integer', 1234),
+  ('long', 1234567890123456789),
+  ('text', 'HW'),
+  ('blob', (select CAST('blob' as blob))),
+  ('object', 123),
+  ('null', NULL)
 ;
 
 -- Example from ./README.md
@@ -18,122 +18,122 @@ SELECT hello_world(); -- Expect Result got RESULT:  [{"hello_world()":"Hello Wor
 
 -- Nullables as null
 SELECT comprehensive_test(
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null")
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null')
 ) as out; -- Expect RESULT got RESULT:  [{"out":"hello"}]
 
 -- Nullables as non null
 SELECT comprehensive_test(
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob")
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob')
 ) as out; -- Expect RESULT got RESULT:  [{"out":"hello"}]
 
 -- Nullables as null
 SELECT
-  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
-  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
-  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
-  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
-  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
-  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) blob__nullable
 ; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":null,"real__not_null":3.140000000000000124,"real__nullable":null,"integer__not_null":1234,"integer__nullable":null,"long__not_null":1234567890123456789,"long__nullable":null,"text__not_null":"HW","text__nullable":null,"blob__not_null":"blob","blob__nullable":null}]
 
 -- Nullables as non null
 SELECT
-  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
-  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
-  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
-  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
-  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
-  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__nullable
 ; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":1,"real__not_null":3.140000000000000124,"real__nullable":3.140000000000000124,"integer__not_null":1234,"integer__nullable":1234,"long__not_null":1234567890123456789,"long__nullable":1234567890123456789,"text__not_null":"HW","text__nullable":"HW","blob__not_null":"blob","blob__nullable":"blob"}]
 
 -- Nullables as null
 SELECT
-  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
-  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
-  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
-  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
-  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
-  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) blob__nullable
 ; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":null,"real__not_null":3.140000000000000124,"real__nullable":null,"integer__not_null":1234,"integer__nullable":null,"long__not_null":1234567890123456789,"long__nullable":null,"text__not_null":"HW","text__nullable":null,"blob__not_null":"blob","blob__nullable":null}]
 
 -- Nullables as null
 SELECT
-  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
-  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
-  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
-  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
-  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
-  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__nullable
 ; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":1,"real__not_null":3.140000000000000124,"real__nullable":3.140000000000000124,"integer__not_null":1234,"integer__nullable":1234,"long__not_null":1234567890123456789,"long__nullable":1234567890123456789,"text__not_null":"HW","text__nullable":"HW","blob__not_null":"blob","blob__nullable":"blob"}]
 
 SELECT
@@ -151,143 +151,143 @@ SELECT
   out__blob__nullable() blob__nullable
 ; -- Expect RESULT got RESULT:  [{"bool__not_null":1,"bool__nullable":null,"real__not_null":3.140000000000000124,"real__nullable":null,"integer__not_null":1234,"integer__nullable":null,"long__not_null":1234567890123456789,"long__nullable":null,"text__not_null":"HW","text__nullable":null,"blob__not_null":"blob","blob__nullable":null}]
 
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 151: CQL extension: Invalid procedure arguments
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 152: CQL extension: Invalid procedure arguments
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 153: CQL extension: Invalid procedure arguments
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 154: CQL extension: Invalid procedure arguments
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT got RESULT:  [{"output":"inout_argument","cql":"text","dummy":"HW","sqlite":"text"}]
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 156: CQL extension: Invalid procedure arguments
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 157: CQL extension: Invalid procedure arguments
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 158: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR got ERROR:  Runtime error near line 151: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR got ERROR:  Runtime error near line 152: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR got ERROR:  Runtime error near line 153: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 154: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT got RESULT:  [{"output":"inout_argument","cql":"text","dummy":"HW","sqlite":"text"}]
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 156: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR got ERROR:  Runtime error near line 157: CQL extension: Invalid procedure arguments
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 158: CQL extension: Invalid procedure arguments
 
 
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":210,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":21,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 164: CQL extension: Invalid procedure arguments
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 165: CQL extension: Invalid procedure arguments
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 166: CQL extension: Invalid procedure arguments
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 168: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":210,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":21,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 164: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 165: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 166: CQL extension: Invalid procedure arguments
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 168: CQL extension: Invalid procedure arguments
 
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":210,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":21,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 173: CQL extension: Invalid procedure arguments
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 174: CQL extension: Invalid procedure arguments
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 175: CQL extension: Invalid procedure arguments
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
-
-
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1.0,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234.0,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456768.0,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT got RESULT:  [{"output":3.140000000000000124,"cql":"real","dummy":3.140000000000000124,"sqlite":"real"}]
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 184: CQL extension: Invalid procedure arguments
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 185: CQL extension: Invalid procedure arguments
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123.0,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 187: CQL extension: Invalid procedure arguments
-
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1.0,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234.0,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456768.0,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT got RESULT:  [{"output":3.140000000000000124,"cql":"real","dummy":3.140000000000000124,"sqlite":"real"}]
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 193: CQL extension: Invalid procedure arguments
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 194: CQL extension: Invalid procedure arguments
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123.0,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":210,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":21,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 173: CQL extension: Invalid procedure arguments
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 174: CQL extension: Invalid procedure arguments
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 175: CQL extension: Invalid procedure arguments
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
 
 
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":2112454933,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 202: CQL extension: Invalid procedure arguments
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 203: CQL extension: Invalid procedure arguments
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 204: CQL extension: Invalid procedure arguments
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 206: CQL extension: Invalid procedure arguments
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1.0,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":1234.0,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":1234567890123456768.0,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect RESULT got RESULT:  [{"output":3.140000000000000124,"cql":"real","dummy":3.140000000000000124,"sqlite":"real"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 184: CQL extension: Invalid procedure arguments
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 185: CQL extension: Invalid procedure arguments
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123.0,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 187: CQL extension: Invalid procedure arguments
 
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":2112454933,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 211: CQL extension: Invalid procedure arguments
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 212: CQL extension: Invalid procedure arguments
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 213: CQL extension: Invalid procedure arguments
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
-
-
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456789,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 221: CQL extension: Invalid procedure arguments
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 222: CQL extension: Invalid procedure arguments
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 223: CQL extension: Invalid procedure arguments
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 225: CQL extension: Invalid procedure arguments
-
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT got RESULT:  [{"output":1234567890123456789,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 230: CQL extension: Invalid procedure arguments
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 231: CQL extension: Invalid procedure arguments
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 232: CQL extension: Invalid procedure arguments
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1.0,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":1234.0,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":1234567890123456768.0,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect RESULT got RESULT:  [{"output":3.140000000000000124,"cql":"real","dummy":3.140000000000000124,"sqlite":"real"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 193: CQL extension: Invalid procedure arguments
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 194: CQL extension: Invalid procedure arguments
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123.0,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
 
 
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 237: CQL extension: Invalid procedure arguments
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 238: CQL extension: Invalid procedure arguments
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 239: CQL extension: Invalid procedure arguments
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 240: CQL extension: Invalid procedure arguments
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT got RESULT:  [{"output":"HW","cql":"text","dummy":"HW","sqlite":"text"}]
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 242: CQL extension: Invalid procedure arguments
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 243: CQL extension: Invalid procedure arguments
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 244: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":2112454933,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 202: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 203: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 204: CQL extension: Invalid procedure arguments
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 206: CQL extension: Invalid procedure arguments
 
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 246: CQL extension: Invalid procedure arguments
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 247: CQL extension: Invalid procedure arguments
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 248: CQL extension: Invalid procedure arguments
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 249: CQL extension: Invalid procedure arguments
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT got RESULT:  [{"output":"HW","cql":"text","dummy":"HW","sqlite":"text"}]
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR got ERROR:  Runtime error near line 251: CQL extension: Invalid procedure arguments
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 252: CQL extension: Invalid procedure arguments
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":2112454933,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 211: CQL extension: Invalid procedure arguments
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 212: CQL extension: Invalid procedure arguments
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 213: CQL extension: Invalid procedure arguments
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
 
 
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 256: CQL extension: Invalid procedure arguments
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 257: CQL extension: Invalid procedure arguments
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 258: CQL extension: Invalid procedure arguments
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 259: CQL extension: Invalid procedure arguments
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 260: CQL extension: Invalid procedure arguments
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT got RESULT:  [{"output":"blob","cql":"blob","dummy":"blob","sqlite":"blob"}]
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 262: CQL extension: Invalid procedure arguments
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR got ERROR:  Runtime error near line 263: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":1234567890123456789,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 221: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 222: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 223: CQL extension: Invalid procedure arguments
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 225: CQL extension: Invalid procedure arguments
 
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR got ERROR:  Runtime error near line 265: CQL extension: Invalid procedure arguments
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR got ERROR:  Runtime error near line 266: CQL extension: Invalid procedure arguments
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR got ERROR:  Runtime error near line 267: CQL extension: Invalid procedure arguments
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR got ERROR:  Runtime error near line 268: CQL extension: Invalid procedure arguments
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR got ERROR:  Runtime error near line 269: CQL extension: Invalid procedure arguments
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT got RESULT:  [{"output":"blob","cql":"blob","dummy":"blob","sqlite":"blob"}]
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR got ERROR:  Runtime error near line 271: CQL extension: Invalid procedure arguments
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT got RESULT:  [{"output":1,"cql":"bool","dummy":1,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT got RESULT:  [{"output":1234,"cql":"integer","dummy":1234,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT got RESULT:  [{"output":1234567890123456789,"cql":"long","dummy":1234567890123456789,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 230: CQL extension: Invalid procedure arguments
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 231: CQL extension: Invalid procedure arguments
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 232: CQL extension: Invalid procedure arguments
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT got RESULT:  [{"output":123,"cql":"object","dummy":123,"sqlite":"integer"}]
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
 
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR got ERROR:  Runtime error near line 237: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR got ERROR:  Runtime error near line 238: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR got ERROR:  Runtime error near line 239: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 240: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT got RESULT:  [{"output":"HW","cql":"text","dummy":"HW","sqlite":"text"}]
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 242: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR got ERROR:  Runtime error near line 243: CQL extension: Invalid procedure arguments
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 244: CQL extension: Invalid procedure arguments
+
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR got ERROR:  Runtime error near line 246: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR got ERROR:  Runtime error near line 247: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR got ERROR:  Runtime error near line 248: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 249: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT got RESULT:  [{"output":"HW","cql":"text","dummy":"HW","sqlite":"text"}]
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR got ERROR:  Runtime error near line 251: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR got ERROR:  Runtime error near line 252: CQL extension: Invalid procedure arguments
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR got ERROR:  Runtime error near line 256: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR got ERROR:  Runtime error near line 257: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR got ERROR:  Runtime error near line 258: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 259: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 260: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect RESULT got RESULT:  [{"output":"blob","cql":"blob","dummy":"blob","sqlite":"blob"}]
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR got ERROR:  Runtime error near line 262: CQL extension: Invalid procedure arguments
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR got ERROR:  Runtime error near line 263: CQL extension: Invalid procedure arguments
+
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR got ERROR:  Runtime error near line 265: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR got ERROR:  Runtime error near line 266: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR got ERROR:  Runtime error near line 267: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR got ERROR:  Runtime error near line 268: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR got ERROR:  Runtime error near line 269: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect RESULT got RESULT:  [{"output":"blob","cql":"blob","dummy":"blob","sqlite":"blob"}]
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR got ERROR:  Runtime error near line 271: CQL extension: Invalid procedure arguments
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT got RESULT:  [{"output":null,"cql":"null","dummy":null,"sqlite":"null"}]
+
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 --
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR

--- a/sources/sqlite3_cql_extension/test.sh
+++ b/sources/sqlite3_cql_extension/test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o errexit
+
+source ../common/test_helpers.sh || exit 1
+
+S=$(cd $(dirname "$0"); pwd)
+
+if [ -z "$SQLITE_PATH" ]; then
+  echo "Error: SQLITE_PATH environment variable is not set"
+  exit 1
+fi
+
+OS=$(uname)
+
+if [ "$OS" = "Darwin" ]; then
+  LIB_EXT="dylib"
+elif [ "$OS" = "Linux" ]; then
+  LIB_EXT="so"
+elif [ "$OS" = "MINGW64_NT" ] || [ "$OS" = "MSYS_NT" ]; then
+  LIB_EXT="dll"
+else
+  echo "Unsupported platform: $OS"
+  exit 1
+fi
+
+$SQLITE_PATH/sqlite3 ":memory:" <<EOF 2>&1 \
+  | LC_ALL=C awk '
+    /^Runtime error/ { getline nextLine; print nextLine "\n" "got ERROR:  " $0; next; }
+    /^\[/ { print "got RESULT:  " $0; next }
+    { print }' \
+  | LC_ALL=C awk '
+    /got/ { printf " %s", $0; next }
+    { printf "\n%s", $0 }
+    END {print ""}' \
+  | tee $S/test.out
+.load $S/out/cqlextension.$LIB_EXT
+.mode json
+.echo on
+.nullvalue 'NULL'
+.read test.sql
+EOF
+
+on_diff_exit $S/test.out

--- a/sources/sqlite3_cql_extension/test.sql
+++ b/sources/sqlite3_cql_extension/test.sql
@@ -1,13 +1,13 @@
 CREATE TABLE t(cql TEXT, dummy, sqlite TEXT GENERATED ALWAYS AS (typeof(dummy)) VIRTUAL);
 INSERT INTO t(cql, dummy) VALUES
-  ("bool", 1),
-  ("real", 3.14),
-  ("integer", 1234),
-  ("long", 1234567890123456789),
-  ("text", 'HW'),
-  ("blob", (select CAST("blob" as blob))),
-  ("object", 123),
-  ("null", NULL)
+  ('bool', 1),
+  ('real', 3.14),
+  ('integer', 1234),
+  ('long', 1234567890123456789),
+  ('text', 'HW'),
+  ('blob', (select CAST('blob' as blob))),
+  ('object', 123),
+  ('null', NULL)
 ;
 
 -- Example from ./README.md
@@ -15,122 +15,122 @@ SELECT hello_world(); -- Expect Result
 
 -- Nullables as null
 SELECT comprehensive_test(
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "null")
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null')
 ) as out; -- Expect RESULT
 
 -- Nullables as non null
 SELECT comprehensive_test(
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "real"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "long"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "text"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
-  (SELECT t.dummy FROM t WHERE t.cql = "blob")
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob')
 ) as out; -- Expect RESULT
 
 -- Nullables as null
 SELECT
-  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
-  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
-  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
-  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
-  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
-  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) blob__nullable
 ; -- Expect RESULT
 
 -- Nullables as non null
 SELECT
-  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
-  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
-  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
-  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
-  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
-  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__nullable
 ; -- Expect RESULT
 
 -- Nullables as null
 SELECT
-  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
-  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
-  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
-  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
-  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
-  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) blob__nullable
 ; -- Expect RESULT
 
 -- Nullables as null
 SELECT
-  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
-  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
-  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
-  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
-  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
-  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
-  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
-  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
-  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
-  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
-  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
-  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__nullable
 ; -- Expect RESULT
 
 SELECT
@@ -148,143 +148,143 @@ SELECT
   out__blob__nullable() blob__nullable
 ; -- Expect RESULT
 
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
 
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
-
-
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
-
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT
 
 
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
-
-
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
-
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
-SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT
 
 
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
-SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
-SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT
 
 
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
-SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
-SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT
 
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
--- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
+
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT
+
+
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect RESULT
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
+
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect RESULT
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect RESULT
+
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 --
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
--- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR

--- a/sources/sqlite3_cql_extension/test.sql
+++ b/sources/sqlite3_cql_extension/test.sql
@@ -1,0 +1,290 @@
+CREATE TABLE t(cql TEXT, dummy, sqlite TEXT GENERATED ALWAYS AS (typeof(dummy)) VIRTUAL);
+INSERT INTO t(cql, dummy) VALUES
+  ("bool", 1),
+  ("real", 3.14),
+  ("integer", 1234),
+  ("long", 1234567890123456789),
+  ("text", 'HW'),
+  ("blob", (select CAST("blob" as blob))),
+  ("object", 123),
+  ("null", NULL)
+;
+
+-- Example from ./README.md
+SELECT hello_world(); -- Expect Result
+
+-- Nullables as null
+SELECT comprehensive_test(
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "null")
+) as out; -- Expect RESULT
+
+-- Nullables as non null
+SELECT comprehensive_test(
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "bool"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "real"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "integer"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "long"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "text"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob"),
+  (SELECT t.dummy FROM t WHERE t.cql = "blob")
+) as out; -- Expect RESULT
+
+-- Nullables as null
+SELECT
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+; -- Expect RESULT
+
+-- Nullables as non null
+SELECT
+  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
+  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
+  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
+  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
+  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
+  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+; -- Expect RESULT
+
+-- Nullables as null
+SELECT
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "null")) blob__nullable
+; -- Expect RESULT
+
+-- Nullables as null
+SELECT
+  inout__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__not_null,
+  inout__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = "bool")) bool__nullable,
+  inout__real__not_null((SELECT t.dummy FROM t WHERE t.cql = "real")) real__not_null,
+  inout__real__nullable((SELECT t.dummy FROM t WHERE t.cql = "real")) real__nullable,
+  inout__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__not_null,
+  inout__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = "integer")) integer__nullable,
+  inout__long__not_null((SELECT t.dummy FROM t WHERE t.cql = "long")) long__not_null,
+  inout__long__nullable((SELECT t.dummy FROM t WHERE t.cql = "long")) long__nullable,
+  inout__text__not_null((SELECT t.dummy FROM t WHERE t.cql = "text")) text__not_null,
+  inout__text__nullable((SELECT t.dummy FROM t WHERE t.cql = "text")) text__nullable,
+  inout__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__not_null,
+  inout__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = "blob")) blob__nullable
+; -- Expect RESULT
+
+SELECT
+  out__bool__not_null() bool__not_null,
+  out__bool__nullable() bool__nullable,
+  out__real__not_null() real__not_null,
+  out__real__nullable() real__nullable,
+  out__integer__not_null() integer__not_null,
+  out__integer__nullable() integer__nullable,
+  out__long__not_null() long__not_null,
+  out__long__nullable() long__nullable,
+  out__text__not_null() text__not_null,
+  out__text__nullable() text__nullable,
+  out__blob__not_null() blob__not_null,
+  out__blob__nullable() blob__nullable
+; -- Expect RESULT
+
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__bool__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+
+
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__real__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__real__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+
+
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__integer__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__integer__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+
+
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__long__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect RESULT
+SELECT inout__long__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+
+
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+SELECT inout__text__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect RESULT
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+SELECT inout__text__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+
+
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+SELECT inout__blob__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect RESULT
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect RESULT
+
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+-- SELECT inout__object__not_null(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR
+--
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "bool"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "integer"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "long"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "real"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "text"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "blob"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "object"; -- Expect ERROR
+-- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = "null"; -- Expect ERROR


### PR DESCRIPTION
- [x] Integrate in CI/CD
- [x] Run test on Linux
- [ ] Run test on Windows
- [ ] Mention it in the doc

### Example code generation for a given CQL procedure

```sql
proc comprehensive_test(
  in in__bool__not_null bool not null,
  in in__bool__nullable bool,
  in in__real__not_null real not null,
  in in__real__nullable real,
  in in__integer__not_null integer not null,
  in in__integer__nullable integer,
  in in__long__not_null long not null,
  in in__long__nullable long,
  in in__text__not_null text not null,
  in in__text__nullable text,
  -- in in__object__not_null object not null,
  -- in in__object__nullable object,
  in in__blob__not_null blob not null,
  in in__blob__nullable blob,
  inout inout__bool__not_null bool not null,
  inout inout__bool__nullable bool,
  inout inout__real__not_null real not null,
  inout inout__real__nullable real,
  inout inout__integer__not_null integer not null,
  inout inout__integer__nullable integer,
  inout inout__long__not_null long not null,
  inout inout__long__nullable long,
  inout inout__text__not_null text not null,
  inout inout__text__nullable text,
  -- inout inout__object__not_null object not null,
  -- inout inout__object__nullable object,
  inout inout__blob__not_null blob not null,
  inout inout__blob__nullable blob,
  out out__real__not_null real not null,
  out out__real__nullable real,
  out out__bool__not_null bool not null,
  out out__bool__nullable bool,
  out out__integer__not_null integer not null,
  out out__integer__nullable integer,
  out out__long__not_null long not null,
  out out__long__nullable long,
  out out__text__not_null text not null,
  out out__text__nullable text,
  -- out out__object__not_null object not null,
  -- out out__object__nullable object,
  out out__blob__not_null blob not null,
  out out__blob__nullable blob
)
begin

  out__bool__not_null := TRUE;
  out__bool__nullable := TRUE;

  out__real__not_null := 3.5;
  out__real__nullable := 3.5;

  out__integer__not_null := 3;
  out__integer__nullable := 3;

  out__long__not_null := 3L;
  out__long__nullable := 3L;

  out__text__not_null := 'three';
  out__text__nullable := 'three';

  -- out__object__not_null := null ~object~;
  -- out__object__nullable := null ~object~;

  out__blob__not_null := (select CAST("blob" as blob));
  out__blob__nullable := (select CAST("blob" as blob));

  select "hello" as `result`;
end;
```

Output:
```c
void call_comprehensive_test(sqlite3_context *_Nonnull context, int32_t argc, sqlite3_value *_Nonnull *_Nonnull argv){
  // 1. Ensure Sqlite function argument count matches count of the procedure in and inout arguments
  if (argc != 24) goto invalid_arguments;

  // 2. Ensure sqlite3 value type is compatible with cql type
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[0]), CQL_DATA_TYPE_BOOL, cql_false)) goto invalid_arguments; // in__bool__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[1]), CQL_DATA_TYPE_BOOL, cql_true)) goto invalid_arguments; // in__bool__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[2]), CQL_DATA_TYPE_DOUBLE, cql_false)) goto invalid_arguments; // in__real__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[3]), CQL_DATA_TYPE_DOUBLE, cql_true)) goto invalid_arguments; // in__real__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[4]), CQL_DATA_TYPE_INT32, cql_false)) goto invalid_arguments; // in__integer__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[5]), CQL_DATA_TYPE_INT32, cql_true)) goto invalid_arguments; // in__integer__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[6]), CQL_DATA_TYPE_INT64, cql_false)) goto invalid_arguments; // in__long__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[7]), CQL_DATA_TYPE_INT64, cql_true)) goto invalid_arguments; // in__long__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[8]), CQL_DATA_TYPE_STRING, cql_false)) goto invalid_arguments; // in__text__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[9]), CQL_DATA_TYPE_STRING, cql_true)) goto invalid_arguments; // in__text__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[10]), CQL_DATA_TYPE_BLOB, cql_false)) goto invalid_arguments; // in__blob__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[11]), CQL_DATA_TYPE_BLOB, cql_true)) goto invalid_arguments; // in__blob__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[12]), CQL_DATA_TYPE_BOOL, cql_false)) goto invalid_arguments; // inout__bool__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[13]), CQL_DATA_TYPE_BOOL, cql_true)) goto invalid_arguments; // inout__bool__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[14]), CQL_DATA_TYPE_DOUBLE, cql_false)) goto invalid_arguments; // inout__real__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[15]), CQL_DATA_TYPE_DOUBLE, cql_true)) goto invalid_arguments; // inout__real__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[16]), CQL_DATA_TYPE_INT32, cql_false)) goto invalid_arguments; // inout__integer__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[17]), CQL_DATA_TYPE_INT32, cql_true)) goto invalid_arguments; // inout__integer__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[18]), CQL_DATA_TYPE_INT64, cql_false)) goto invalid_arguments; // inout__long__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[19]), CQL_DATA_TYPE_INT64, cql_true)) goto invalid_arguments; // inout__long__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[20]), CQL_DATA_TYPE_STRING, cql_false)) goto invalid_arguments; // inout__text__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[21]), CQL_DATA_TYPE_STRING, cql_true)) goto invalid_arguments; // inout__text__nullable
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[22]), CQL_DATA_TYPE_BLOB, cql_false)) goto invalid_arguments; // inout__blob__not_null
  if (!is_sqlite3_type_compatible_with_cql_core_type(sqlite3_value_type(argv[23]), CQL_DATA_TYPE_BLOB, cql_true)) goto invalid_arguments; // inout__blob__nullable

  // 3. Marshalled argument initialization
  cql_bool             in__bool__not_null        = RESOLVE_NOTNULL_BOOL_FROM_SQLITE3_VALUE(argv[0]);
  cql_nullable_bool    in__bool__nullable        = resolve_nullable_bool_from_sqlite3_value(argv[1]);
  cql_double           in__real__not_null        = RESOLVE_NOTNULL_REAL_FROM_SQLITE3_VALUE(argv[2]);
  cql_nullable_double  in__real__nullable        = resolve_nullable_real_from_sqlite3_value(argv[3]);
  cql_int32            in__integer__not_null     = RESOLVE_NOTNULL_INTEGER_FROM_SQLITE3_VALUE(argv[4]);
  cql_nullable_int32   in__integer__nullable     = resolve_nullable_integer_from_sqlite3_value(argv[5]);
  cql_int64            in__long__not_null        = RESOLVE_NOTNULL_LONG_FROM_SQLITE3_VALUE(argv[6]);
  cql_nullable_int64   in__long__nullable        = resolve_nullable_long_from_sqlite3_value(argv[7]);
  cql_string_ref       in__text__not_null        = resolve_text_from_sqlite3_value(argv[8]);
  cql_string_ref       in__text__nullable        = resolve_text_from_sqlite3_value(argv[9]);
  cql_blob_ref         in__blob__not_null        = resolve_blob_from_sqlite3_value(argv[10]);
  cql_blob_ref         in__blob__nullable        = resolve_blob_from_sqlite3_value(argv[11]);
  cql_bool             inout__bool__not_null     = RESOLVE_NOTNULL_BOOL_FROM_SQLITE3_VALUE(argv[12]);
  cql_nullable_bool    inout__bool__nullable     = resolve_nullable_bool_from_sqlite3_value(argv[13]);
  cql_double           inout__real__not_null     = RESOLVE_NOTNULL_REAL_FROM_SQLITE3_VALUE(argv[14]);
  cql_nullable_double  inout__real__nullable     = resolve_nullable_real_from_sqlite3_value(argv[15]);
  cql_int32            inout__integer__not_null  = RESOLVE_NOTNULL_INTEGER_FROM_SQLITE3_VALUE(argv[16]);
  cql_nullable_int32   inout__integer__nullable  = resolve_nullable_integer_from_sqlite3_value(argv[17]);
  cql_int64            inout__long__not_null     = RESOLVE_NOTNULL_LONG_FROM_SQLITE3_VALUE(argv[18]);
  cql_nullable_int64   inout__long__nullable     = resolve_nullable_long_from_sqlite3_value(argv[19]);
  cql_string_ref       inout__text__not_null     = resolve_text_from_sqlite3_value(argv[20]);
  cql_string_ref       inout__text__nullable     = resolve_text_from_sqlite3_value(argv[21]);
  cql_blob_ref         inout__blob__not_null     = resolve_blob_from_sqlite3_value(argv[22]);
  cql_blob_ref         inout__blob__nullable     = resolve_blob_from_sqlite3_value(argv[23]);
  cql_double           out__real__not_null       = 0;
  cql_nullable_double  out__real__nullable;        cql_set_null(out__real__nullable);
  cql_bool             out__bool__not_null       = 0;
  cql_nullable_bool    out__bool__nullable;        cql_set_null(out__bool__nullable);
  cql_int32            out__integer__not_null    = 0;
  cql_nullable_int32   out__integer__nullable;     cql_set_null(out__integer__nullable);
  cql_int64            out__long__not_null       = 0;
  cql_nullable_int64   out__long__nullable;        cql_set_null(out__long__nullable);
  cql_string_ref       out__text__not_null       = NULL;
  cql_string_ref       out__text__nullable       = NULL;
  cql_blob_ref         out__blob__not_null       = NULL;
  cql_blob_ref         out__blob__nullable       = NULL;

  // 4. Initialize procedure dependencies
  comprehensive_test_result_set_ref _data_result_set_ = NULL;
  sqlite3* db = sqlite3_context_db_handle(context);
  cql_code rc = SQLITE_OK;

  // 5. Call the procedure
  rc = comprehensive_test_fetch_results(
    db,
    &_data_result_set_,
    in__bool__not_null,
    in__bool__nullable,
    in__real__not_null,
    in__real__nullable,
    in__integer__not_null,
    in__integer__nullable,
    in__long__not_null,
    in__long__nullable,
    in__text__not_null,
    in__text__nullable,
    in__blob__not_null,
    in__blob__nullable,
    &inout__bool__not_null,
    &inout__bool__nullable,
    &inout__real__not_null,
    &inout__real__nullable,
    &inout__integer__not_null,
    &inout__integer__nullable,
    &inout__long__not_null,
    &inout__long__nullable,
    &inout__text__not_null,
    &inout__text__nullable,
    &inout__blob__not_null,
    &inout__blob__nullable,
    &out__real__not_null,
    &out__real__nullable,
    &out__bool__not_null,
    &out__bool__nullable,
    &out__integer__not_null,
    &out__integer__nullable,
    &out__long__not_null,
    &out__long__nullable,
    &out__text__not_null,
    &out__text__nullable,
    &out__blob__not_null,
    &out__blob__nullable
  );

  // 6. Cleanup In arguments since they are no longer needed
  cql_string_release(in__text__not_null);
  cql_string_release(in__text__nullable);
  cql_blob_release(in__blob__not_null);
  cql_blob_release(in__blob__nullable);

  // 7. Ensure the procedure executed successfully
  if (rc != SQLITE_OK) {
    sqlite3_result_null(context);
    goto cleanup;
  }

  // 8. Resolve the result base on:
  //   (A) The first column of first row of the result_set, if any
  //   (B) The first outtie argument (in or inout) value, if any
  //   (C) Fallback to: null
  //
  // Current strategy: (A) Using the result set
  set_sqlite3_result_from_result_set(context, (cql_result_set_ref)_data_result_set_);
  goto cleanup;

invalid_arguments:
  sqlite3_result_error(context, "CQL extension: Invalid procedure arguments", -1);
  return;

cleanup:
  // 10. Cleanup Outtie arguments
  if(inout__text__not_null) cql_string_release(inout__text__not_null);
  if(inout__text__nullable) cql_string_release(inout__text__nullable);
  if(inout__blob__not_null) cql_blob_release(inout__blob__not_null);
  if(inout__blob__nullable) cql_blob_release(inout__blob__nullable);
  if(out__text__not_null) cql_string_release(out__text__not_null);
  if(out__text__nullable) cql_string_release(out__text__nullable);
  if(out__blob__not_null) cql_blob_release(out__blob__not_null);
  if(out__blob__nullable) cql_blob_release(out__blob__nullable);
  /* Avoid empty block warning */ ;
}
```