### PR TITLE
UTF8 support in `cg_encode_json_string_literal`

### DIFF
--- a/sources/test/cg_test_query_plan.out.ref
+++ b/sources/test/cg_test_query_plan.out.ref
@@ -352,7 +352,7 @@ BEGIN
   LET query_plan_trivial_object := trivial_object();
   LET query_plan_trivial_blob := trivial_blob();
 
-  LET stmt := "INSERT INTO `table one`(id, name)\\n  VALUES (1, 'Irene')\\nON CONFLICT (id)\\nDO UPDATE\\n  SET name = excluded.name || 'replace' || ' \\u00e2\\u0080\\u00a2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
+  LET stmt := "INSERT INTO `table one`(id, name)\\n  VALUES (1, 'Irene')\\nON CONFLICT (id)\\nDO UPDATE\\n  SET name = excluded.name || 'replace' || ' \xe2\x80\xa2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
   INSERT INTO sql_temp(id, sql) VALUES(10, stmt);
   CURSOR C FOR EXPLAIN QUERY PLAN
   INSERT INTO `table one`(id, name)
@@ -371,7 +371,7 @@ BEGIN
   LET query_plan_trivial_object := trivial_object();
   LET query_plan_trivial_blob := trivial_blob();
 
-  LET stmt := "WITH\\n  some_cte (id, name) AS (\\n    SELECT 1, 'Irene'\\n  )\\nINSERT INTO `table one`(id, name)\\n  SELECT some_cte.id, some_cte.name\\n    FROM some_cte\\n    WHERE id = 1\\nON CONFLICT (id)\\nDO UPDATE\\n  SET name = excluded.name || 'replace' || ' \\u00e2\\u0080\\u00a2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
+  LET stmt := "WITH\\n  some_cte (id, name) AS (\\n    SELECT 1, 'Irene'\\n  )\\nINSERT INTO `table one`(id, name)\\n  SELECT some_cte.id, some_cte.name\\n    FROM some_cte\\n    WHERE id = 1\\nON CONFLICT (id)\\nDO UPDATE\\n  SET name = excluded.name || 'replace' || ' \xe2\x80\xa2 ' || '\\\\x01\\\\x02\\\\xA1\\\\x1b\\\\x00\\\\xg' || 'it''s high noon\\\\r\\\\n\\\\f\\\\b\\\\t\\\\v' || \\\"it's\\\" || name";
   INSERT INTO sql_temp(id, sql) VALUES(11, stmt);
   CURSOR C FOR EXPLAIN QUERY PLAN
   WITH


### PR DESCRIPTION
I had an issue when using const groups with JSON output. I was using the JSON output to generate Swift constants that matched the const groups in CQL. I was running into issues when there were unicode characters in the strings of my const groups.

UTF8 is valid in JSON. However we don't want to generate JSON with garbage (non-UTF8 non-ASCII) data in. I noted [this PR](https://github.com/facebookincubator/CG-SQL/pull/89) which added checks to escape characters that overflowed a signed char; however, for multi-byte UTF8 codepoints, the check was applied separately to each byte which resulted in malformed encoding.

I made `cg_encode_json_string_literal` check at each character position if what follows is a valid UTF8 multibyte sequence. If it is, it's copied verbatim into the output (since it's definitely valid within a JSON string). Single-byte characters fall back to use the old codepath, which still checks for control characters (or things like Latin-1 characters that may have slipped in) that must be escaped.

Since CG-SQL doesn't link against any libraries with unicode validation functions, I added some (`utf8_sequence_length`, `is_utf8_continuation`, `valid_utf8_sequence`) for use as helpers within `encoders.c`. 

I note that I haven't updated `cg_pretty_quote_plaintext`. (Essentially it's because doing this much has fixed my current issue, and I wanted to make sure you were happy with this direction before pushing further with it.) If you think it's worth it, I can have a look at that too.