### PR TITLE
Adding helper functions to create "blob arrays"

### DIFF
--- a/sources/cql.y
+++ b/sources/cql.y
@@ -3488,6 +3488,13 @@ cql_noexport CSTR cql_builtin_text() {
     "[[builtin]]"
     "@op null : call fmt as cql_format_null;"
 
+    "[[builtin]]"
+    "declare function cql_make_blob_stream(list cql_blob_list!) create blob!;"
+    "[[builtin]]"
+    "declare proc cql_cursor_from_blob_stream(C cursor, b blob, i int!) using transaction;"
+    "[[builtin]]"
+    "declare function cql_blob_stream_count(b blob!) int!;"
+
     "@@end_include@@"
     ;
 }

--- a/sources/cqlrt.lua
+++ b/sources/cqlrt.lua
@@ -1872,6 +1872,7 @@ function cql_make_blob_stream(blob_list)
   return table.concat(b)
 end
 
+-- the count of blobs is encoded at the head of the blob stream.
 function cql_blob_stream_count(b)
   if #b < 4 then
     return 0
@@ -1910,10 +1911,13 @@ function cql_cursor_from_blob_stream(db, C, C_types, C_fields, b, index)
     _start = string.unpack("<i4", b, 1 + index * 4)
   end
 
+  -- bogus offset order
   if _start > _end then
     return -4
   end
 
+  -- this can still fail during decode but that's par of the course
+  -- we have to assume the blobs are hostile
   local blob = string.sub(b, _start + 1, _end + 1)
   return cql_cursor_from_blob(db, C, C_types, C_fields, blob)
 end

--- a/sources/cqlrt.lua
+++ b/sources/cqlrt.lua
@@ -1841,6 +1841,83 @@ function cql_cursor_from_blob(db, C, C_types, C_fields, buffer)
   return rc
 end
 
+-- create a single blob for the whole stream of appended blobs
+-- with offsets for easy array style access.
+function cql_make_blob_stream(blob_list)
+  local count = #blob_list
+
+  local b = {}
+  table.insert(b, string.pack("<i4", count))
+
+  offset_next = (1 + count)*4
+
+  local i = 0
+  while i < count
+  do
+    local blob = blob_list[i+1]
+    local size = cql_get_blob_size(blob)
+    offset_next = offset_next + size
+    table.insert(b, string.pack("<i4", offset_next))
+    i = i + 1
+  end
+
+  local i = 0
+  while i < count
+  do
+    local blob = blob_list[i+1]
+    table.insert(b, blob)
+    i = i + 1
+  end
+
+  return table.concat(b)
+end
+
+function cql_blob_stream_count(b)
+  if #b < 4 then
+    return 0
+  end
+  return string.unpack("<i4", b)
+end
+
+-- fetch the cursor from the indicated blob stream
+function cql_cursor_from_blob_stream(db, C, C_types, C_fields, b, index)
+  C._has_row_ = false
+
+  local len = #b
+  if len < 4 then
+    return -1
+  end
+
+  -- the first 4 bytes are the count of blobs
+  local count = string.unpack("<i4", b)
+
+  if (index < 0 or index >= count or (index + 1) * 4 >= len) then
+    return -2
+  end
+
+  -- note that we're assuming little endian here, this could be generalized
+  local _end = string.unpack("<i4", b, 1 + (index + 1) * 4)
+
+  if _end > len then
+    return -3
+  end
+
+  -- the first blob starts after the offsets and count
+  local _start = (count + 1) * 4;
+
+  if index > 0 then
+    -- the first blob starts at after the offsets, that offset is  not recorded
+    _start = string.unpack("<i4", b, 1 + index * 4)
+  end
+
+  if _start > _end then
+    return -4
+  end
+
+  local blob = string.sub(b, _start + 1, _end + 1)
+  return cql_cursor_from_blob(db, C, C_types, C_fields, blob)
+end
+
 function cql_blob_from_int(prefix, seed)
   if prefix == nil then
     prefix = ''

--- a/sources/cqlrt_common.c
+++ b/sources/cqlrt_common.c
@@ -2978,12 +2978,12 @@ cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull blob_list)
 
   cql_bytebuf b;
   cql_bytebuf_open(&b);
-  cql_int32 count = cql_blob_list_count(blob_list);
+  cql_uint32 count = (cql_uint32)cql_blob_list_count(blob_list);
 
   // note that we're assuming little endian here, this could be generalized
   cql_append_value(&b, count);
 
-  cql_int32 offset_next = (1 + count)*sizeof(cql_int32);
+  cql_int32 offset_next = (cql_int32)((1 + count)*sizeof(cql_int32));
 
   for (cql_int32 i = 0; i < count; i++) {
     cql_blob_ref blob = cql_blob_list_get_at(blob_list, i);
@@ -2998,7 +2998,7 @@ cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull blob_list)
 
   for (cql_int32 i = 0; i < count; i++) {
     cql_blob_ref blob = cql_blob_list_get_at(blob_list, i);
-    cql_int32 size = cql_get_blob_size(blob);
+    cql_uint32 size = (cql_uint32)cql_get_blob_size(blob);
     const uint8_t *bytes = (const uint8_t *)cql_get_blob_bytes(blob);
    
     cql_bytebuf_append(&b, bytes, size);

--- a/sources/cqlrt_common.c
+++ b/sources/cqlrt_common.c
@@ -2970,7 +2970,6 @@ cql_code cql_cursor_to_blob(
   return SQLITE_OK;
 }
 
-
 // create a single blob for the whole stream of appended blobs
 // with offsets for easy array style access.
 cql_blob_ref _Nonnull cql_make_blob_stream(

--- a/sources/cqlrt_common.c
+++ b/sources/cqlrt_common.c
@@ -2979,6 +2979,8 @@ cql_blob_ref _Nonnull cql_make_blob_stream(
   cql_bytebuf b;
   cql_bytebuf_open(&b);
   cql_int32 count = cql_blob_list_count(blob_list);
+
+  // note that we're assuming little endian here, this could be generalized
   cql_append_value(&b, count);
 
   cql_int32 offset_next = (1 + count)*sizeof(cql_int32);
@@ -2987,6 +2989,8 @@ cql_blob_ref _Nonnull cql_make_blob_stream(
     cql_blob_ref blob = cql_blob_list_get_at(blob_list, i);
     cql_int32 size = cql_get_blob_size(blob);
     offset_next += size;
+
+    // note that we're assuming little endian here, this could be generalized
     cql_append_value(&b, offset_next);
   }
 
@@ -3391,12 +3395,14 @@ cql_code cql_cursor_from_blob_stream(
   }
 
   // the first 4 bytes are the count of blobs
+  // note that we're assuming little endian here, this could be generalized
   uint32_t count = *(uint32_t *)bytes;
 
   if (index < 0 || index >= count || (index + 1) * 4 >= len) {
     goto error;
   }
 
+  // note that we're assuming little endian here, this could be generalized
   uint32_t end = *(uint32_t *)(bytes + (index + 1) * 4);
   if (end > len) {
     goto error;
@@ -3407,6 +3413,7 @@ cql_code cql_cursor_from_blob_stream(
 
   if (index > 0) {
     // the first blob starts at 0 which is not recorded
+    // note that we're assuming little endian here, this could be generalized
     start = *(uint32_t *)(bytes + index * 4);
   }
 

--- a/sources/lua_demo/run_test_lua.ref
+++ b/sources/lua_demo/run_test_lua.ref
@@ -16,4 +16,9 @@ blob corruption results: good: 0, bad: 1000
 err: 	19	db info:	19	UNIQUE constraint failed: backing.the key
 err: 	19	db info:	19	UNIQUE constraint failed: backing.the key
 err: 	19	db info:	19	UNIQUE constraint failed: backing.the key
+err: 	-1	thrown exception
+err: 	-3	thrown exception
+err: 	-4	thrown exception
+err: 	-2	thrown exception
+err: 	-2	thrown exception
 exit code	0

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -10795,9 +10795,9 @@ additional_checks:
 static void sem_infer_result_blob_type(ast_node *ast, ast_node *arg_list) {
   EXTRACT_ANY_NOTNULL(cursor, arg_list->left);
 
-  CSTR sname = cursor->sem->sptr->struct_name;
+  CSTR struct_name = cursor->sem->sptr->struct_name;
 
-  if (!sname || !find_table_or_view_even_deleted(sname)) {
+  if (!struct_name || !find_table_or_view_even_deleted(struct_name)) {
      record_error(ast);
      report_error(cursor,
        "CQL0024: cursor not declared with 'LIKE table_name', blob type can't be inferred",
@@ -10810,7 +10810,7 @@ static void sem_infer_result_blob_type(ast_node *ast, ast_node *arg_list) {
   ast_node *blob = new_ast_str("$");
   blob->sem = new_sem(SEM_TYPE_BLOB|SEM_TYPE_NOTNULL);
   blob->sem->name = "$";
-  blob->sem->kind = cursor->sem->sptr->struct_name;
+  blob->sem->kind = struct_name;
 
   AST_REWRITE_INFO_RESET();
 

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -102,6 +102,10 @@ extern cql_string_ref _Nonnull cql_format_string(cql_string_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_blob(cql_blob_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_object(cql_object_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_null(cql_nullable_bool ignored);
+extern cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull list);
+extern CQL_WARN_UNUSED cql_code cql_cursor_from_blob_stream(sqlite3 *_Nonnull _db_, cql_dynamic_cursor *_Nonnull C, cql_blob_ref _Nullable b, cql_int32 i);
+
+extern cql_int32 cql_blob_stream_count(cql_blob_ref _Nonnull b);
 extern cql_nullable_int32 side_effect1(void);
 extern cql_nullable_int32 side_effect2(void);
 extern CQL_WARN_UNUSED cql_code with_result_set(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
@@ -711,6 +715,13 @@ DECLARE PROC cql_cursor_to_blob (C CURSOR, OUT result BLOB!) USING TRANSACTION;
 /*
 [[builtin]]
 DECLARE PROC cql_cursor_from_blob (C CURSOR, b BLOB) USING TRANSACTION;
+*/
+
+// The statement ending at line XXXX
+
+/*
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
 */
 cql_int32 c_runtime_generation = 0;
 cql_int32 c_runtime_generation_on_else = 0;

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -378,6 +378,12 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_globals.c.ref
+++ b/sources/test/cg_test_c_globals.c.ref
@@ -102,6 +102,10 @@ extern cql_string_ref _Nonnull cql_format_string(cql_string_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_blob(cql_blob_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_object(cql_object_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_null(cql_nullable_bool ignored);
+extern cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull list);
+extern CQL_WARN_UNUSED cql_code cql_cursor_from_blob_stream(sqlite3 *_Nonnull _db_, cql_dynamic_cursor *_Nonnull C, cql_blob_ref _Nullable b, cql_int32 i);
+
+extern cql_int32 cql_blob_stream_count(cql_blob_ref _Nonnull b);
 
 // The statement ending at line XXXX
 
@@ -128,6 +132,13 @@ DECLARE PROC cql_cursor_to_blob (C CURSOR, OUT result BLOB!) USING TRANSACTION;
 /*
 [[builtin]]
 DECLARE PROC cql_cursor_from_blob (C CURSOR, b BLOB) USING TRANSACTION;
+*/
+
+// The statement ending at line XXXX
+
+/*
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
 */
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_globals.h.ref
+++ b/sources/test/cg_test_c_globals.h.ref
@@ -372,6 +372,12 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 #ifndef _foo_var_group_decl_
 #define _foo_var_group_decl_ 1
 

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -102,6 +102,10 @@ extern cql_string_ref _Nonnull cql_format_string(cql_string_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_blob(cql_blob_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_object(cql_object_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_null(cql_nullable_bool ignored);
+extern cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull list);
+extern CQL_WARN_UNUSED cql_code cql_cursor_from_blob_stream(sqlite3 *_Nonnull _db_, cql_dynamic_cursor *_Nonnull C, cql_blob_ref _Nullable b, cql_int32 i);
+
+extern cql_int32 cql_blob_stream_count(cql_blob_ref _Nonnull b);
 extern cql_nullable_int32 side_effect1(void);
 extern cql_nullable_int32 side_effect2(void);
 extern CQL_WARN_UNUSED cql_code with_result_set(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
@@ -711,6 +715,13 @@ DECLARE PROC cql_cursor_to_blob (C CURSOR, OUT result BLOB!) USING TRANSACTION;
 /*
 [[builtin]]
 DECLARE PROC cql_cursor_from_blob (C CURSOR, b BLOB) USING TRANSACTION;
+*/
+
+// The statement ending at line XXXX
+
+/*
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
 */
 cql_int32 c_runtime_generation = 0;
 cql_int32 c_runtime_generation_on_else = 0;

--- a/sources/test/cg_test_c_with_header.h.ref
+++ b/sources/test/cg_test_c_with_header.h.ref
@@ -378,6 +378,12 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -102,6 +102,10 @@ extern cql_string_ref _Nonnull cql_format_string(cql_string_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_blob(cql_blob_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_object(cql_object_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_null(cql_nullable_bool ignored);
+extern cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull list);
+extern CQL_WARN_UNUSED cql_code cql_cursor_from_blob_stream(sqlite3 *_Nonnull _db_, cql_dynamic_cursor *_Nonnull C, cql_blob_ref _Nullable b, cql_int32 i);
+
+extern cql_int32 cql_blob_stream_count(cql_blob_ref _Nonnull b);
 extern cql_nullable_int32 side_effect1(void);
 extern cql_nullable_int32 side_effect2(void);
 extern CQL_WARN_UNUSED cql_code with_result_set(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
@@ -711,6 +715,13 @@ DECLARE PROC cql_cursor_to_blob (C CURSOR, OUT result BLOB!) USING TRANSACTION;
 /*
 [[builtin]]
 DECLARE PROC cql_cursor_from_blob (C CURSOR, b BLOB) USING TRANSACTION;
+*/
+
+// The statement ending at line XXXX
+
+/*
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
 */
 cql_int32 c_runtime_generation = 0;
 cql_int32 c_runtime_generation_on_else = 0;

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -378,6 +378,12 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern cql_int32 c_runtime_generation;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_type_getters.c.ref
+++ b/sources/test/cg_test_c_with_type_getters.c.ref
@@ -102,6 +102,10 @@ extern cql_string_ref _Nonnull cql_format_string(cql_string_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_blob(cql_blob_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_object(cql_object_ref _Nullable val);
 extern cql_string_ref _Nonnull cql_format_null(cql_nullable_bool ignored);
+extern cql_blob_ref _Nonnull cql_make_blob_stream(cql_object_ref _Nonnull list);
+extern CQL_WARN_UNUSED cql_code cql_cursor_from_blob_stream(sqlite3 *_Nonnull _db_, cql_dynamic_cursor *_Nonnull C, cql_blob_ref _Nullable b, cql_int32 i);
+
+extern cql_int32 cql_blob_stream_count(cql_blob_ref _Nonnull b);
 extern CQL_WARN_UNUSED cql_code selector(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 
 #ifndef row_type_decl_emit_object_result_set_row
@@ -158,6 +162,13 @@ DECLARE PROC cql_cursor_to_blob (C CURSOR, OUT result BLOB!) USING TRANSACTION;
 /*
 [[builtin]]
 DECLARE PROC cql_cursor_from_blob (C CURSOR, b BLOB) USING TRANSACTION;
+*/
+
+// The statement ending at line XXXX
+
+/*
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
 */
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_type_getters.h.ref
+++ b/sources/test/cg_test_c_with_type_getters.h.ref
@@ -372,6 +372,12 @@
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 #define CRC_selector -2086804524444672762L
 
 extern cql_string_ref _Nonnull selector_stored_procedure_name;

--- a/sources/test/cg_test_json_schema.out.ref
+++ b/sources/test/cg_test_json_schema.out.ref
@@ -5395,6 +5395,39 @@
 
     The statement ending at line XXXX
 
+    [[builtin]]
+    DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION
+
+    {
+      "name" : "cql_cursor_from_blob_stream",
+      "args" : [
+        {
+          "name" : "C",
+          "type" : "",
+          "isNotNull" : 0
+        },
+        {
+          "name" : "b",
+          "type" : "blob",
+          "isNotNull" : 0
+        },
+        {
+          "name" : "i",
+          "type" : "integer",
+          "isNotNull" : 1
+        }
+      ],
+      "attributes" : [
+        {
+          "name" : "cql:builtin",
+          "value" : 1
+        }
+      ],
+      "usesDatabase" : 1
+    },
+
+    The statement ending at line XXXX
+
     DECLARE PROC result_proc (id INT, t TEXT) (x INT, y INT)
 
     {
@@ -8217,6 +8250,61 @@
         "isNotNull" : 1
       },
       "createsObject" : 1
+    },
+
+    The statement ending at line XXXX
+
+    [[builtin]]
+    DECLARE FUNC cql_make_blob_stream (list OBJECT<cql_blob_list>!) CREATE BLOB!
+
+    {
+      "name" : "cql_make_blob_stream",
+      "args" : [
+        {
+          "name" : "list",
+          "type" : "object",
+          "kind" : "cql_blob_list",
+          "isNotNull" : 1
+        }
+      ],
+      "attributes" : [
+        {
+          "name" : "cql:builtin",
+          "value" : 1
+        }
+      ],
+      "returnType" : {
+        "type" : "blob",
+        "isNotNull" : 1
+      },
+      "createsObject" : 1
+    },
+
+    The statement ending at line XXXX
+
+    [[builtin]]
+    DECLARE FUNC cql_blob_stream_count (b BLOB!) INT!
+
+    {
+      "name" : "cql_blob_stream_count",
+      "args" : [
+        {
+          "name" : "b",
+          "type" : "blob",
+          "isNotNull" : 1
+        }
+      ],
+      "attributes" : [
+        {
+          "name" : "cql:builtin",
+          "value" : 1
+        }
+      ],
+      "returnType" : {
+        "type" : "integer",
+        "isNotNull" : 1
+      },
+      "createsObject" : 0
     },
 
     The statement ending at line XXXX

--- a/sources/test/cg_test_lua.lua.ref
+++ b/sources/test/cg_test_lua.lua.ref
@@ -22,6 +22,13 @@ DECLARE PROC cql_cursor_to_blob (C CURSOR, OUT result BLOB!) USING TRANSACTION;
 [ [ builtin ] ]
 DECLARE PROC cql_cursor_from_blob (C CURSOR, b BLOB) USING TRANSACTION;
 --]]
+
+-- The statement ending at line XXXX
+
+--[[
+[ [ builtin ] ]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
+--]]
 local lua_runtime_generation = 0
 local lua_runtime_generation_on_else = 0
 

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -7754,10 +7754,6 @@ create table my_blob
     z text
 );
 
-declare function cql_make_blob_stream(list cql_blob_list!) create blob!;
-declare proc cql_cursor_from_blob_stream(C cursor, b blob, i int!) using transaction;
-declare function cql_blob_stream_count(b blob!) int!;
-
 proc control_blob(out control blob!)
 begin
   -- the hex for the test blob we use

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -7760,28 +7760,108 @@ declare function cql_blob_stream_count(b blob!) int!;
 
 TEST!(blob_stream,
 begin
-    let builder := cql_blob_list_create();
-    cursor C like my_blob;
-    let i := 0;
-    for i < 5; i := i + 1;
-    begin
-        fetch C() from values () @dummy_seed(i) @dummy_nullables;
-        let b := cql_cursor_to_blob(C);
-        cql_blob_list_add(builder, b);
-    end;
+  let builder := cql_blob_list_create();
+  cursor C like my_blob;
+  let i := 0;
+  for i < 5; i := i + 1;
+  begin
+    fetch C() from values () @dummy_seed(i) @dummy_nullables;
+    let b := cql_cursor_to_blob(C);
+    cql_blob_list_add(builder, b);
+  end;
 
-    b := cql_make_blob_stream(builder);
+  b := cql_make_blob_stream(builder);
 
-    let num := cql_blob_stream_count(b);
+  let num := cql_blob_stream_count(b);
+  EXPECT_EQ!(num, 5);
 
-    i := 0;
-    for i < num; i := i + 1;
-    begin
-        cql_cursor_from_blob_stream(C, b, i);
-        EXPECT_EQ!(c.x, i);
-        EXPECT_EQ!(c.y, i);
-        EXPECT_EQ!(c.z, printf("z_%d", i));
-    end;
+  i := 0;
+  for i < num; i := i + 1;
+  begin
+    cql_cursor_from_blob_stream(C, b, i);
+    EXPECT_EQ!(c.x, i);
+    EXPECT_EQ!(c.y, i);
+    EXPECT_EQ!(c.z, printf("z_%d", i));
+  end;
+
+  -- invalid index
+  let hit := false;
+  try
+    cql_cursor_from_blob_stream(C, b, -1);
+  catch
+    hit := true;
+  end;
+  EXPECT_EQ!(hit, true);
+  EXPECT_EQ!(C, false);
+end);
+
+TEST!(blob_stream_fixed_blob,
+begin
+  -- We revalidate based on a fixed blob, the format must be invariant across all output types
+  -- and versions.  E.g. the lua build must produce the same blob
+  let b := (select x'05000000230000002E00000039000000440000004F000000696973000700007A5F3000696973000702027A5F3100696973000704047A5F3200696973000706067A5F3300696973000708087A5F3400');
+  let num := cql_blob_stream_count(b);
+  EXPECT_EQ!(num, 5);
+
+  cursor C like my_blob;
+  let i := 0;
+  for i < num; i := i + 1;
+  begin
+    cql_cursor_from_blob_stream(C, b, i);
+    EXPECT_EQ!(c.x, i);
+    EXPECT_EQ!(c.y, i);
+    EXPECT_EQ!(c.z, printf("z_%d", i));
+  end;
+end);
+
+TEST!(blob_stream_empty,
+begin
+  let b := (select x'00');
+  let hit := false;
+  cursor C like my_blob;
+  try
+    cql_cursor_from_blob_stream(C, b, 0);
+  catch
+    hit := true;
+  end;
+  -- no row
+  EXPECT_EQ!(hit, true);
+  EXPECT_EQ!(c, false);
+end);
+
+TEST!(blob_stream_invalid_offsets__,
+begin
+  let b := (select x'05000000FF00000000000000');
+  let hit := 0;
+  cursor C like my_blob;
+  try
+    -- the offset of the first blob is too big
+    cql_cursor_from_blob_stream(C, b, 0);
+  catch
+    hit := 1;
+  end;
+  EXPECT_EQ!(hit, 1);
+  EXPECT_EQ!(C, false);
+
+  hit := 0;
+  try
+    -- the start offset of the 2nd blob (index 0) is too big
+    cql_cursor_from_blob_stream(C, b, 1);
+  catch
+    hit := 1;
+  end;
+  EXPECT_EQ!(hit, 1);
+  EXPECT_EQ!(C, false);
+
+  hit := 0;
+  try
+    -- the count claims to be 5 but there are not enough offsets
+    cql_cursor_from_blob_stream(C, b, 3);
+  catch
+    hit := 1;
+  end;
+  EXPECT_EQ!(hit, 1);
+  EXPECT_EQ!(C, false);
 end);
 
 END_SUITE();

--- a/sources/test/sem_test_dev.out.ref
+++ b/sources/test/sem_test_dev.out.ref
@@ -4187,6 +4187,87 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
+[[builtin]]
+DECLARE FUNC cql_make_blob_stream (list OBJECT<cql_blob_list>!) CREATE BLOB!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: blob notnull create_func
+    | {name cql_make_blob_stream}: blob notnull create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: list: object<cql_blob_list> notnull variable in
+      |   | {param_detail}: list: object<cql_blob_list> notnull variable in
+      |     | {name list}: list: object<cql_blob_list> notnull variable in
+      |     | {notnull}: object<cql_blob_list> notnull
+      |       | {type_object}: object<cql_blob_list>
+      |         | {name cql_blob_list}
+      | {create_data_type}: blob notnull create_func
+        | {notnull}: blob notnull
+          | {type_blob}: blob
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_proc_stmt}: ok dml_proc
+    | {proc_name_type}
+    | | {name cql_cursor_from_blob_stream}: ok dml_proc
+    | | {int 2}
+    | {proc_params_stmts}
+      | {params}: ok
+        | {param}: C: cursor variable in
+        | | {param_detail}: C: cursor variable in
+        |   | {name C}: C: cursor variable in
+        |   | {type_cursor}: cursor
+        | {params}
+          | {param}: b: blob variable in
+          | | {param_detail}: b: blob variable in
+          |   | {name b}: b: blob variable in
+          |   | {type_blob}: blob
+          | {params}
+            | {param}: i: integer notnull variable in
+              | {param_detail}: i: integer notnull variable in
+                | {name i}: i: integer notnull variable in
+                | {notnull}: integer notnull
+                  | {type_int}: integer
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE FUNC cql_blob_stream_count (b BLOB!) INT!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: integer notnull
+    | {name cql_blob_stream_count}: integer notnull
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: b: blob notnull variable in
+      |   | {param_detail}: b: blob notnull variable in
+      |     | {name b}: b: blob notnull variable in
+      |     | {notnull}: blob notnull
+      |       | {type_blob}: blob
+      | {notnull}: integer notnull
+        | {type_int}: integer
+
+The statement ending at line XXXX
+
 EXPLAIN
 SELECT 1;
 

--- a/sources/test/sem_test_migrate.out.ref
+++ b/sources/test/sem_test_migrate.out.ref
@@ -4187,6 +4187,87 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
+[[builtin]]
+DECLARE FUNC cql_make_blob_stream (list OBJECT<cql_blob_list>!) CREATE BLOB!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: blob notnull create_func
+    | {name cql_make_blob_stream}: blob notnull create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: list: object<cql_blob_list> notnull variable in
+      |   | {param_detail}: list: object<cql_blob_list> notnull variable in
+      |     | {name list}: list: object<cql_blob_list> notnull variable in
+      |     | {notnull}: object<cql_blob_list> notnull
+      |       | {type_object}: object<cql_blob_list>
+      |         | {name cql_blob_list}
+      | {create_data_type}: blob notnull create_func
+        | {notnull}: blob notnull
+          | {type_blob}: blob
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_proc_stmt}: ok dml_proc
+    | {proc_name_type}
+    | | {name cql_cursor_from_blob_stream}: ok dml_proc
+    | | {int 2}
+    | {proc_params_stmts}
+      | {params}: ok
+        | {param}: C: cursor variable in
+        | | {param_detail}: C: cursor variable in
+        |   | {name C}: C: cursor variable in
+        |   | {type_cursor}: cursor
+        | {params}
+          | {param}: b: blob variable in
+          | | {param_detail}: b: blob variable in
+          |   | {name b}: b: blob variable in
+          |   | {type_blob}: blob
+          | {params}
+            | {param}: i: integer notnull variable in
+              | {param_detail}: i: integer notnull variable in
+                | {name i}: i: integer notnull variable in
+                | {notnull}: integer notnull
+                  | {type_int}: integer
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE FUNC cql_blob_stream_count (b BLOB!) INT!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: integer notnull
+    | {name cql_blob_stream_count}: integer notnull
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: b: blob notnull variable in
+      |   | {param_detail}: b: blob notnull variable in
+      |     | {name b}: b: blob notnull variable in
+      |     | {notnull}: blob notnull
+      |       | {type_blob}: blob
+      | {notnull}: integer notnull
+        | {type_int}: integer
+
+The statement ending at line XXXX
+
 @SCHEMA_UPGRADE_VERSION (5);
 
   {schema_upgrade_version_stmt}: ok

--- a/sources/test/sem_test_prev.out.ref
+++ b/sources/test/sem_test_prev.out.ref
@@ -4187,6 +4187,87 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
+[[builtin]]
+DECLARE FUNC cql_make_blob_stream (list OBJECT<cql_blob_list>!) CREATE BLOB!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: blob notnull create_func
+    | {name cql_make_blob_stream}: blob notnull create_func
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: list: object<cql_blob_list> notnull variable in
+      |   | {param_detail}: list: object<cql_blob_list> notnull variable in
+      |     | {name list}: list: object<cql_blob_list> notnull variable in
+      |     | {notnull}: object<cql_blob_list> notnull
+      |       | {type_object}: object<cql_blob_list>
+      |         | {name cql_blob_list}
+      | {create_data_type}: blob notnull create_func
+        | {notnull}: blob notnull
+          | {type_blob}: blob
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_proc_stmt}: ok dml_proc
+    | {proc_name_type}
+    | | {name cql_cursor_from_blob_stream}: ok dml_proc
+    | | {int 2}
+    | {proc_params_stmts}
+      | {params}: ok
+        | {param}: C: cursor variable in
+        | | {param_detail}: C: cursor variable in
+        |   | {name C}: C: cursor variable in
+        |   | {type_cursor}: cursor
+        | {params}
+          | {param}: b: blob variable in
+          | | {param_detail}: b: blob variable in
+          |   | {name b}: b: blob variable in
+          |   | {type_blob}: blob
+          | {params}
+            | {param}: i: integer notnull variable in
+              | {param_detail}: i: integer notnull variable in
+                | {name i}: i: integer notnull variable in
+                | {notnull}: integer notnull
+                  | {type_int}: integer
+
+The statement ending at line XXXX
+
+[[builtin]]
+DECLARE FUNC cql_blob_stream_count (b BLOB!) INT!;
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}: integer notnull
+    | {name cql_blob_stream_count}: integer notnull
+    | {func_params_return}
+      | {params}: ok
+      | | {param}: b: blob notnull variable in
+      |   | {param_detail}: b: blob notnull variable in
+      |     | {name b}: b: blob notnull variable in
+      |     | {notnull}: blob notnull
+      |       | {type_blob}: blob
+      | {notnull}: integer notnull
+        | {type_int}: integer
+
+The statement ending at line XXXX
+
 @DECLARE_DEPLOYABLE_REGION base;
 
   {declare_deployable_region_stmt}: base: region deployable

--- a/sources/test/test_ast.out.ref
+++ b/sources/test/test_ast.out.ref
@@ -3770,6 +3770,80 @@ The statement ending at line XXXX
 
 The statement ending at line XXXX
 
+[[builtin]]
+  {stmt_and_attr}
+  | {misc_attrs}
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}
+    | {name cql_make_blob_stream}
+    | {func_params_return}
+      | {params}
+      | | {param}
+      |   | {param_detail}
+      |     | {name list}
+      |     | {notnull}
+      |       | {name cql_blob_list}
+      | {create_data_type}
+        | {notnull}
+          | {type_blob}
+
+The statement ending at line XXXX
+
+[[builtin]]
+  {stmt_and_attr}
+  | {misc_attrs}
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_proc_stmt}
+    | {proc_name_type}
+    | | {name cql_cursor_from_blob_stream}
+    | | {int 2}
+    | {proc_params_stmts}
+      | {params}
+        | {param}
+        | | {param_detail}
+        |   | {name C}
+        |   | {type_cursor}
+        | {params}
+          | {param}
+          | | {param_detail}
+          |   | {name b}
+          |   | {type_blob}
+          | {params}
+            | {param}
+              | {param_detail}
+                | {name i}
+                | {notnull}
+                  | {type_int}
+
+The statement ending at line XXXX
+
+[[builtin]]
+  {stmt_and_attr}
+  | {misc_attrs}
+  | | {misc_attr}
+  |   | {dot}
+  |     | {name cql}
+  |     | {name builtin}
+  | {declare_func_stmt}
+    | {name cql_blob_stream_count}
+    | {func_params_return}
+      | {params}
+      | | {param}
+      |   | {param_detail}
+      |     | {name b}
+      |     | {notnull}
+      |       | {type_blob}
+      | {notnull}
+        | {type_int}
+
+The statement ending at line XXXX
+
   {expr_macro_def}
   | {macro_name_formals}
   | | {name foo}


### PR DESCRIPTION
The idea here is that you might want to put more than one row into a blob.  It's really more like a blob stream actually...

The helpers are:

```
DECLARE FUNC cql_make_blob_stream (list OBJECT<cql_blob_list>!) CREATE BLOB!
DECLARE FUNC cql_blob_stream_count (b BLOB!) INT!;
DECLARE PROC cql_cursor_from_blob_stream (C CURSOR, b BLOB, i INT!) USING TRANSACTION;
```

* use `cql_blob_list` helpers to make a list of blobs to encode
   * these blobs should be generated by serializing cursors via blob storage
* use `cql_make_blob_stream` to make the final blob, the "stream"

The final blob has

* a count of embedded blobs
* the offset to the end of each blob
* the data for each blob

Then:
* use `cql_cursor_from_blob_stream` to extract one of the blobs into a cursor

Importantly, such blobs can be nested in other blobs as part of blob storage.  With these helpers it's easy to take a rowset, quickly iterate it to build a single blob and then store it.