### PR TITLE
Enable extension build

### DIFF
--- a/sources/cqlrt.c
+++ b/sources/cqlrt.c
@@ -9,6 +9,10 @@
 // there are many macros defined for the base types etc.
 #include "cqlrt.h"
 
+#ifdef CQL_SQLITE_EXT
+extern const sqlite3_api_routines *sqlite3_api;
+#endif
+
 #include <memory.h>
 #include <stdbool.h>
 

--- a/sources/cqlrt.h
+++ b/sources/cqlrt.h
@@ -13,6 +13,10 @@
 #include <math.h>
 #include <sqlite3.h>
 
+#ifdef CQL_SQLITE_EXT
+#include <sqlite3ext.h>
+#endif
+
 #ifdef CQLRT_DIAG
 #include "diags.h"
 #endif

--- a/sources/sqlite3_cql_extension/Sample.sql
+++ b/sources/sqlite3_cql_extension/Sample.sql
@@ -7,6 +7,8 @@
 
 declare proc printf no check;
 
+@echo c, "extern const sqlite3_api_routines *sqlite3_api;\n";
+
 -- trivial case fixed text output as a result set
 proc hello_world()
 begin

--- a/sources/sqlite3_cql_extension/TestCases.sql
+++ b/sources/sqlite3_cql_extension/TestCases.sql
@@ -5,6 +5,8 @@ declare proc printf no check;
 #define cql_error_trace() fprintf(stderr, "Error at %s:%d in %s: %d %s\n", __FILE__, __LINE__, _PROC_, _rc_, sqlite3_errmsg(_db_))
 ';
 
+@echo C, "extern const sqlite3_api_routines *sqlite3_api;\n";
+
 -- auto  generateed by the python, simply `grep "DECLARE SELECT" out/SampleInterop.c | sed s/...//`
 -- the prototype is emitted in a comment so you just strip it out
 -- see out/SampleInterop.c if this is unclear at all

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.c
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.c
@@ -1,10 +1,15 @@
-#ifndef NO_SQLITE_EXT
-#include <sqlite3ext.h>
-extern const sqlite3_api_routines *sqlite3_api;
-#endif
+// This file contains the implementation of the CQL SQLite extension
+// helper functions. These functions are used to convert SQLite values
+// to CQL types and vice versa so that CQL procedures can be called
+// from SQLite queries using the virtual table (and hence table-valued
+// function) mechanism.
 
 #include "cql_sqlite_extension.h"
 #include "cqlrt.h"
+
+#ifdef CQL_SQLITE_EXT
+extern const sqlite3_api_routines *sqlite3_api;
+#endif
 
 #define trace_printf(x, ...)
 // #define trace_printf printf

--- a/sources/sqlite3_cql_extension/cql_sqlite_extension.h
+++ b/sources/sqlite3_cql_extension/cql_sqlite_extension.h
@@ -1,7 +1,3 @@
-#ifndef NO_SQLITE_EXT
-#include <sqlite3ext.h>
-#endif
-
 #include "cqlrt.h"
 
 cql_bool is_sqlite3_type_compatible_with_cql_core_type(int sqlite_type, int8_t cql_core_type, cql_bool is_nullable);

--- a/sources/sqlite3_cql_extension/demo.sh
+++ b/sources/sqlite3_cql_extension/demo.sh
@@ -52,7 +52,7 @@ popd >/dev/null
 
 pushd $S >/dev/null
 
-CC="cc -g -O0 -DNO_SQLITE_EXT"
+CC="cc -g -O0"
 
 ${CC} \
   -I./out \

--- a/sources/sqlite3_cql_extension/demo.sh
+++ b/sources/sqlite3_cql_extension/demo.sh
@@ -10,6 +10,7 @@ S=$(cd $(dirname "$0"); pwd)
 O=$S/out
 R=$S/..
 
+CC=cc
 while [ "${1:-}" != "" ]; do
   if [ "$1" == "--use_gcc" ]; then
     CC=gcc

--- a/sources/sqlite3_cql_extension/make_extension.sh
+++ b/sources/sqlite3_cql_extension/make_extension.sh
@@ -14,6 +14,9 @@ echo
 S=$(cd $(dirname "$0"); pwd)
 O=$S/out
 R=$S/..
+T=.
+
+source $S/../common/test_helpers.sh || exit 1
 
 if [ -v SQLITE_PATH ]; then
   echo using external SQLITE ${SQLITE_PATH}
@@ -102,4 +105,12 @@ ls ./out/cqlextension.${LIB_EXT}
 
 popd >/dev/null
 
-$SQLITE_PATH/sqlite3 <test_extension.sql
+echo running SQLite test cases with extension
+set +e
+$SQLITE_PATH/sqlite3 <test_extension.sql > out/test_extension.out 2>&1
+
+echo checking output difference
+
+on_diff_exit ./test_extension.out
+
+echo "test passed"

--- a/sources/sqlite3_cql_extension/test.out.ref
+++ b/sources/sqlite3_cql_extension/test.out.ref
@@ -1,6 +1,5 @@
 # Clean up output directory
 # Build CQL compiler
-make: Nothing to be done for 'all'.
 # Generate stored procedures C and JSON output
 Sample.c
 Sample.json

--- a/sources/sqlite3_cql_extension/test.sh
+++ b/sources/sqlite3_cql_extension/test.sh
@@ -21,9 +21,10 @@ done
 pushd $S >/dev/null
 
 echo "running demo"
+set +e
 bash ./demo.sh > $S/test.out
+cat $S/test.out
 
 on_diff_exit $S/test.out
 
-cat $S/test.out
 echo "test passed"

--- a/sources/sqlite3_cql_extension/test_extension.out.ref
+++ b/sources/sqlite3_cql_extension/test_extension.out.ref
@@ -1,0 +1,138 @@
+Hello World!
+hello1
+hello2
+hello3
+hello1
+hello2
+1
+
+3.14
+
+1234
+
+1234567890123456789
+
+HW
+
+blob
+
+1
+1
+3.14
+3.14
+1234
+1234
+1234567890123456789
+1234567890123456789
+HW
+HW
+blob
+blob
+1||3.14||1234||1234567890123456789||HW||blob|
+1|1|3.14|3.14|1234|1234|1234567890123456789|1234567890123456789|HW|HW|blob|blob
+1||3.14||1234||1234567890123456789||HW||blob|
+Runtime error near line 168: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 169: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 170: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 171: CQL extension: Invalid proc_namedure arguments
+inout_argument|text|HW|text
+Runtime error near line 173: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 174: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 175: CQL extension: Invalid proc_namedure arguments
+1|bool|1|integer
+210|integer|1234|integer
+21|long|1234567890123456789|integer
+Runtime error near line 181: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 182: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 183: CQL extension: Invalid proc_namedure arguments
+123|object|123|integer
+Runtime error near line 185: CQL extension: Invalid proc_namedure arguments
+1|bool|1|integer
+210|integer|1234|integer
+21|long|1234567890123456789|integer
+Runtime error near line 190: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 191: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 192: CQL extension: Invalid proc_namedure arguments
+123|object|123|integer
+|null||null
+1.0|bool|1|integer
+1234.0|integer|1234|integer
+1.23456789012346e+18|long|1234567890123456789|integer
+3.14|real|3.14|real
+Runtime error near line 201: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 202: CQL extension: Invalid proc_namedure arguments
+123.0|object|123|integer
+Runtime error near line 204: CQL extension: Invalid proc_namedure arguments
+1.0|bool|1|integer
+1234.0|integer|1234|integer
+1.23456789012346e+18|long|1234567890123456789|integer
+3.14|real|3.14|real
+Runtime error near line 210: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 211: CQL extension: Invalid proc_namedure arguments
+123.0|object|123|integer
+|null||null
+1|bool|1|integer
+1234|integer|1234|integer
+2112454933|long|1234567890123456789|integer
+Runtime error near line 219: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 220: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 221: CQL extension: Invalid proc_namedure arguments
+123|object|123|integer
+Runtime error near line 223: CQL extension: Invalid proc_namedure arguments
+1|bool|1|integer
+1234|integer|1234|integer
+2112454933|long|1234567890123456789|integer
+Runtime error near line 228: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 229: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 230: CQL extension: Invalid proc_namedure arguments
+123|object|123|integer
+|null||null
+1|bool|1|integer
+1234|integer|1234|integer
+1234567890123456789|long|1234567890123456789|integer
+Runtime error near line 238: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 239: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 240: CQL extension: Invalid proc_namedure arguments
+123|object|123|integer
+Runtime error near line 242: CQL extension: Invalid proc_namedure arguments
+1|bool|1|integer
+1234|integer|1234|integer
+1234567890123456789|long|1234567890123456789|integer
+Runtime error near line 247: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 248: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 249: CQL extension: Invalid proc_namedure arguments
+123|object|123|integer
+|null||null
+Runtime error near line 254: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 255: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 256: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 257: CQL extension: Invalid proc_namedure arguments
+HW|text|HW|text
+Runtime error near line 259: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 260: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 261: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 263: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 264: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 265: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 266: CQL extension: Invalid proc_namedure arguments
+HW|text|HW|text
+Runtime error near line 268: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 269: CQL extension: Invalid proc_namedure arguments
+|null||null
+Runtime error near line 273: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 274: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 275: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 276: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 277: CQL extension: Invalid proc_namedure arguments
+blob|blob|blob|blob
+Runtime error near line 279: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 280: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 282: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 283: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 284: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 285: CQL extension: Invalid proc_namedure arguments
+Runtime error near line 286: CQL extension: Invalid proc_namedure arguments
+blob|blob|blob|blob
+Runtime error near line 288: CQL extension: Invalid proc_namedure arguments
+|null||null
+10|20|30

--- a/sources/sqlite3_cql_extension/test_extension.sql
+++ b/sources/sqlite3_cql_extension/test_extension.sql
@@ -1,3 +1,5 @@
+.load out/cqlextension
+
 -- These test cases are no longer used but I (Rico) did not want to
 -- to delete them because @grifx might want to revive these with more
 -- loadable extension work.  They are not needed now as the new tests
@@ -22,22 +24,10 @@ INSERT INTO t(cql, dummy) VALUES
 ;
 
 -- Example from ./README.md
-SELECT hello_world(); -- Expect Result
+SELECT * from hello_world(); -- Expect Result
 
 -- Nullables as null
-SELECT comprehensive_test(
-  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+SELECT * from comprehensive_test1(
   (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
   (SELECT t.dummy FROM t WHERE t.cql = 'null'),
   (SELECT t.dummy FROM t WHERE t.cql = 'real'),
@@ -52,8 +42,25 @@ SELECT comprehensive_test(
   (SELECT t.dummy FROM t WHERE t.cql = 'null')
 ) as out; -- Expect RESULT
 
+SELECT * from comprehensive_test2(
+  (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'real'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'integer'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'long'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'text'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'null')
+) as out; -- Expect RESULT
+
+SELECT * from comprehensive_test3() as out; -- Expect RESULT
+
 -- Nullables as non null
-SELECT comprehensive_test(
+SELECT * from comprehensive_test1(
   (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
   (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
   (SELECT t.dummy FROM t WHERE t.cql = 'real'),
@@ -65,7 +72,10 @@ SELECT comprehensive_test(
   (SELECT t.dummy FROM t WHERE t.cql = 'text'),
   (SELECT t.dummy FROM t WHERE t.cql = 'text'),
   (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
-  (SELECT t.dummy FROM t WHERE t.cql = 'blob'),
+  (SELECT t.dummy FROM t WHERE t.cql = 'blob')
+) as out; -- Expect Result;
+
+SELECT * from comprehensive_test2(
   (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
   (SELECT t.dummy FROM t WHERE t.cql = 'bool'),
   (SELECT t.dummy FROM t WHERE t.cql = 'real'),
@@ -81,36 +91,32 @@ SELECT comprehensive_test(
 ) as out; -- Expect RESULT
 
 -- Nullables as null
-SELECT
-  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
-  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) bool__nullable,
-  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
-  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) real__nullable,
-  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
-  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) integer__nullable,
-  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
-  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) long__nullable,
-  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
-  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) text__nullable,
-  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
-  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null')) blob__nullable
-; -- Expect RESULT
+select * from in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool'));
+select * from  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null'));
+select * from in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real'));
+select * from in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null'));
+select * from in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer'));
+select * from in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null'));
+select * from in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long'));
+select * from in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null'));
+select * from in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text'));
+select * from in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null'));
+select * from in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob'));
+select * from in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'null'));
 
 -- Nullables as non null
-SELECT
-  in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__not_null,
-  in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'bool')) bool__nullable,
-  in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__not_null,
-  in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'real')) real__nullable,
-  in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__not_null,
-  in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'integer')) integer__nullable,
-  in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__not_null,
-  in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'long')) long__nullable,
-  in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__not_null,
-  in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'text')) text__nullable,
-  in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__not_null,
-  in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'blob')) blob__nullable
-; -- Expect RESULT
+select * from in__bool__not_null((SELECT t.dummy FROM t WHERE t.cql = 'bool'));
+select * from in__bool__nullable((SELECT t.dummy FROM t WHERE t.cql = 'bool'));
+select * from in__real__not_null((SELECT t.dummy FROM t WHERE t.cql = 'real'));
+select * from in__real__nullable((SELECT t.dummy FROM t WHERE t.cql = 'real'));
+select * from in__integer__not_null((SELECT t.dummy FROM t WHERE t.cql = 'integer'));
+select * from in__integer__nullable((SELECT t.dummy FROM t WHERE t.cql = 'integer'));
+select * from in__long__not_null((SELECT t.dummy FROM t WHERE t.cql = 'long'));
+select * from in__long__nullable((SELECT t.dummy FROM t WHERE t.cql = 'long'));
+select * from in__text__not_null((SELECT t.dummy FROM t WHERE t.cql = 'text'));
+select * from in__text__nullable((SELECT t.dummy FROM t WHERE t.cql = 'text'));
+select * from in__blob__not_null((SELECT t.dummy FROM t WHERE t.cql = 'blob'));
+select * from in__blob__nullable((SELECT t.dummy FROM t WHERE t.cql = 'blob'));
 
 -- Nullables as null
 SELECT
@@ -159,14 +165,14 @@ SELECT
   out__blob__nullable() blob__nullable
 ; -- Expect RESULT
 
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
-SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
 
 SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT

--- a/sources/sqlite3_cql_extension/test_extension.sql
+++ b/sources/sqlite3_cql_extension/test_extension.sql
@@ -165,14 +165,14 @@ SELECT
   out__blob__nullable() blob__nullable
 ; -- Expect RESULT
 
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
-SELECT * from result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'integer'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'long'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'real'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'text'; -- Expect RESULT
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
+SELECT result_from_inout(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
 
 
 SELECT inout__bool__not_null(t.dummy) output, t.* FROM t WHERE t.cql = 'bool'; -- Expect RESULT
@@ -305,3 +305,5 @@ SELECT inout__blob__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -
 -- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'blob'; -- Expect ERROR
 -- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'object'; -- Expect ERROR
 -- SELECT inout__object__nullable(t.dummy) output, t.* FROM t WHERE t.cql = 'null'; -- Expect ERROR
+
+select * from three_int_test(10,20,30);


### PR DESCRIPTION
The .so build has been corrected and `make_extension.sh` now builds and loads an extension using the sqlite.load command

The archived test cases were corrected.