### PR TITLE
changing luarocks version to try to avoid CICD failure

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -117,7 +117,7 @@ jobs:
             flex \
             gcc \
             libsqlite3-dev \
-            luarocks \
+            luarocks=3.11.0-* \
             lua5.4 liblua5.4-dev \
             sqlite3 \
             jq \

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -117,15 +117,12 @@ jobs:
             flex \
             gcc \
             libsqlite3-dev \
-            luarocks=3.8.0-* \
-            lua5.4 liblua5.4-dev \
             sqlite3 \
             jq \
             default-jre \
             default-jdk
 
           sudo pip3 install gcovr
-          sudo luarocks install lsqlite3
       - name: Execute test script using Clang in non-interactive mode
         run: ./test.sh --use_clang --non_interactive
       - name: Execute test script using GCC in non-interactive mode

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -117,7 +117,7 @@ jobs:
             flex \
             gcc \
             libsqlite3-dev \
-            luarocks=3.11.0-* \
+            luarocks=3.8.0-* \
             lua5.4 liblua5.4-dev \
             sqlite3 \
             jq \

--- a/sources/sqlite3_cql_extension/cqlsqlite3extension.py
+++ b/sources/sqlite3_cql_extension/cqlsqlite3extension.py
@@ -170,7 +170,7 @@ int sqlite3_cqlextension_init(sqlite3 *_Nonnull db, char *_Nonnull *_Nonnull pzE
   int rc = SQLITE_OK;
   cql_rowset_aux_init *aux = NULL;""")
     for proc in data['queries'] + data['deletes'] + data['inserts'] + data['generalInserts'] + data['updates'] + data['general']:
-		if "cql:private" in proc['attributes']:
+        if "cql:private" in proc['attributes']:
             continue
 
         proc_name = proc['canonicalName']


### PR DESCRIPTION
https://github.com/ricomariani/CG-SQL-author/issues/185

The CICD was failing because luarocks no longer installs (see issue for root cause).  However, we don't even need Lua or Laurocks for our CICD at this point so I just removed it.  If we ever do need it we'll have to consider how to get this in a stable fashion.