### PR TITLE
Add additional README files

### DIFF
--- a/beta/README.md
+++ b/beta/README.md
@@ -1,14 +1,7 @@
 # Summary
 
-This is a snapshot of the key runtime files plus the compiler in amalgam form.  
-
-Major releases will include a pre-built version of the amalgam at that point in time and the necessary runtime libraries that went with it.
-
-You can make your own amalgam using the `make_amalgam.sh` script in the sources directory,
-the result goes in `sources/out/cql_amalgam.c`
-
-This one-file version of the compiler can be stripped to just the parts you want using various defines
-(see `test_amalgam.sh` for examples) and it is easily consumed.
+This is a snapshot of the key runtime files plus the compiler in amalgam form.  The `beta` drop
+is updated more frequently than the release drop but the mechanism is the same.
 
 The idea is that you can readily consume the beta without needing to meet the requirements of
 a build.  i.e. you don't need `bison` or `flex` for instance.
@@ -27,5 +20,4 @@ publish can be useful.
 * `cqlrt_common.c` -- the common parts of the runtime (uses `cqlrt` or `cqlrt_cf`)
 * `cqlrt_common.h` -- headers for the same
 * `cql_amalgam.c` -- the compiler in amalgam form
-* `make_release.sh` -- script to create the above and do basic testing on it
-* `test_amalgam.sh` -- verifies that the amalgam can be used as expected with various `-D` options
+* `make_beta.sh` -- script to create the above and do basic testing on it

--- a/sources/common/README.md
+++ b/sources/common/README.md
@@ -1,0 +1,12 @@
+# Summary
+
+Assorted test helpers:
+
+* `json_check.py` to test for well-formed JSON (e.g. for schema and query plan)
+* `test_bison.sh` to ensure the installed `bison` is modern enough
+* `test_Flex.sh` to ensure the installed `flex` is modern enough.
+
+# License
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.

--- a/sources/cqljson/README.md
+++ b/sources/cqljson/README.md
@@ -1,0 +1,26 @@
+# Summary
+
+`cqljson.py` is used to read the JSON schema output of the CQL compiler
+and create various artifacts that visualize it.  For instand it can produce
+an ERD.
+
+# Usage
+
+```
+--table_diagram input.json [universe] > tables.dot
+   creates a .dot file for a table diagram
+
+--region_diagram input.json > regions.dot
+   creates a .dot file for a region diagram
+
+--erd input.json [universe] > erd.dot
+   creates a .dot file for an ER diagram
+
+--sql input.json > inputdb.sql
+   creates a .sql file for a database with the schema info
+```
+
+# License
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.

--- a/sources/cqlrt_cf/README.md
+++ b/sources/cqlrt_cf/README.md
@@ -1,0 +1,20 @@
+# Summary
+
+A CQL runtime designed for use with Apple CF. This code defines the CQLRT implementation using
+CF notions to retain/release etc.  CQL strings map to `CFStringRef`.  CQL blobs map to `CFDataRef`.
+The necessary comparisons and so forth are included such the `cqlrt_common` can do the rest.
+
+* `clean.sh` -- cleans all build artifacts
+* `cqlholder.m` -- a simple ObjC wrapper that retains a CQL reference
+* `cqlobjc.py` -- converts CQL JSON format into interop functions for Objective-C
+* `cqlrt_cf.c` -- the C helpers needed to do the linkage to CF
+* `cqlrt_cf.h` -- the cqlrt.h equivalent
+* `demo_main.m` -- an objective C file that uses `demo_todo.sql` using ObjC interface
+* `demo_todo.sql` -- the procedures we are going to invoke
+* `make.sh` -- builds the system and runs it
+* `min.sh` -- minimal build-only, use where CF is missing (e.g. on Linux) but you want to to try to catch build errors
+
+# License
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.

--- a/sources/json_test/README.md
+++ b/sources/json_test/README.md
@@ -1,0 +1,20 @@
+# Summary
+
+This test tool verifies that the JSON schema output is well formed according to the expected output rules.
+As a consequence the `.y` can be transformed into a railroad diagram for the JSON schema output (and it is).
+
+The idea is that by defining the expected output for each of the JSON schema sections with a grammar
+we can test that it is compliant.
+
+This tool is invoked by the main `test.sh` script.
+
+Note that the `.y` file has no actions, we just need to know if the input is compliant or not.  The normal
+parser output gives us useful diagnostics that that tell us where we went wrong.
+
+Importantly since this always runs, when a new section is added we know the tests will fail until the grammar
+is properly updated.
+
+# License
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.

--- a/sources/linetester/README.md
+++ b/sources/linetester/README.md
@@ -1,0 +1,93 @@
+# Summary
+
+`linetest` is a test tool.  It processes the output .c code of a compilation
+looking for the `#line` directives and compares them against the expected.
+
+Since new tests are always added all of the line numbers in the test collateral
+are relative to the procedure they are found in.  The generated output is normalized
+to reflect this, so in short, each procedure looks like it wqas compiled in its
+own file.
+
+# Usage
+
+```bash
+linetest expected_lines output_file.c
+```
+
+# Contents
+
+* `linetest.c` -- checked in compiled version of linetest.sql
+* `linetest.h` -- checked in compiled version of linetest.sql
+* `linetest.sql` -- the line tester (uses cqlhelp.c for args and setup stuff)
+* `regen.sh` -- rebuilds linetest.c and linetest.h
+
+Importantly, we do not always regenerate `linetest.c` because we expect that the compiler
+might be slightly broken during development.  So we regenerate a working comparator
+from time to time to keep the output relatively fresh viz code gen norms but not
+instantly up to date.  It is wise not to depend on a compilers latest features in
+the test cases immediatly.
+
+# License
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+# Test Case Markup
+
+Line numbers are relative to the line the #define _PROC_
+
+Anything outside the #define and #undef for _PROC is IGNORED, it's just comments.
+
+The test cases are echoed here but again, that will be ignored, it's just here
+for your viewing pleasure.  The source of truth is in "test/linetest.sql"
+annotated source code from there included.
+
+```
+TEST: simple statements
+----------------
+10: CREATE PROC based_statements ()
+11: BEGIN
+12:   DECLARE x INTEGER NOT NULL;      THIS IS FOR DISPLAY ONLY.
+13:   SET x := 1;                      THIS TEXT IS PROOF THAT THIS IS NOT PARSED.
+14:   SET x := 2;
+15:   SET x := 3;
+16:   @ECHO c, "/* hello ";
+17:   @ECHO c, "world \n";
+18:   SET x := 4;
+19:   SET x := 5;
+20: END;
+----------------
+
+Note that the proc started at line 10.  That's because there was a comment
+but the starting line is not relevant, everything will be normalized to
+a proc that starts at line 1 anyway.
+
+#define _PROC_ "based_statements"
+# 1
+void based_statements(void) {
+# 1
+  cql_int32 x = 0;
+# 1
+
+# 3 "test/linetest.sql"
+# 4 "test/linetest.sql"
+  x = 1;
+# 5 "test/linetest.sql"
+  x = 2;
+# 6 "test/linetest.sql"
+  x = 3;
+# 6
+  /* hello world 
+# 9 "test/linetest.sql"
+  x = 4;
+# 10 "test/linetest.sql"
+  x = 5;
+# 11 "test/linetest.sql"
+
+# 11
+}
+#undef _PROC_
+```
+
+The test cases cover every statement type that needs line handling.  Simple statements
+are best so as to avoid spurious errors due to codegen changes.

--- a/sources/lua_demo/README
+++ b/sources/lua_demo/README
@@ -1,6 +1,0 @@
-demo.sh can be run from this directory
-
-run_test.sh should be run from the main sources directory
-
-the main test script does not execute lua code because that would require assumptions about
-lua install that we are not yet willing to make

--- a/sources/lua_demo/README.md
+++ b/sources/lua_demo/README.md
@@ -1,0 +1,32 @@
+# Summary
+
+These files illustrate the usage of an the generation of Lua from CQL.  CQL can generate
+C or Lua natively.
+
+* `demo.sh` -- test and demo output script
+* `demo.sql` -- simple Lua demo
+* `lua_upgrade0.ref` -- referendce output for schema upgrade with Lua (baseline)
+* `lua_upgrade1.ref` -- referendce output for schema upgrade with Lua (0 to 1)
+* `lua_upgrade2.ref` -- referendce output for schema upgrade with Lua (1 to 2)
+* `lua_upgrade3.ref` -- referendce output for schema upgrade with Lua (2 to 3)
+* `lua_upgrade4.ref` -- referendce output for schema upgrade with Lua (3 to 4)
+* `prepare_run_test.sh` -- build the run test and test helpers in lua, concat them to make buildable artifacts
+* `qp.sql` -- a simple test for query plan output
+* `run_test.sh` -- build and execute the standard run tests for Lua (`test/run_test.sql`)
+* `run_test_lua.ref` -- reference output for the run tests
+* `t[1-5].sql` -- assorted small test cases for easy debugging of basics
+* `test_helpers.lua` -- lua version of test helpers, these are simple runtime function used by test cases
+* `upgrade_harness.cql` -- runs the upgrade steps in sequence and verifies as we go along
+
+# Usage
+
+* `demo.sh` can be run from this directory
+* `run_test.sh` should be run from the main sources directory
+
+the main test script does not execute lua code because that would require assumptions about
+lua install that we are not yet willing to make
+
+# License
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.

--- a/sources/test/README.md
+++ b/sources/test/README.md
@@ -1,0 +1,23 @@
+# Test Directory Notes
+
+Here is, in short, all the primary test collateral expect for those things
+(such as what is in `test2`) must be in some other directory by necessity.
+
+Interop subsystems are not considered part of the main runtime -- they are
+"sample code" and they are therefore tested seperately.
+
+All language features are tested here.  The most important files are:
+
+* `test.sql` -- for parsing tests
+* `macro_test.sql` -- for parsing with macros
+* `sem_test.sql` -- for semantic analysis
+* `cg_test.sql` -- for C code gen
+* `run_test.sql` -- code that will actually run and self-verify
+
+Many tests can appear in one file because in most cases error generation
+does not terminate compilation.  But there are exceptions and therefore
+there are some test cases that test one thing in one file.  The compiler
+will exit after that failure.
+
+The test cases are largely self-documenting.  e.g. `sem_test.sql` is
+teeming with comments.


### PR DESCRIPTION
This pull request adds or updates README documentation files throughout the project to provide clear summaries, usage instructions, and licensing information for various components, tools, and test directories. The changes improve clarity and maintainability by describing the purpose, contents, and usage of each directory or tool.

Documentation improvements:

* Added a summary and detailed contents section to `beta/README.md` and expanded `release/README.md` to clarify the purpose of the beta and release drops, their contents, and usage notes. [[1]](diffhunk://#diff-e8f09c5604321978dc14b1fa41e065561fe217f41a7eb62d584c6689c95ce935R1-R23) [[2]](diffhunk://#diff-117e4d23e1c4e40eddf252278b9949f31efaf18ec19c9cc3354c0ecc94603e7aR1-R31)
* Added new README files for `sources/common`, `sources/cqljson`, `sources/json_test`, `sources/linetester`, `sources/lua_demo`, `sources/cqlrt_cf`, and `sources/test` directories, each describing the purpose, usage, and contents of the respective tools or test suites. [[1]](diffhunk://#diff-a13c57544677eb717b82f816aeaa8a58d3032c90bb53f250feb376ee789a1e47R1-R12) [[2]](diffhunk://#diff-6c781a53054d27cd96c6860152eb957046e3200962dcb2c29ce800219af2faeaR1-R26) [[3]](diffhunk://#diff-7072b9463e74a4bdf3038c5670a755fa72e4f95bd050c90c157b8ddee64a57d9R1-R20) [[4]](diffhunk://#diff-a27765d5a7926890968b10907afcc2214f2e55c0e750a7950aff5d38e7f0812cR1-R93) [[5]](diffhunk://#diff-a437e63cf6ac38bf789e0bc144baf7c7d1e2da80958986b253113de4c04e6408R1-R32) [[6]](diffhunk://#diff-0c551cf475903d28f04694a77b643f07427508f785c535e8456e81228611dbebR1-R20) [[7]](diffhunk://#diff-d4240b84989dc2e1041a3d9b3744915ae95b2dcadce98880760758beab22d82dR1-R23)

Licensing clarification:

* Added or updated MIT license information in the new and revised README files to clarify the licensing of the source code. [[1]](diffhunk://#diff-a13c57544677eb717b82f816aeaa8a58d3032c90bb53f250feb376ee789a1e47R1-R12) [[2]](diffhunk://#diff-6c781a53054d27cd96c6860152eb957046e3200962dcb2c29ce800219af2faeaR1-R26) [[3]](diffhunk://#diff-7072b9463e74a4bdf3038c5670a755fa72e4f95bd050c90c157b8ddee64a57d9R1-R20) [[4]](diffhunk://#diff-a27765d5a7926890968b10907afcc2214f2e55c0e750a7950aff5d38e7f0812cR1-R93) [[5]](diffhunk://#diff-a437e63cf6ac38bf789e0bc144baf7c7d1e2da80958986b253113de4c04e6408R1-R32) [[6]](diffhunk://#diff-0c551cf475903d28f04694a77b643f07427508f785c535e8456e81228611dbebR1-R20)

Cleanup and replacement:

* Removed the old `sources/lua_demo/README` and replaced it with a new, more comprehensive `README.md` that includes summary, usage, contents, and license information. [[1]](diffhunk://#diff-d5a8af41f88c0bb12f13bb0000505612470646c4d0e7c0e72c096e744497a960L1-L6) [[2]](diffhunk://#diff-a437e63cf6ac38bf789e0bc144baf7c7d1e2da80958986b253113de4c04e6408R1-R32)