### PR TITLE
Attribute support for enums and constant groups

### DIFF
--- a/sources/cg_json_schema.c
+++ b/sources/cg_json_schema.c
@@ -515,7 +515,13 @@ static void cg_json_enums(charbuf* output) {
     EXTRACT_STRING(name, name_ast);
     EXTRACT_ANY_NOTNULL(type, typed_name->right);
 
-    cg_json_test_details(output, ast, NULL);
+    ast_node *misc_attrs = NULL;
+    if (is_ast_stmt_and_attr(ast->parent)) {
+      EXTRACT_STMT_AND_MISC_ATTRS(stmt, misc, ast->parent->parent);
+      misc_attrs = misc;
+    }
+
+    cg_json_test_details(output, ast, misc_attrs);
 
     COMMA;
     bprintf(output, "{\n");
@@ -523,6 +529,11 @@ static void cg_json_enums(charbuf* output) {
     bprintf(output, "\"name\" : \"%s\",\n", name);
     cg_json_data_type(output, type->sem->sem_type | SEM_TYPE_NOTNULL, NULL);
     bprintf(output, ",\n");
+
+    if (misc_attrs) {
+      cg_json_misc_attrs(output, misc_attrs);
+      bprintf(output, ",\n");
+    }
 
     cg_json_enum_values(enum_values, output);
 
@@ -593,12 +604,23 @@ static void cg_json_constant_groups(charbuf* output) {
     EXTRACT_NOTNULL(const_values, ast->right);
     EXTRACT_STRING(name, name_ast);
 
-    cg_json_test_details(output, ast, NULL);
+    ast_node *misc_attrs = NULL;
+    if (is_ast_stmt_and_attr(ast->parent)) {
+      EXTRACT_STMT_AND_MISC_ATTRS(stmt, misc, ast->parent->parent);
+      misc_attrs = misc;
+    }
+
+    cg_json_test_details(output, ast, misc_attrs);
 
     COMMA;
     bprintf(output, "{\n");
     BEGIN_INDENT(t, 2);
     bprintf(output, "\"name\" : \"%s\",\n", name);
+
+    if (misc_attrs) {
+      cg_json_misc_attrs(output, misc_attrs);
+      bprintf(output, ",\n");
+    }
 
     cg_json_const_values(const_values, output);
 

--- a/sources/json_test/json_test.y
+++ b/sources/json_test/json_test.y
@@ -686,6 +686,7 @@ enum: '{'
       NAME STRING_LITERAL ','
       TYPE STRING_LITERAL ','
       IS_NOT_NULL '1' ','
+      opt_attributes
       VALUES '[' enum_values ']'
       '}'
   ;
@@ -819,6 +820,7 @@ const_groups: const_group | const_group ',' const_groups
 
 const_group: '{'
       NAME STRING_LITERAL ','
+      opt_attributes
       VALUES '[' const_values ']'
       '}'
   ;

--- a/sources/test/cg_test_json_schema.out.ref
+++ b/sources/test/cg_test_json_schema.out.ref
@@ -8842,6 +8842,7 @@
     }
     The statement ending at line XXXX
 
+    [[builtin]]
     CONST GROUP cql_data_types (
       CQL_DATA_TYPE_NULL = 0,
       CQL_DATA_TYPE_INT32 = 1,
@@ -8859,6 +8860,12 @@
     ,
     {
       "name" : "cql_data_types",
+      "attributes" : [
+        {
+          "name" : "cql:builtin",
+          "value" : 1
+        }
+      ],
       "values" : [
         {
           "name" : "CQL_DATA_TYPE_NULL",


### PR DESCRIPTION
Fixes #191

Ability to use attributes on an enum or a constant group. Note that I haven't added the ability to apply attributes to different cases, only the enum or constant group as a whole.