### PR TITLE
Don't try to call private procedures from within sqlite extension

### DIFF
--- a/sources/sqlite3_cql_extension/cqlsqlite3extension.py
+++ b/sources/sqlite3_cql_extension/cqlsqlite3extension.py
@@ -170,6 +170,9 @@ int sqlite3_cqlextension_init(sqlite3 *_Nonnull db, char *_Nonnull *_Nonnull pzE
   int rc = SQLITE_OK;
   cql_rowset_aux_init *aux = NULL;""")
     for proc in data['queries'] + data['deletes'] + data['inserts'] + data['generalInserts'] + data['updates'] + data['general']:
+		if "cql:private" in proc['attributes']:
+            continue
+
         proc_name = proc['canonicalName']
         has_projection = 'projection' in proc
 


### PR DESCRIPTION

Summary:

The `cqlsqlite3extension.py` codegen script previously was ignoring private sprocs when generating the functions that call them, but was not skipping them when generating the entry point function. Now it skips them there too.

Test Plan:

Code generated by the python script now successfully compiles.
